### PR TITLE
Update Drawable scale to have X, Y components

### DIFF
--- a/playground/demoWorker.js
+++ b/playground/demoWorker.js
@@ -29,7 +29,7 @@ function initWorker() {
         drawableID = id;
         renderer.updateDrawableProperties(drawableID, {
             position: [0, 0],
-            scale: 100,
+            scale: [100, 100],
             direction: 90
         });
     });
@@ -50,7 +50,8 @@ function thinkStep() {
 
     var props = {};
     //props.position = [posX, posY];
-    props.direction = fudge;
+    //props.direction = fudge;
+    props.scale = [fudge, 100];
     //props.pixelate = fudge;
     //props.scale = 100;
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -59,7 +59,7 @@ class Drawable {
         }
 
         this._position = twgl.v3.create(0, 0);
-        this._scale = 100;
+        this._scale = twgl.v3.create(100, 100);
         this._direction = 90;
         this._transformDirty = true;
         this._effectBits = 0;
@@ -312,8 +312,11 @@ Drawable.prototype.updateProperties = function (properties) {
         this._direction = properties.direction;
         dirty = true;
     }
-    if ('scale' in properties && this._scale != properties.scale) {
-        this._scale = properties.scale;
+    if ('scale' in properties && (
+        this._scale[0] != properties.scale[0] ||
+        this._scale[1] != properties.scale[1])) {
+        this._scale[0] = properties.scale[0];
+        this._scale[1] = properties.scale[1];
         dirty = true;
     }
     if (dirty) {
@@ -369,9 +372,9 @@ Drawable.prototype._calculateTransform = function () {
     var rotation = (270 - this._direction) * Math.PI / 180;
     twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
 
-    var scaledSize = twgl.v3.mulScalar(
-        this._uniforms.u_skinSize, this._scale / 100);
-    scaledSize[2] = 0; // was NaN because u_skinSize has only 2 components
+    var scaledSize = twgl.v3.divScalar(twgl.v3.multiply(
+        this._uniforms.u_skinSize, this._scale), 100);
+    scaledSize[3] = 0; // was NaN because the vectors have only 2 components.
     twgl.m4.scale(modelMatrix, scaledSize, modelMatrix);
 
     this._transformDirty = false;


### PR DESCRIPTION
Here's one possible solution to #9, which would let us support all the rotation modes.

It's also a little bit more generic, so we could play with things like "stretch" blocks if desired...

![scalex-demo](https://cloud.githubusercontent.com/assets/120403/16741896/576d776c-4773-11e6-85e4-70514cfa1e28.gif)
