### PR TITLE
Windows compat: Tell webpack-dev-server to poll

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,14 @@ var webpack = require('webpack');
 var base = {
     devServer: {
         contentBase: path.resolve(__dirname, 'playground'),
-        host: '0.0.0.0'
+        host: '0.0.0.0',
+        watchOptions: {
+            aggregateTimeout: 300,
+            poll: 1000
+        },
+        stats: {
+            colors: true
+        }
     },
     module: {
         loaders: [


### PR DESCRIPTION
When running on Windows, Webpack seems to more reliably notice altered files when running in polling mode. We already use the `--watch-poll` argument in the `watch` script, but this change adds equivalent settings to the config used in the `start` script by `webpack-dev-server`.

/cc @thisandagain 