### PR TITLE
Use path to webpack for postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist.js",
   "scripts": {
-    "postinstall": "webpack",
+    "postinstall": "./node_modules/.bin/webpack",
     "test": "make test"
   },
   "dependencies": {


### PR DESCRIPTION
When postinstall runs via a parent package, it needs an explicit path. Fixup for #38 