### PR TITLE
Bounding-box optimizations for touching color, touching drawables

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -5,7 +5,6 @@
     <title>Scratch WebGL rendering demo</title>
     <style>
         #scratch-stage { width: 480px; }
-        #debug-canvas { width: 480px; }
     </style>
 </head>
 <body style="background: lightsteelblue">
@@ -129,7 +128,8 @@
 
     function drawStep() {
         renderer.draw();
-        renderer.getBounds(drawableID2);
+        //renderer.getBounds(drawableID2);
+        renderer.isTouchingColor(drawableID2, [255,255,255]);
         requestAnimationFrame(drawStep);
     }
     drawStep();

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -2,6 +2,7 @@ var twgl = require('twgl.js');
 var svgToImage = require('svg-to-image');
 var xhr = require('xhr');
 
+var Rectangle = require('./Rectangle');
 var ShaderManager = require('./ShaderManager');
 
 class Drawable {
@@ -488,28 +489,8 @@ Drawable.prototype.getBounds = function () {
         transformedHullPoints.push(glPoint);
     }
     // Search through transformed points to generate box on axes.
-    let bounds = {
-        left: Infinity,
-        right: -Infinity,
-        top: -Infinity,
-        bottom: Infinity
-    };
-    for (let i = 0; i < transformedHullPoints.length; i++) {
-        let x = transformedHullPoints[i][0];
-        let y = transformedHullPoints[i][1];
-        if (x < bounds.left) {
-            bounds.left = x;
-        }
-        if (x > bounds.right) {
-            bounds.right = x;
-        }
-        if (y > bounds.top) {
-            bounds.top = y;
-        }
-        if (y < bounds.bottom) {
-            bounds.bottom = y;
-        }
-    }
+    let bounds = new Rectangle();
+    bounds.initFromPointsAABB(transformedHullPoints);
     return bounds;
 };
 

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview
+ * A utility for creating and comparing axis-aligned rectangles.
+ */
+
+class Rectangle {
+    /**
+     * Rectangles are always initialized to the "largest possible rectangle";
+     * use one of the init* methods below to set up a particular rectangle.
+     * @constructor
+     */
+    constructor () {
+        this.left = -Infinity;
+        this.right = Infinity;
+        this.bottom = -Infinity;
+        this.top = Infinity;
+    }
+
+    /**
+     * Initialize a Rectangle from given Scratch-coordinate bounds.
+     * @param {number} left Left bound of the rectangle.
+     * @param {number} right Right bound of the rectangle.
+     * @param {number} bottom Bottom bound of the rectangle.
+     * @param {number} top Top bound of the rectangle.
+     */
+    initFromBounds (left, right, bottom, top) {
+        this.left = left;
+        this.right = right;
+        this.bottom = bottom;
+        this.top = top;
+    }
+
+    /**
+     * Initialize a Rectangle to the minimum AABB around a set of points.
+     * @param {Array.<Array.<number>>} points Array of [x, y] points.
+     */
+    initFromPointsAABB (points) {
+        this.left = Infinity;
+        this.right = -Infinity;
+        this.top = -Infinity;
+        this.bottom = Infinity;
+        for (let i = 0; i < points.length; i++) {
+            let x = points[i][0];
+            let y = points[i][1];
+            if (x < this.left) {
+                this.left = x;
+            }
+            if (x > this.right) {
+                this.right = x;
+            }
+            if (y > this.top) {
+                this.top = y;
+            }
+            if (y < this.bottom) {
+                this.bottom = y;
+            }
+        }
+    }
+
+    /**
+     * Determine if this Rectangle intersects some other.
+     * Note that this is a comparison assuming the Rectangle was
+     * initialized with Scratch-space bounds or points.
+     * @param {!Rectangle} other Rectangle to check if intersecting.
+     * @return {Boolean} True if this Rectangle intersects other.
+     */
+    intersects (other) {
+        return (
+            this.left <= other.right &&
+            other.left <= this.right &&
+            this.top >= other.bottom &&
+            other.top >= this.bottom
+        );
+    }
+
+    /**
+     * Determine if this Rectangle fully contains some other.
+     * Note that this is a comparison assuming the Rectangle was
+     * initialized with Scratch-space bounds or points.
+     * @param {!Rectangle} other Rectangle to check if fully contained.
+     * @return {Boolean} True if this Rectangle fully contains other.
+     */
+    contains (other) {
+        return (
+            other.left > this.left &&
+            other.right < this.right &&
+            other.top < this.top &&
+            other.bottom > this.bottom
+        );
+    }
+}
+
+module.exports = Rectangle;

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -111,7 +111,7 @@ class Rectangle {
     /**
      * Push out the Rectangle to integer bounds.
      */
-    ceil() {
+    snapToInt() {
         this.left = Math.floor(this.left);
         this.right = Math.ceil(this.right);
         this.bottom = Math.floor(this.bottom);

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -90,6 +90,25 @@ class Rectangle {
     }
 
     /**
+     * Clamp a Rectangle to bounds.
+     * @param {number} left Left clamp.
+     * @param {number} right Right clamp.
+     * @param {number} bottom Bottom clamp.
+     * @param {number} top Top clamp.
+     */
+    clamp (left, right, bottom, top) {
+        this.left = Math.max(this.left, left);
+        this.right = Math.min(this.right, right);
+        this.bottom = Math.max(this.bottom, bottom);
+        this.top = Math.min(this.top, top);
+        // Ensure rectangle coordinates in order.
+        this.left = Math.min(this.left, this.right);
+        this.right = Math.max(this.right, this.left);
+        this.bottom = Math.min(this.bottom, this.top);
+        this.top = Math.max(this.top, this.bottom);
+    }
+
+    /**
      * Width of the Rectangle.
      * @return {number} Width of rectangle.
      */

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -88,6 +88,22 @@ class Rectangle {
             other.bottom > this.bottom
         );
     }
+
+    /**
+     * Width of the Rectangle.
+     * @return {number} Width of rectangle.
+     */
+    get width () {
+        return Math.abs(this.left - this.right);
+    }
+
+    /**
+     * Height of the Rectangle.
+     * @return {number} Height of rectangle.
+     */
+    get height () {
+        return Math.abs(this.top - this.bottom);
+    }
 }
 
 module.exports = Rectangle;

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -109,6 +109,16 @@ class Rectangle {
     }
 
     /**
+     * Push out the Rectangle to integer bounds.
+     */
+    ceil() {
+        this.left = Math.floor(this.left);
+        this.right = Math.ceil(this.right);
+        this.bottom = Math.floor(this.bottom);
+        this.top = Math.ceil(this.top);
+    }
+
+    /**
      * Width of the Rectangle.
      * @return {number} Width of rectangle.
      */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -254,7 +254,7 @@ RenderWebGL.prototype.isTouchingColor = function(drawableID, color3b, mask3b) {
 
     // Use integer coordinates for queries - weird things happen
     // when you provide float width/heights to gl.viewport and projection.
-    bounds.ceil();
+    bounds.snapToInt();
 
     if (bounds.width == 0 || bounds.height == 0) {
         // No space to query.
@@ -376,7 +376,7 @@ RenderWebGL.prototype.isTouchingDrawables = function(drawableID, candidateIDs) {
 
     // Use integer coordinates for queries - weird things happen
     // when you provide float width/heights to gl.viewport and projection.
-    bounds.ceil();
+    bounds.snapToInt();
 
     if (bounds.width == 0 || bounds.height == 0) {
         // No space to query.


### PR DESCRIPTION
Features:

- Adds a Rectangle utility class with lots of useful methods. The Rectangle assumes coordinates are in Scratch-space.
- Add `getAABB` to Drawable, which returns the quickly-calculated bounding box.
- Add `getFastBounds` to Drawable. If calculating the convex hull-tight bounding box would be fast (not requiring pixel-reading), it returns that; otherwise it returns the same box as `getAABB`.
- Use `getFastBounds` to optimize isTouchingColor and isTouchingDrawables. This does what was previously suggested in the TODOs: limit the size of the viewport to the query bounding box, only read the pixels from that bounding box, and filter the items drawn to possible intersecting bounding boxes. I chose to do the filtering before the `_drawThese` filter function, so that we could return very early if possible.

I didn't add the same optimizations to `pick`, because it would first help to put pick coordinates in Scratch-space (#29) to do the bounding box intersection consistently with the above.