### PR TITLE
Update dirty transform before calculating bounds

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -445,6 +445,9 @@ Drawable.prototype.getBounds = function () {
     if (this.needsConvexHullPoints()) {
         throw 'Needs updated convex hull points before bounds calculation.';
     }
+    if (this._transformDirty) {
+        this._calculateTransform();
+    }
     // First, transform all the convex hull points by the current Drawable's
     // transform. This allows us to skip recalculating the convex hull
     // for many Drawable updates, including translation, rotation, scaling.


### PR DESCRIPTION
For example, because if we do, "move 10 steps, if on edge bounce", the bounds calculation should reflect the movement.