### PR TITLE
Build module to be imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # NPM
 /node_modules
 npm-*
+/dist.js

--- a/package.json
+++ b/package.json
@@ -9,26 +9,27 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-render-webgl.git"
   },
-  "main": "./src/index.js",
+  "main": "./dist.js",
   "scripts": {
+    "postinstall": "webpack",
     "test": "make test"
   },
   "dependencies": {
-    "svg-to-image": "1.1.3",
-    "twgl.js": "1.5.2",
-    "xhr": "2.2.0"
-  },
-  "devDependencies": {
     "babel-core": "6.9.1",
     "babel-eslint": "6.0.4",
     "babel-loader": "6.2.4",
     "babel-polyfill": "6.9.1",
     "babel-preset-es2015": "6.9.0",
-    "eslint": "2.7.0",
     "json-loader": "0.5.4",
     "raw-loader": "0.5.1",
+    "svg-to-image": "1.1.3",
+    "twgl.js": "1.5.2",
+    "xhr": "2.2.0",
+    "webpack": "1.13.0"
+  },
+  "devDependencies": {
+    "eslint": "2.7.0",
     "tap": "5.7.1",
-    "webpack": "1.13.0",
     "webpack-dev-server": "1.14.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
 
-module.exports = {
-    entry: {
-        'render': './src/index-web.js',
-        'render.min': './src/index-web.js'
-    },
-    output: {
-        path: __dirname,
-        filename: '[name].js'
-    },
+var base = {
     module: {
         loaders: [
             {
@@ -42,3 +34,25 @@ module.exports = {
         })
     ]
 };
+
+module.exports = [Object.assign({}, base, {
+    entry: {
+        'render': './src/index-web.js',
+        'render.min': './src/index-web.js'
+    },
+    output: {
+        path: __dirname,
+        filename: '[name].js'
+    },
+}),
+Object.assign({}, base, {
+    entry: {
+        'render': './src/index.js'
+    },
+    output: {
+        library: 'ScratchRender',
+        libraryTarget: 'commonjs2',
+        path: __dirname,
+        filename: 'dist.js'
+    }
+})];


### PR DESCRIPTION
If another package wants to import `src/index.js`, it needs to replicate the loader config in `webpack.config.js`. To avoid this, package the module in `dist.js` and set that as the module to require.

I changed `main` to point to this so that other packages can just `require('scratch-blocks')`, but it would also work for our purposes to add `"webpack": "./dist.js"` if we want to keep `src/index.js` as `main`.