### PR TITLE
Canvas skins for Drawables

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -9,7 +9,6 @@
     </style>
 </head>
 <body style="background: lightsteelblue">
-<canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
 <canvas id="scratch-stage" width="10" height="10" style="border:3px dashed black"></canvas>
 <p>
     <select id="fudgeproperty" onchange="onFudgePropertyChanged(this.value)">
@@ -38,11 +37,20 @@
     var fudge = 90;
     var renderer = new RenderWebGL(canvas);
 
+    var exampleCanvas = document.createElement('canvas');
+    exampleCanvas.width = 100;
+    exampleCanvas.height = 100;
+    var exampleContext = exampleCanvas.getContext('2d');
+    exampleContext.fillStyle = '#FF0000';
+    exampleContext.rect(0, 0, 100, 100);
+    exampleContext.fill();
+
     var drawableID = renderer.createDrawable();
     renderer.updateDrawableProperties(drawableID, {
         position: [0, 0],
         scale: [100, 100],
-        direction: 90
+        direction: 90,
+        skin: exampleCanvas
     });
     var drawableID2 = renderer.createDrawable();
     renderer.updateDrawableProperties(drawableID2, {
@@ -83,7 +91,7 @@
             case 'brightness': props.brightness = fudge; break;
             case 'ghost': props.ghost = fudge; break;
         }
-        renderer.updateDrawableProperties(drawableID2, props);
+        renderer.updateDrawableProperties(drawableID, props);
     }
 
     // Adapted from code by Simon Sarris: http://stackoverflow.com/a/10450761
@@ -128,8 +136,17 @@
     };
 
     function drawStep() {
+        // Fill canvas with a random color.
+        exampleContext.fillStyle = '#' + ('00000'+(Math.random()*(1<<24)|0).toString(16)).slice(-6);
+        exampleContext.rect(0, 0, 100, 100);
+        exampleContext.fill();
+        exampleContext.font = "48px sans";
+        exampleContext.fillStyle = '#FFFFFF';
+        exampleContext.fillText('test', 0, 50);
+        renderer.updateDrawableProperties(drawableID, {
+            skin: exampleCanvas
+        });
         renderer.draw();
-        renderer.getBounds(drawableID2);
         requestAnimationFrame(drawStep);
     }
     drawStep();

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -156,28 +156,38 @@ Drawable.prototype.getID = function () {
  * Set this Drawable's skin.
  * The Drawable will continue using the existing skin until the new one loads.
  * If there is no existing skin, the Drawable will use a 1x1 transparent image.
- * @param {string} skin_url The URL of the skin.
+ * @param {string|HTMLElement} skin_ref The URL of the skin, or a canvas node.
  */
-Drawable.prototype.setSkin = function (skin_url) {
+Drawable.prototype.setSkin = function (skin_ref) {
     // TODO: cache Skins instead of loading each time. Ref count them?
     // TODO: share Skins across Drawables - see also destroy()
-    if (skin_url) {
-        var ext = skin_url.substring(skin_url.lastIndexOf('.')+1);
+    if (skin_ref.tagName && skin_ref.tagName == 'CANVAS') {
+        this.setCanvasSkin(skin_ref);
+    } else if (skin_ref) {
+        var ext = skin_ref.substring(skin_ref.lastIndexOf('.')+1);
         switch (ext) {
         case 'svg':
         case 'svg/get/':
         case 'svgz':
         case 'svgz/get/':
-            this._setSkinSVG(skin_url);
+            this._setSkinSVG(skin_ref);
             break;
         default:
-            this._setSkinBitmap(skin_url);
+            this._setSkinBitmap(skin_ref);
             break;
         }
     }
     else {
         this._useSkin(null, 0, 0, 1, true);
     }
+};
+
+/**
+ * Set the Drawable to have a Canvas skin.
+ * @param {HTMLElement} canvas Canvas DOM node.
+ */
+Drawable.prototype.setCanvasSkin = function (canvas) {
+    this._setSkinCore(canvas, 2);
 };
 
 /**


### PR DESCRIPTION
Mostly intended as a demo...

I was thinking about how to implement monitors, and this could be one approach. With this, I think we even have the choice whether the actual UI is implemented in the renderer (perhaps, for example, as a subclass of Drawable), or in the VM (i.e., we can construct a canvas over there and just pass it as a skin whenever it's updated).

This was really easy to pull off, since canvas nodes are basically treated as bitmaps.

![canvas-draw](https://cloud.githubusercontent.com/assets/120403/19331813/cc971144-90b4-11e6-825e-08806fa488e8.gif)

Thoughts?
