### PR TITLE
Precise bounding boxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2015": "6.9.0",
     "eslint": "2.7.0",
     "gh-pages": "0.11.0",
+    "hull.js": "0.2.10",
     "json": "9.0.4",
     "json-loader": "0.5.4",
     "lodash.defaultsdeep": "4.6.0",

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,11 +3,29 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch WebGL rendering demo</title>
+    <style>
+        #scratch-stage { width: 480px; }
+        #debug-canvas { width: 480px; }
+    </style>
 </head>
 <body style="background: lightsteelblue">
 <canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
 <canvas id="scratch-stage" width="10" height="10" style="border:3px dashed black"></canvas>
 <p>
+    <select id="fudgeproperty" onchange="onFudgePropertyChanged(this.value)">
+        <option value="posx">Position X</option>
+        <option value="posy">Position Y</option>
+        <option value="direction">Direction</option>
+        <option value="scalex">Scale X</option>
+        <option value="scaley">Scale Y</option>
+        <option value="color">Color</option>
+        <option value="fisheye">Fisheye</option>
+        <option value="whirl">Whirl</option>
+        <option value="pixelate">Pixelate</option>
+        <option value="mosaic">Mosaic</option>
+        <option value="brightness">Brightness</option>
+        <option value="ghost">Ghost</option>
+    </select>
     <input type="range" id="fudge" style="width:50%" value="90" min="-90" max="270" step="any" oninput="onFudgeChanged(this.value)" onchange="onFudgeChanged(this.value)">
 </p>
 <p>
@@ -32,6 +50,15 @@
             '09dc888b0b7df19f70d81588ae73420e.svg/get/'
     });
 
+    var fudgeSelect = document.getElementById('fudgeproperty');
+    var posX = 0;
+    var posY = 0;
+    var scaleX = 100;
+    var scaleY = 100;
+    var fudgeProperty = 'posx';
+    function onFudgePropertyChanged(newValue) {
+        fudgeProperty = newValue;
+    }
     var fudgeInput = document.getElementById('fudge');
     function onFudgeMinChanged(newValue) {
         fudgeInput.min = newValue;
@@ -42,11 +69,21 @@
     function onFudgeChanged(newValue) {
         fudge = newValue;
         var props = {};
-        //props.position = [posX, posY];
-        //props.direction = fudge;
-        //props.pixelate = fudge;
-        props.scale = [fudge, 100];
-        renderer.updateDrawableProperties(drawableID, props);
+        switch (fudgeProperty) {
+            case 'posx': props.position = [fudge, posY]; posX = fudge; break;
+            case 'posy': props.position = [posX, fudge]; posY = fudge; break;
+            case 'direction': props.direction = fudge; break;
+            case 'scalex': props.scale = [fudge, scaleY]; scaleX = fudge; break;
+            case 'scaley': props.scale = [scaleX, fudge]; scaleY = fudge; break;
+            case 'color': props.color = fudge; break;
+            case 'whirl': props.whirl = fudge; break;
+            case 'fisheye': props.fisheye = fudge; break;
+            case 'pixelate': props.pixelate = fudge; break;
+            case 'mosaic': props.mosaic = fudge; break;
+            case 'brightness': props.brightness = fudge; break;
+            case 'ghost': props.ghost = fudge; break;
+        }
+        renderer.updateDrawableProperties(drawableID2, props);
     }
 
     // Adapted from code by Simon Sarris: http://stackoverflow.com/a/10450761
@@ -92,6 +129,7 @@
 
     function drawStep() {
         renderer.draw();
+        renderer.getBounds(drawableID2);
         requestAnimationFrame(drawStep);
     }
     drawStep();

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1,3 +1,4 @@
+var hull = require('hull.js');
 var twgl = require('twgl.js');
 
 var Drawable = require('./Drawable');
@@ -190,6 +191,40 @@ RenderWebGL.prototype.draw = function () {
     this._drawThese(
         this._drawables, ShaderManager.DRAW_MODE.default, this._projection);
 };
+
+
+/**
+ * Get the precise bounds for a Drawable.
+ * @param {int} drawableID ID of Drawable to get bounds for.
+ * @return {Object} Bounds for a tight box around the Drawable.
+ */
+RenderWebGL.prototype.getBounds = function (drawableID) {
+    const drawable = Drawable.getDrawableByID(drawableID);
+    // Tell the Drawable about its updated convex hull, if necessary.
+    if (drawable.needsConvexHullPoints()) {
+        const points = this._getConvexHullPointsForDrawable(drawableID);
+        drawable.setConvexHullPoints(points);
+    }
+    let bounds = drawable.getBounds();
+    // In debug mode, draw the bounds.
+    if (this._debugCanvas) {
+        let gl = this._gl;
+        this._debugCanvas.width = gl.canvas.width;
+        this._debugCanvas.height = gl.canvas.height;
+        let context = this._debugCanvas.getContext('2d');
+        context.drawImage(gl.canvas, 0, 0);
+        context.strokeStyle = '#FF0000';
+        let pr = window.devicePixelRatio;
+        context.strokeRect(
+            pr * (bounds.left + this._nativeSize[0]/2),
+            pr * (bounds.top + this._nativeSize[1]/2),
+            pr * (bounds.right - bounds.left),
+            pr * (bounds.bottom - bounds.top)
+        );
+    }
+    return bounds;
+};
+
 
 /**
  * Check if a particular Drawable is touching a particular color.
@@ -486,16 +521,101 @@ RenderWebGL.prototype._drawThese = function(
             twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
             twgl.setUniforms(currentShader, {u_projectionMatrix: projection});
             twgl.setUniforms(currentShader, {u_fudge: window.fudge || 0});
-
-            // TODO: should these be set after the Drawable's uniforms?
-            // That would allow Drawable-scope uniforms to be overridden...
-            if (extraUniforms) {
-                twgl.setUniforms(currentShader, extraUniforms);
-            }
         }
 
         twgl.setUniforms(currentShader, drawable.getUniforms());
 
+        // Apply extra uniforms after the Drawable's, to allow overwriting.
+        if (extraUniforms) {
+            twgl.setUniforms(currentShader, extraUniforms);
+        }
+
         twgl.drawBufferInfo(gl, gl.TRIANGLES, this._bufferInfo);
     }
+};
+
+/**
+ * Get the convex hull points for a particular Drawable.
+ * To do this, draw the Drawable unrotated, unscaled, and untranslated.
+ * Read back the pixels and find all boundary points.
+ * Finally, apply a convex hull algorithm to simplify the set.
+ * @param {int} drawablesID The Drawable IDs calculate convex hull for.
+ * @return {Array.<Array.<number>>} points Convex hull points, as [[x, y], ...]
+ */
+RenderWebGL.prototype._getConvexHullPointsForDrawable = function (drawableID) {
+    const drawable = Drawable.getDrawableByID(drawableID);
+    const [width, height] = drawable._uniforms.u_skinSize;
+    // No points in the hull if invisible or size is 0.
+    if (!drawable.getVisible() || width == 0 || height == 0) {
+        return [];
+    }
+
+    // Only draw to the size of the untransformed drawable.
+    const gl = this._gl;
+    twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+    gl.viewport(0, 0, width, height);
+
+    // Clear the canvas with Drawable.NONE.
+    const noneColor = Drawable.color4fFromID(Drawable.NONE);
+    gl.clearColor.apply(gl, noneColor);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    // Overwrite the model matrix to be unrotated, unscaled, untranslated.
+    let modelMatrix = twgl.m4.identity();
+    twgl.m4.rotateZ(modelMatrix, Math.PI, modelMatrix);
+    twgl.m4.scale(modelMatrix, [width, height], modelMatrix);
+
+    const projection = twgl.m4.ortho(
+        -0.5 * width, 0.5 * width,
+        -0.5 * height, 0.5 * height,
+        -1, 1
+    );
+
+    this._drawThese([drawableID],
+        ShaderManager.DRAW_MODE.silhouette,
+        projection,
+        undefined,
+        {u_modelMatrix: modelMatrix}
+    );
+
+    const pixels = new Buffer(width * height * 4);
+    gl.readPixels(
+        0, 0, width, height,
+        gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+    // Known boundary points on left/right edges of pixels.
+    let boundaryPoints = [];
+
+    /**
+     * Helper method to look up a pixel.
+     * @param {int} x X coordinate of the pixel in `pixels`.
+     * @param {int} y Y coordinate of the pixel in `pixels`.
+     * @return Known ID at that pixel, or Drawable.NONE.
+     */
+    const _getPixel = function (x, y) {
+        var pixelBase = ((width * y) + x) * 4;
+        return Drawable.color4bToID(
+            pixels[pixelBase],
+            pixels[pixelBase + 1],
+            pixels[pixelBase + 2],
+            pixels[pixelBase + 3]);
+    };
+    for (let y = 0; y <= height; y++) {
+        // Scan from left.
+        for (let x = 0; x < width; x++) {
+            if (_getPixel(x, y) > Drawable.NONE) {
+                boundaryPoints.push([x, y]);
+                break;
+            }
+        }
+        // Scan from right.
+        for (let x = width - 1; x >= 0; x--) {
+            if (_getPixel(x, y) > Drawable.NONE) {
+                boundaryPoints.push([x, y]);
+                break;
+            }
+        }
+    }
+    // Simplify boundary points using convex hull.
+    return hull(boundaryPoints, Infinity);
 };

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -27,6 +27,7 @@ module.exports = ShaderManager;
  * - A conversion function which takes a Scratch value (generally in the range
  *   0..100 or -100..100) and maps it to a value useful to the shader. This
  *   mapping may not be reversible.
+ * - `shapeChanges`, whether the effect could change the drawn shape.
  * @type {Object.<string,Object.<string,*>>}
  */
 ShaderManager.EFFECT_INFO = {
@@ -34,25 +35,29 @@ ShaderManager.EFFECT_INFO = {
         mask: 1 << 0,
         converter: function(x) {
             return (x / 200) % 1;
-        }
+        },
+        shapeChanges: false
     },
     fisheye: {
         mask: 1 << 1,
         converter: function(x) {
             return Math.max(0, (x + 100) / 100);
-        }
+        },
+        shapeChanges: true
     },
     whirl: {
         mask: 1 << 2,
         converter: function(x) {
             return x * Math.PI / 180;
-        }
+        },
+        shapeChanges: true
     },
     pixelate: {
         mask: 1 << 3,
         converter: function(x) {
             return Math.abs(x) / 10;
-        }
+        },
+        shapeChanges: true
     },
     mosaic: {
         mask: 1 << 4,
@@ -60,19 +65,22 @@ ShaderManager.EFFECT_INFO = {
             x = Math.round((Math.abs(x) + 10) / 10);
             // TODO: cap by Math.min(srcWidth, srcHeight)
             return Math.max(1, Math.min(x, 512));
-        }
+        },
+        shapeChanges: true
     },
     brightness: {
         mask: 1 << 5,
         converter: function(x) {
             return Math.max(-100, Math.min(x, 100)) / 100;
-        }
+        },
+        shapeChanges: false
     },
     ghost: {
         mask: 1 << 6,
         converter: function(x) {
             return 1 - Math.max(0, Math.min(x, 100)) / 100;
-        }
+        },
+        shapeChanges: false
     }
 };
 


### PR DESCRIPTION
Not sure if this is the right solution, but I got curious to experiment with bounding boxes and thought it might be at least worth showing to get thoughts going.

Demo: https://www.dropbox.com/s/c68l3q04qu5398f/bounds.mov?dl=0

The basic approach here is something like this: https://en.wikipedia.org/wiki/Minimum_bounding_box#Arbitrarily_oriented_minimum_bounding_box

To support things like this: https://scratch.mit.edu/projects/124995042/ correctly and efficiently.

I wanted to be able to recalculate the precise bounds without doing a read-back every time the direction/scale changes. My first thought was to calculate the pixel-precise bounding box in a single orientation, like this:
<img width="137" alt="screen shot 2016-10-11 at 2 58 45 pm" src="https://cloud.githubusercontent.com/assets/120403/19284275/3e039048-8fc3-11e6-8425-ed2c1b2cc525.png">
And then simply transform the four corner points when the sprite is transformed. But, I think this is not enough. For example, for the cat in the orientation above, the whiskers sets the minimum bounding box. But once you rotate to something like this:

<img width="130" alt="screen shot 2016-10-11 at 2 59 53 pm" src="https://cloud.githubusercontent.com/assets/120403/19284312/673e2e78-8fc3-11e6-8826-9727923a5fae.png">

The whiskers no longer matter - it's the foot instead.

This implementation works by calculating the convex hull points for the drawable whenever necessary (e.g., whenever the shape of the drawable could possibly change, including on some graphic effects). Whenever the bounds are requested, the convex hull points are transformed with the drawable transform, and then the box can be found from that.

Thoughts very welcome on both approach and details. Might be missing a better approach here, would be curious to hear! 