### PR TITLE
Change whirl direction to match Scratch 2.0 3D

### DIFF
--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -48,7 +48,7 @@ ShaderManager.EFFECT_INFO = {
     whirl: {
         mask: 1 << 2,
         converter: function(x) {
-            return x * Math.PI / 180;
+            return -x * Math.PI / 180;
         },
         shapeChanges: true
     },


### PR DESCRIPTION
The whirl effect's direction was reversed in Scratch 2.0 with the introduction of Stage3D. This "bug" has existed for long enough to become the expected whirl direction. This change adjusts the Scratch 3.0 whirl direction to match the Scratch 2.0 3D whirl direction instead of the Scratch 2.0 2D whirl direction.

Resolves #22 