### PR TITLE
Convert class methods to ES6 style

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -209,7 +209,6 @@ class Drawable {
      */
     _setSkinSVG (skinMd5ext) {
         const url = skinMd5ext;
-        const instance = this;
 
         const svgCanvas = document.createElement('canvas');
         const svgRenderer = new SvgRenderer(svgCanvas);
@@ -217,7 +216,7 @@ class Drawable {
         const gotSVG = (err, response, body) => {
             if (!err) {
                 svgRenderer.fromString(body, () => {
-                    instance._setSkinCore(svgCanvas, svgRenderer.getDrawRatio());
+                    this._setSkinCore(svgCanvas, svgRenderer.getDrawRatio());
                 });
             }
         };
@@ -235,10 +234,9 @@ class Drawable {
      * @private
      */
     _setSkinCore (source, costumeResolution) {
-        const instance = this;
         const callback = (err, texture, sourceInCallback) => {
-            if (!err && (instance._pendingSkin === texture)) {
-                instance._useSkin(texture, sourceInCallback.width, sourceInCallback.height, costumeResolution);
+            if (!err && (this._pendingSkin === texture)) {
+                this._useSkin(texture, sourceInCallback.width, sourceInCallback.height, costumeResolution);
             }
         };
 
@@ -251,12 +249,12 @@ class Drawable {
             src: source
         };
         const willCallCallback = typeof source === 'string';
-        instance._pendingSkin = twgl.createTexture(gl, options, willCallCallback ? callback : null);
+        this._pendingSkin = twgl.createTexture(gl, options, willCallCallback ? callback : null);
 
         // If we won't get a callback, start using the skin immediately.
         // This will happen if the data is already local.
         if (!willCallCallback) {
-            callback(null, instance._pendingSkin, source);
+            callback(null, this._pendingSkin, source);
         }
     }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -5,6 +5,13 @@ const Rectangle = require('./Rectangle');
 const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
 const ShaderManager = require('./ShaderManager');
 
+/**
+ * @callback Drawable~idFilterFunc
+ * @param {int} drawableID The ID to filter.
+ * @return {bool} True if the ID passes the filter, otherwise false.
+ */
+
+
 class Drawable {
     /**
      * An object which can be drawn by the renderer.
@@ -78,21 +85,450 @@ class Drawable {
         // Load a real skin
         this.setSkin(Drawable._DEFAULT_SKIN);
     }
+
+    /**
+     * An invalid Drawable ID which can be used to signify absence, etc.
+     * @type {int}
+     */
+    static get NONE () {
+        return -1;
+    }
+
+    /**
+     * Fetch a Drawable by its ID number.
+     * @param {int} drawableID The ID of the Drawable to fetch.
+     * @returns {?Drawable} The specified Drawable if found, otherwise null.
+     */
+    static getDrawableByID (drawableID) {
+        return Drawable._allDrawables[drawableID];
+    }
+
+    /**
+     * Dispose of this Drawable. Do not use it after calling this method.
+     */
+    dispose () {
+        this.setSkin(null);
+        if (this._id >= 0) {
+            delete Drawable[this._id];
+        }
+    }
+
+    /**
+     * Mark this Drawable's transform as dirty.
+     * It will be recalculated next time it's needed.
+     */
+    setTransformDirty () {
+        this._transformDirty = true;
+    }
+
+    /**
+     * Retrieve the ID for this Drawable.
+     * @returns {number} The ID for this Drawable.
+     */
+    getID () {
+        return this._id;
+    }
+
+    /**
+     * Set this Drawable's skin.
+     * The Drawable will continue using the existing skin until the new one loads.
+     * If there is no existing skin, the Drawable will use a 1x1 transparent image.
+     * @param {string} skinUrl The URL of the skin.
+     * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
+     */
+    setSkin (skinUrl, optCostumeResolution) {
+        // TODO: cache Skins instead of loading each time. Ref count them?
+        // TODO: share Skins across Drawables - see also destroy()
+        if (skinUrl) {
+            const ext = skinUrl.substring(skinUrl.lastIndexOf('.') + 1);
+            switch (ext) {
+            case 'svg':
+            case 'svg/get/':
+            case 'svgz':
+            case 'svgz/get/':
+                this._setSkinSVG(skinUrl);
+                break;
+            default:
+                this._setSkinBitmap(skinUrl, optCostumeResolution);
+                break;
+            }
+        } else {
+            this._useSkin(null, 0, 0, 1, true);
+        }
+    }
+
+    /**
+     * Use a skin if it is the currently-pending skin, or if skipPendingCheck==true.
+     * If the passed skin is used (for either reason) _pendingSkin will be cleared.
+     * @param {WebGLTexture} skin The skin to use.
+     * @param {int} width The width of the skin.
+     * @param {int} height The height of the skin.
+     * @param {int} costumeResolution The resolution to use for this skin.
+     * @param {boolean} [skipPendingCheck] If true, don't compare to _pendingSkin.
+     * @private
+     */
+    _useSkin (skin, width, height, costumeResolution, skipPendingCheck) {
+        if (skipPendingCheck || (skin === this._pendingSkin)) {
+            this._pendingSkin = null;
+            if (this._uniforms.u_skin && (this._uniforms.u_skin !== skin)) {
+                this._gl.deleteTexture(this._uniforms.u_skin);
+            }
+            this._setSkinSize(width, height, costumeResolution);
+            this._uniforms.u_skin = skin;
+        }
+    }
+
+    /**
+     * @returns {int} A bitmask identifying which effects are currently in use.
+     */
+    getEnabledEffects () {
+        return this._effectBits;
+    }
+
+    /**
+     * Load a bitmap skin. Supports the same formats as the Image element.
+     * @param {string} skinMd5ext The MD5 and file extension of the bitmap skin.
+     * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
+     * @private
+     */
+    _setSkinBitmap (skinMd5ext, optCostumeResolution) {
+        const url = skinMd5ext;
+        this._setSkinCore(url, optCostumeResolution);
+    }
+
+    /**
+     * Load an SVG-based skin. This still needs quite a bit of work to match the
+     * level of quality found in Scratch 2.0:
+     * - We should detect when a skin is being scaled up and render the SVG at a
+     *   higher resolution in those cases.
+     * - Colors seem a little off. This may be browser-specific.
+     * - This method works in Chrome, Firefox, Safari, and Edge but causes a
+     *   security error in IE.
+     * @param {string} skinMd5ext The MD5 and file extension of the SVG skin.
+     * @private
+     */
+    _setSkinSVG (skinMd5ext) {
+        const url = skinMd5ext;
+        const instance = this;
+
+        const svgCanvas = document.createElement('canvas');
+        const svgRenderer = new SvgRenderer(svgCanvas);
+
+        const gotSVG = (err, response, body) => {
+            if (!err) {
+                svgRenderer.fromString(body, () => {
+                    instance._setSkinCore(svgCanvas, svgRenderer.getDrawRatio());
+                });
+            }
+        };
+        xhr.get({
+            useXDR: true,
+            url: url
+        }, gotSVG);
+        // TODO: if there's no current u_skin, install *something* before returning
+    }
+
+    /**
+     * Common code for setting all skin types.
+     * @param {string|Image} source The source of image data for the skin.
+     * @param {int} costumeResolution The resolution to use for this skin.
+     * @private
+     */
+    _setSkinCore (source, costumeResolution) {
+        const instance = this;
+        const callback = (err, texture, sourceInCallback) => {
+            if (!err && (instance._pendingSkin === texture)) {
+                instance._useSkin(texture, sourceInCallback.width, sourceInCallback.height, costumeResolution);
+            }
+        };
+
+        const gl = this._gl;
+        const options = {
+            auto: true,
+            mag: gl.NEAREST,
+            min: gl.NEAREST, // TODO: mipmaps, linear (except pixelate)
+            wrap: gl.CLAMP_TO_EDGE,
+            src: source
+        };
+        const willCallCallback = typeof source === 'string';
+        instance._pendingSkin = twgl.createTexture(gl, options, willCallCallback ? callback : null);
+
+        // If we won't get a callback, start using the skin immediately.
+        // This will happen if the data is already local.
+        if (!willCallCallback) {
+            callback(null, instance._pendingSkin, source);
+        }
+    }
+
+    /**
+     * @returns {object.<string, *>} the shader uniforms to be used when rendering this Drawable.
+     */
+    getUniforms () {
+        if (this._transformDirty) {
+            this._calculateTransform();
+        }
+        return this._uniforms;
+    }
+
+    /**
+     * @returns {boolean} whether this Drawable is visible.
+     */
+    getVisible () {
+        return this._visible;
+    }
+
+    /**
+     * Update the position, direction, scale, or effect properties of this Drawable.
+     * @param {object.<string,*>} properties The new property values to set.
+     */
+    updateProperties (properties) {
+        let dirty = false;
+        if ('skin' in properties) {
+            this.setSkin(properties.skin, properties.costumeResolution);
+            this.setConvexHullDirty();
+        }
+        if ('position' in properties && (
+            this._position[0] !== properties.position[0] ||
+            this._position[1] !== properties.position[1])) {
+            this._position[0] = properties.position[0];
+            this._position[1] = properties.position[1];
+            dirty = true;
+        }
+        if ('direction' in properties && this._direction !== properties.direction) {
+            this._direction = properties.direction;
+            dirty = true;
+        }
+        if ('scale' in properties && (
+            this._scale[0] !== properties.scale[0] ||
+            this._scale[1] !== properties.scale[1])) {
+            this._scale[0] = properties.scale[0];
+            this._scale[1] = properties.scale[1];
+            dirty = true;
+        }
+        if ('rotationCenter' in properties && (
+            this._rotationCenter[0] !== properties.rotationCenter[0] ||
+            this._rotationCenter[1] !== properties.rotationCenter[1])) {
+            this._rotationCenter[0] = properties.rotationCenter[0];
+            this._rotationCenter[1] = properties.rotationCenter[1];
+            dirty = true;
+        }
+        if ('visible' in properties) {
+            this._visible = properties.visible;
+            this.setConvexHullDirty();
+        }
+        if (dirty) {
+            this.setTransformDirty();
+        }
+        const numEffects = ShaderManager.EFFECTS.length;
+        for (let index = 0; index < numEffects; ++index) {
+            const effectName = ShaderManager.EFFECTS[index];
+            if (effectName in properties) {
+                const rawValue = properties[effectName];
+                const effectInfo = ShaderManager.EFFECT_INFO[effectName];
+                if (rawValue) {
+                    this._effectBits |= effectInfo.mask;
+                } else {
+                    this._effectBits &= ~effectInfo.mask;
+                }
+                const converter = effectInfo.converter;
+                this._uniforms[`u_${effectName}`] = converter(rawValue);
+                if (effectInfo.shapeChanges) {
+                    this.setConvexHullDirty();
+                }
+            }
+        }
+    }
+
+    /**
+     * Set the dimensions of this Drawable's skin.
+     * @param {int} width The width of the new skin.
+     * @param {int} height The height of the new skin.
+     * @param {int} [costumeResolution] The resolution to use for this skin.
+     * @private
+     */
+    _setSkinSize (width, height, costumeResolution) {
+        costumeResolution = costumeResolution || 1;
+        width /= costumeResolution;
+        height /= costumeResolution;
+        if (this._uniforms.u_skinSize[0] !== width || this._uniforms.u_skinSize[1] !== height) {
+            this._uniforms.u_skinSize[0] = width;
+            this._uniforms.u_skinSize[1] = height;
+            this.setTransformDirty();
+        }
+        this.setConvexHullDirty();
+    }
+
+    /**
+     * Get the size of the Drawable's current skin.
+     * @return {Array.<number>} Skin size, width and height.
+     */
+    getSkinSize () {
+        return this._uniforms.u_skinSize.slice();
+    }
+
+    /**
+     * Calculate the transform to use when rendering this Drawable.
+     * @private
+     */
+    _calculateTransform () {
+        const modelMatrix = this._uniforms.u_modelMatrix;
+
+        twgl.m4.identity(modelMatrix);
+        twgl.m4.translate(modelMatrix, this._position, modelMatrix);
+
+        const rotation = (270 - this._direction) * Math.PI / 180;
+        twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
+
+
+        // Adjust rotation center relative to the skin.
+        const rotationAdjusted = twgl.v3.subtract(
+            this._rotationCenter,
+            twgl.v3.divScalar(this._uniforms.u_skinSize, 2)
+        );
+        rotationAdjusted[1] *= -1; // Y flipped to Scratch coordinate.
+        rotationAdjusted[2] = 0; // Z coordinate is 0.
+
+        twgl.m4.translate(modelMatrix, rotationAdjusted, modelMatrix);
+
+        const scaledSize = twgl.v3.divScalar(twgl.v3.multiply(this._uniforms.u_skinSize, this._scale), 100);
+        scaledSize[2] = 0; // was NaN because the vectors have only 2 components.
+        twgl.m4.scale(modelMatrix, scaledSize, modelMatrix);
+
+        this._transformDirty = false;
+    }
+
+    /**
+     * Whether the Drawable needs convex hull points provided by the renderer.
+     * @return {boolean} True when no convex hull known, or it's dirty.
+     */
+    needsConvexHullPoints () {
+        return !this._convexHullPoints || this._convexHullDirty;
+    }
+
+    /**
+     * Set the convex hull to be dirty.
+     * Do this whenever the Drawable's shape has possibly changed.
+     */
+    setConvexHullDirty () {
+        this._convexHullDirty = true;
+    }
+
+    /**
+     * Set the convex hull points for the Drawable.
+     * @param {Array.<Array.<number>>} points Convex hull points, as [[x, y], ...]
+     */
+    setConvexHullPoints (points) {
+        this._convexHullPoints = points;
+        this._convexHullDirty = false;
+    }
+
+    /**
+     * Get the precise bounds for a Drawable.
+     * This function applies the transform matrix to the known convex hull,
+     * and then finds the minimum box along the axes.
+     * Before calling this, ensure the renderer has updated convex hull points.
+     * @return {!Rectangle} Bounds for a tight box around the Drawable.
+     */
+    getBounds () {
+        if (this.needsConvexHullPoints()) {
+            throw new Error('Needs updated convex hull points before bounds calculation.');
+        }
+        if (this._transformDirty) {
+            this._calculateTransform();
+        }
+        // First, transform all the convex hull points by the current Drawable's
+        // transform. This allows us to skip recalculating the convex hull
+        // for many Drawable updates, including translation, rotation, scaling.
+        const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
+        const skinSize = this._uniforms.u_skinSize;
+        const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
+        const transformedHullPoints = [];
+        for (let i = 0; i < this._convexHullPoints.length; i++) {
+            const point = this._convexHullPoints[i];
+            const glPoint = twgl.v3.create(
+                0.5 + (-point[0] / skinSize[0]),
+                0.5 + (-point[1] / skinSize[1]),
+                0
+            );
+            twgl.m4.transformPoint(tm, glPoint, glPoint);
+            transformedHullPoints.push(glPoint);
+        }
+        // Search through transformed points to generate box on axes.
+        const bounds = new Rectangle();
+        bounds.initFromPointsAABB(transformedHullPoints);
+        return bounds;
+    }
+
+    /**
+     * Get the rough axis-aligned bounding box for the Drawable.
+     * Calculated by transforming the skin's bounds.
+     * Note that this is less precise than the box returned by `getBounds`,
+     * which is tightly snapped to account for a Drawable's transparent regions.
+     * `getAABB` returns a much less accurate bounding box, but will be much
+     * faster to calculate so may be desired for quick checks/optimizations.
+     * @return {!Rectangle} Rough axis-aligned bounding box for Drawable.
+     */
+    getAABB () {
+        if (this._transformDirty) {
+            this._calculateTransform();
+        }
+        const tm = this._uniforms.u_modelMatrix;
+        const bounds = new Rectangle();
+        bounds.initFromPointsAABB([
+            twgl.m4.transformPoint(tm, [-0.5, -0.5, 0]),
+            twgl.m4.transformPoint(tm, [0.5, -0.5, 0]),
+            twgl.m4.transformPoint(tm, [-0.5, 0.5, 0]),
+            twgl.m4.transformPoint(tm, [0.5, 0.5, 0])
+        ]);
+        return bounds;
+    }
+
+    /**
+     * Return the best Drawable bounds possible without performing graphics queries.
+     * I.e., returns the tight bounding box when the convex hull points are already
+     * known, but otherwise return the rough AABB of the Drawable.
+     * @return {!Rectangle} Bounds for the Drawable.
+     */
+    getFastBounds () {
+        if (!this.needsConvexHullPoints()) {
+            return this.getBounds();
+        }
+        return this.getAABB();
+    }
+
+    /**
+     * Calculate a color to represent the given ID number. At least one component of
+     * the resulting color will be non-zero if the ID is not Drawable.NONE.
+     * @param {int} id The ID to convert.
+     * @returns {number[]} An array of [r,g,b,a], each component in the range [0,1].
+     */
+    static color4fFromID (id) {
+        id -= Drawable.NONE;
+        const r = ((id >> 0) & 255) / 255.0;
+        const g = ((id >> 8) & 255) / 255.0;
+        const b = ((id >> 16) & 255) / 255.0;
+        return [r, g, b, 1.0];
+    }
+
+    /**
+     * Calculate the ID number represented by the given color. If all components of
+     * the color are zero, the result will be Drawable.NONE; otherwise the result
+     * will be a valid ID.
+     * @param {int} r The red value of the color, in the range [0,255].
+     * @param {int} g The green value of the color, in the range [0,255].
+     * @param {int} b The blue value of the color, in the range [0,255].
+     * @param {int} a The alpha value of the color, in the range [0,255].
+     * @returns {int} The ID represented by that color.
+     */
+    // eslint-disable-next-line no-unused-vars
+    static color4bToID (r, g, b, a) {
+        let id;
+        id = (r & 255) << 0;
+        id |= (g & 255) << 8;
+        id |= (b & 255) << 16;
+        return id + Drawable.NONE;
+    }
 }
-
-module.exports = Drawable;
-
-/**
- * @callback Drawable~idFilterFunc
- * @param {int} drawableID The ID to filter.
- * @return {bool} True if the ID passes the filter, otherwise false.
- */
-
-/**
- * An invalid Drawable ID which can be used to signify absence, etc.
- * @type {int}
- */
-Drawable.NONE = -1;
 
 /**
  * The ID to be assigned next time the Drawable constructor is called.
@@ -108,454 +544,16 @@ Drawable._nextDrawable = 0;
  */
 Drawable._allDrawables = {};
 
-/**
- * Fetch a Drawable by its ID number.
- * @param {int} drawableID The ID of the Drawable to fetch.
- * @returns {?Drawable} The specified Drawable if found, otherwise null.
- */
-Drawable.getDrawableByID = function (drawableID) {
-    return Drawable._allDrawables[drawableID];
-};
-
 // TODO: fall back on a built-in skin to protect against network problems
 Drawable._DEFAULT_SKIN = {
     squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-        '7e24c99c1b853e52f8e7f9004416fa34.png/get/',
+    '7e24c99c1b853e52f8e7f9004416fa34.png/get/',
     bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-        '66895930177178ea01d9e610917f8acf.png/get/',
+    '66895930177178ea01d9e610917f8acf.png/get/',
     scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-        '09dc888b0b7df19f70d81588ae73420e.svg/get/',
+    '09dc888b0b7df19f70d81588ae73420e.svg/get/',
     gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-        'a49ff276b9b8f997a1ae163992c2c145.png/get/'
+    'a49ff276b9b8f997a1ae163992c2c145.png/get/'
 }.squirrel;
 
-/**
- * Dispose of this Drawable. Do not use it after calling this method.
- */
-Drawable.prototype.dispose = function () {
-    this.setSkin(null);
-    if (this._id >= 0) {
-        delete Drawable[this._id];
-    }
-};
-
-/**
- * Mark this Drawable's transform as dirty.
- * It will be recalculated next time it's needed.
- */
-Drawable.prototype.setTransformDirty = function () {
-    this._transformDirty = true;
-};
-
-/**
- * Retrieve the ID for this Drawable.
- * @returns {number} The ID for this Drawable.
- */
-Drawable.prototype.getID = function () {
-    return this._id;
-};
-
-/**
- * Set this Drawable's skin.
- * The Drawable will continue using the existing skin until the new one loads.
- * If there is no existing skin, the Drawable will use a 1x1 transparent image.
- * @param {string} skinUrl The URL of the skin.
- * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
- */
-Drawable.prototype.setSkin = function (skinUrl, optCostumeResolution) {
-    // TODO: cache Skins instead of loading each time. Ref count them?
-    // TODO: share Skins across Drawables - see also destroy()
-    if (skinUrl) {
-        const ext = skinUrl.substring(skinUrl.lastIndexOf('.') + 1);
-        switch (ext) {
-        case 'svg':
-        case 'svg/get/':
-        case 'svgz':
-        case 'svgz/get/':
-            this._setSkinSVG(skinUrl);
-            break;
-        default:
-            this._setSkinBitmap(skinUrl, optCostumeResolution);
-            break;
-        }
-    } else {
-        this._useSkin(null, 0, 0, 1, true);
-    }
-};
-
-/**
- * Use a skin if it is the currently-pending skin, or if skipPendingCheck==true.
- * If the passed skin is used (for either reason) _pendingSkin will be cleared.
- * @param {WebGLTexture} skin The skin to use.
- * @param {int} width The width of the skin.
- * @param {int} height The height of the skin.
- * @param {int} costumeResolution The resolution to use for this skin.
- * @param {boolean} [skipPendingCheck] If true, don't compare to _pendingSkin.
- * @private
- */
-Drawable.prototype._useSkin = function (
-    skin, width, height, costumeResolution, skipPendingCheck) {
-
-    if (skipPendingCheck || (skin === this._pendingSkin)) {
-        this._pendingSkin = null;
-        if (this._uniforms.u_skin && (this._uniforms.u_skin !== skin)) {
-            this._gl.deleteTexture(this._uniforms.u_skin);
-        }
-        this._setSkinSize(width, height, costumeResolution);
-        this._uniforms.u_skin = skin;
-    }
-};
-
-/**
- * @returns {int} A bitmask identifying which effects are currently in use.
- */
-Drawable.prototype.getEnabledEffects = function () {
-    return this._effectBits;
-};
-
-/**
- * Load a bitmap skin. Supports the same formats as the Image element.
- * @param {string} skinMd5ext The MD5 and file extension of the bitmap skin.
- * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
- * @private
- */
-Drawable.prototype._setSkinBitmap = function (skinMd5ext, optCostumeResolution) {
-    const url = skinMd5ext;
-    this._setSkinCore(url, optCostumeResolution);
-};
-
-/**
- * Load an SVG-based skin. This still needs quite a bit of work to match the
- * level of quality found in Scratch 2.0:
- * - We should detect when a skin is being scaled up and render the SVG at a
- *   higher resolution in those cases.
- * - Colors seem a little off. This may be browser-specific.
- * - This method works in Chrome, Firefox, Safari, and Edge but causes a
- *   security error in IE.
- * @param {string} skinMd5ext The MD5 and file extension of the SVG skin.
- * @private
- */
-Drawable.prototype._setSkinSVG = function (skinMd5ext) {
-    const url = skinMd5ext;
-    const instance = this;
-
-    const svgCanvas = document.createElement('canvas');
-    const svgRenderer = new SvgRenderer(svgCanvas);
-
-    const gotSVG = (err, response, body) => {
-        if (!err) {
-            svgRenderer.fromString(body, () => {
-                instance._setSkinCore(svgCanvas, svgRenderer.getDrawRatio());
-            });
-        }
-    };
-    xhr.get({
-        useXDR: true,
-        url: url
-    }, gotSVG);
-    // TODO: if there's no current u_skin, install *something* before returning
-};
-
-/**
- * Common code for setting all skin types.
- * @param {string|Image} source The source of image data for the skin.
- * @param {int} costumeResolution The resolution to use for this skin.
- * @private
- */
-Drawable.prototype._setSkinCore = function (source, costumeResolution) {
-    const instance = this;
-    const callback = function (err, texture, sourceInCallback) {
-        if (!err && (instance._pendingSkin === texture)) {
-            instance._useSkin(
-                texture, sourceInCallback.width, sourceInCallback.height, costumeResolution);
-        }
-    };
-
-    const gl = this._gl;
-    const options = {
-        auto: true,
-        mag: gl.NEAREST,
-        min: gl.NEAREST, // TODO: mipmaps, linear (except pixelate)
-        wrap: gl.CLAMP_TO_EDGE,
-        src: source
-    };
-    const willCallCallback = typeof source === 'string';
-    instance._pendingSkin = twgl.createTexture(
-        gl, options, willCallCallback ? callback : null);
-
-    // If we won't get a callback, start using the skin immediately.
-    // This will happen if the data is already local.
-    if (!willCallCallback) {
-        callback(null, instance._pendingSkin, source);
-    }
-};
-
-/**
- * @returns {object.<string, *>} the shader uniforms to be used when rendering this Drawable.
- */
-Drawable.prototype.getUniforms = function () {
-    if (this._transformDirty) {
-        this._calculateTransform();
-    }
-    return this._uniforms;
-};
-
-/**
- * @returns {boolean} whether this Drawable is visible.
- */
-Drawable.prototype.getVisible = function () {
-    return this._visible;
-};
-
-/**
- * Update the position, direction, scale, or effect properties of this Drawable.
- * @param {object.<string,*>} properties The new property values to set.
- */
-Drawable.prototype.updateProperties = function (properties) {
-    let dirty = false;
-    if ('skin' in properties) {
-        this.setSkin(properties.skin, properties.costumeResolution);
-        this.setConvexHullDirty();
-    }
-    if ('position' in properties && (
-        this._position[0] !== properties.position[0] ||
-        this._position[1] !== properties.position[1])) {
-        this._position[0] = properties.position[0];
-        this._position[1] = properties.position[1];
-        dirty = true;
-    }
-    if ('direction' in properties && this._direction !== properties.direction) {
-        this._direction = properties.direction;
-        dirty = true;
-    }
-    if ('scale' in properties && (
-        this._scale[0] !== properties.scale[0] ||
-        this._scale[1] !== properties.scale[1])) {
-        this._scale[0] = properties.scale[0];
-        this._scale[1] = properties.scale[1];
-        dirty = true;
-    }
-    if ('rotationCenter' in properties && (
-        this._rotationCenter[0] !== properties.rotationCenter[0] ||
-        this._rotationCenter[1] !== properties.rotationCenter[1])) {
-        this._rotationCenter[0] = properties.rotationCenter[0];
-        this._rotationCenter[1] = properties.rotationCenter[1];
-        dirty = true;
-    }
-    if ('visible' in properties) {
-        this._visible = properties.visible;
-        this.setConvexHullDirty();
-    }
-    if (dirty) {
-        this.setTransformDirty();
-    }
-    const numEffects = ShaderManager.EFFECTS.length;
-    for (let index = 0; index < numEffects; ++index) {
-        const effectName = ShaderManager.EFFECTS[index];
-        if (effectName in properties) {
-            const rawValue = properties[effectName];
-            const effectInfo = ShaderManager.EFFECT_INFO[effectName];
-            if (rawValue) {
-                this._effectBits |= effectInfo.mask;
-            } else {
-                this._effectBits &= ~effectInfo.mask;
-            }
-            const converter = effectInfo.converter;
-            this._uniforms[`u_${effectName}`] = converter(rawValue);
-            if (effectInfo.shapeChanges) {
-                this.setConvexHullDirty();
-            }
-        }
-    }
-};
-
-/**
- * Set the dimensions of this Drawable's skin.
- * @param {int} width The width of the new skin.
- * @param {int} height The height of the new skin.
- * @param {int} [costumeResolution] The resolution to use for this skin.
- * @private
- */
-Drawable.prototype._setSkinSize = function (width, height, costumeResolution) {
-    costumeResolution = costumeResolution || 1;
-    width /= costumeResolution;
-    height /= costumeResolution;
-    if (this._uniforms.u_skinSize[0] !== width || this._uniforms.u_skinSize[1] !== height) {
-        this._uniforms.u_skinSize[0] = width;
-        this._uniforms.u_skinSize[1] = height;
-        this.setTransformDirty();
-    }
-    this.setConvexHullDirty();
-};
-
-/**
- * Get the size of the Drawable's current skin.
- * @return {Array.<number>} Skin size, width and height.
- */
-Drawable.prototype.getSkinSize = function () {
-    return this._uniforms.u_skinSize.slice();
-};
-
-/**
- * Calculate the transform to use when rendering this Drawable.
- * @private
- */
-Drawable.prototype._calculateTransform = function () {
-    const modelMatrix = this._uniforms.u_modelMatrix;
-
-    twgl.m4.identity(modelMatrix);
-    twgl.m4.translate(modelMatrix, this._position, modelMatrix);
-
-    const rotation = (270 - this._direction) * Math.PI / 180;
-    twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
-
-
-    // Adjust rotation center relative to the skin.
-    const rotationAdjusted = twgl.v3.subtract(
-        this._rotationCenter,
-        twgl.v3.divScalar(this._uniforms.u_skinSize, 2)
-    );
-    rotationAdjusted[1] *= -1; // Y flipped to Scratch coordinate.
-    rotationAdjusted[2] = 0; // Z coordinate is 0.
-
-    twgl.m4.translate(modelMatrix, rotationAdjusted, modelMatrix);
-
-    const scaledSize = twgl.v3.divScalar(twgl.v3.multiply(
-        this._uniforms.u_skinSize, this._scale), 100);
-    scaledSize[2] = 0; // was NaN because the vectors have only 2 components.
-    twgl.m4.scale(modelMatrix, scaledSize, modelMatrix);
-
-    this._transformDirty = false;
-};
-
-/**
- * Whether the Drawable needs convex hull points provided by the renderer.
- * @return {boolean} True when no convex hull known, or it's dirty.
- */
-Drawable.prototype.needsConvexHullPoints = function () {
-    return !this._convexHullPoints || this._convexHullDirty;
-};
-
-/**
- * Set the convex hull to be dirty.
- * Do this whenever the Drawable's shape has possibly changed.
- */
-Drawable.prototype.setConvexHullDirty = function () {
-    this._convexHullDirty = true;
-};
-
-/**
- * Set the convex hull points for the Drawable.
- * @param {Array.<Array.<number>>} points Convex hull points, as [[x, y], ...]
- */
-Drawable.prototype.setConvexHullPoints = function (points) {
-    this._convexHullPoints = points;
-    this._convexHullDirty = false;
-};
-
-/**
- * Get the precise bounds for a Drawable.
- * This function applies the transform matrix to the known convex hull,
- * and then finds the minimum box along the axes.
- * Before calling this, ensure the renderer has updated convex hull points.
- * @return {!Rectangle} Bounds for a tight box around the Drawable.
- */
-Drawable.prototype.getBounds = function () {
-    if (this.needsConvexHullPoints()) {
-        throw new Error('Needs updated convex hull points before bounds calculation.');
-    }
-    if (this._transformDirty) {
-        this._calculateTransform();
-    }
-    // First, transform all the convex hull points by the current Drawable's
-    // transform. This allows us to skip recalculating the convex hull
-    // for many Drawable updates, including translation, rotation, scaling.
-    const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
-    const skinSize = this._uniforms.u_skinSize;
-    const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
-    const transformedHullPoints = [];
-    for (let i = 0; i < this._convexHullPoints.length; i++) {
-        const point = this._convexHullPoints[i];
-        const glPoint = twgl.v3.create(
-            0.5 + (-point[0] / skinSize[0]),
-            0.5 + (-point[1] / skinSize[1]),
-            0
-        );
-        twgl.m4.transformPoint(tm, glPoint, glPoint);
-        transformedHullPoints.push(glPoint);
-    }
-    // Search through transformed points to generate box on axes.
-    const bounds = new Rectangle();
-    bounds.initFromPointsAABB(transformedHullPoints);
-    return bounds;
-};
-
-/**
- * Get the rough axis-aligned bounding box for the Drawable.
- * Calculated by transforming the skin's bounds.
- * Note that this is less precise than the box returned by `getBounds`,
- * which is tightly snapped to account for a Drawable's transparent regions.
- * `getAABB` returns a much less accurate bounding box, but will be much
- * faster to calculate so may be desired for quick checks/optimizations.
- * @return {!Rectangle} Rough axis-aligned bounding box for Drawable.
- */
-Drawable.prototype.getAABB = function () {
-    if (this._transformDirty) {
-        this._calculateTransform();
-    }
-    const tm = this._uniforms.u_modelMatrix;
-    const bounds = new Rectangle();
-    bounds.initFromPointsAABB([
-        twgl.m4.transformPoint(tm, [-0.5, -0.5, 0]),
-        twgl.m4.transformPoint(tm, [0.5, -0.5, 0]),
-        twgl.m4.transformPoint(tm, [-0.5, 0.5, 0]),
-        twgl.m4.transformPoint(tm, [0.5, 0.5, 0])
-    ]);
-    return bounds;
-};
-
-/**
- * Return the best Drawable bounds possible without performing graphics queries.
- * I.e., returns the tight bounding box when the convex hull points are already
- * known, but otherwise return the rough AABB of the Drawable.
- * @return {!Rectangle} Bounds for the Drawable.
- */
-Drawable.prototype.getFastBounds = function () {
-    if (!this.needsConvexHullPoints()) {
-        return this.getBounds();
-    }
-    return this.getAABB();
-};
-
-/**
- * Calculate a color to represent the given ID number. At least one component of
- * the resulting color will be non-zero if the ID is not Drawable.NONE.
- * @param {int} id The ID to convert.
- * @returns {number[]} An array of [r,g,b,a], each component in the range [0,1].
- */
-Drawable.color4fFromID = function (id) {
-    id -= Drawable.NONE;
-    const r = ((id >> 0) & 255) / 255.0;
-    const g = ((id >> 8) & 255) / 255.0;
-    const b = ((id >> 16) & 255) / 255.0;
-    return [r, g, b, 1.0];
-};
-
-/**
- * Calculate the ID number represented by the given color. If all components of
- * the color are zero, the result will be Drawable.NONE; otherwise the result
- * will be a valid ID.
- * @param {int} r The red value of the color, in the range [0,255].
- * @param {int} g The green value of the color, in the range [0,255].
- * @param {int} b The blue value of the color, in the range [0,255].
- * @param {int} a The alpha value of the color, in the range [0,255].
- * @returns {int} The ID represented by that color.
- */
-// eslint-disable-next-line no-unused-vars
-Drawable.color4bToID = function (r, g, b, a) {
-    let id;
-    id = (r & 255) << 0;
-    id |= (g & 255) << 8;
-    id |= (b & 255) << 16;
-    return id + Drawable.NONE;
-};
+module.exports = Drawable;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -515,11 +515,9 @@ class Drawable {
      * @param {int} r The red value of the color, in the range [0,255].
      * @param {int} g The green value of the color, in the range [0,255].
      * @param {int} b The blue value of the color, in the range [0,255].
-     * @param {int} a The alpha value of the color, in the range [0,255].
      * @returns {int} The ID represented by that color.
      */
-    // eslint-disable-next-line no-unused-vars
-    static color4bToID (r, g, b, a) {
+    static color4bToID (r, g, b) {
         let id;
         id = (r & 255) << 0;
         id |= (g & 255) << 8;
@@ -544,14 +542,10 @@ Drawable._allDrawables = {};
 
 // TODO: fall back on a built-in skin to protect against network problems
 Drawable._DEFAULT_SKIN = {
-    squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-    '7e24c99c1b853e52f8e7f9004416fa34.png/get/',
-    bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-    '66895930177178ea01d9e610917f8acf.png/get/',
-    scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-    '09dc888b0b7df19f70d81588ae73420e.svg/get/',
-    gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-    'a49ff276b9b8f997a1ae163992c2c145.png/get/'
+    squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/',
+    bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/66895930177178ea01d9e610917f8acf.png/get/',
+    scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/09dc888b0b7df19f70d81588ae73420e.svg/get/',
+    gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/a49ff276b9b8f997a1ae163992c2c145.png/get/'
 }.squirrel;
 
 module.exports = Drawable;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -517,7 +517,7 @@ class Drawable {
      * @param {int} b The blue value of the color, in the range [0,255].
      * @returns {int} The ID represented by that color.
      */
-    static color4bToID (r, g, b) {
+    static color3bToID (r, g, b) {
         let id;
         id = (r & 255) << 0;
         id |= (g & 255) << 8;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -382,8 +382,7 @@ class RenderWebGL {
             const pixelID = Drawable.color4bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
-                pixels[pixelBase + 2],
-                pixels[pixelBase + 3]);
+                pixels[pixelBase + 2]);
             if (pixelID > Drawable.NONE) {
                 return true;
             }
@@ -463,8 +462,7 @@ class RenderWebGL {
             const pixelID = Drawable.color4bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
-                pixels[pixelBase + 2],
-                pixels[pixelBase + 3]);
+                pixels[pixelBase + 2]);
             hits[pixelID] = (hits[pixelID] || 0) + 1;
         }
 
@@ -701,8 +699,7 @@ class RenderWebGL {
             return Drawable.color4bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
-                pixels[pixelBase + 2],
-                pixels[pixelBase + 3]);
+                pixels[pixelBase + 2]);
         };
         for (let y = 0; y <= height; y++) {
             // Scan from left.

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -4,6 +4,21 @@ const twgl = require('twgl.js');
 const Drawable = require('./Drawable');
 const ShaderManager = require('./ShaderManager');
 
+/**
+ * Maximum touch size for a picking check.
+ * TODO: Figure out a reasonable max size. Maybe this should be configurable?
+ * @type {int[]}
+ */
+const MAX_TOUCH_SIZE = [3, 3];
+
+/**
+ * "touching {color}?" or "{color} touching {color}?" tests will be true if the
+ * target is touching a color whose components are each within this tolerance of
+ * the corresponding component of the query color.
+ * @type {int} between 0 (exact matches only) and 255 (match anything).
+ */
+const TOLERANCE_TOUCHING_COLOR = 2;
+
 
 class RenderWebGL {
     /**
@@ -32,8 +47,7 @@ class RenderWebGL {
         this._createGeometry();
 
         this.setBackgroundColor(1, 1, 1);
-        this.setStageSize(
-            xLeft || -240, xRight || 240, yBottom || -180, yTop || 180);
+        this.setStageSize(xLeft || -240, xRight || 240, yBottom || -180, yTop || 180);
         this.resize(this._nativeSize[0], this._nativeSize[1]);
         this._createQueryBuffers();
 
@@ -43,729 +57,672 @@ class RenderWebGL {
         gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
         this._shaderManager = new ShaderManager(gl);
     }
+
+    /**
+     * Set the physical size of the stage in device-independent pixels.
+     * This will be multiplied by the device's pixel ratio on high-DPI displays.
+     * @param {int} pixelsWide The desired width in device-independent pixels.
+     * @param {int} pixelsTall The desired height in device-independent pixels.
+     */
+    resize (pixelsWide, pixelsTall) {
+        const pixelRatio = window.devicePixelRatio || 1;
+        this._gl.canvas.width = pixelsWide * pixelRatio;
+        this._gl.canvas.height = pixelsTall * pixelRatio;
+    }
+
+    /**
+     * Set the background color for the stage. The stage will be cleared with this
+     * color each frame.
+     * @param {number} red The red component for the background.
+     * @param {number} green The green component for the background.
+     * @param {number} blue The blue component for the background.
+     */
+    setBackgroundColor (red, green, blue) {
+        this._backgroundColor = [red, green, blue, 1];
+    }
+
+    /**
+     * Tell the renderer to draw various debug information to the provided canvas
+     * during certain operations.
+     * @param {canvas} canvas The canvas to use for debug output.
+     */
+    setDebugCanvas (canvas) {
+        this._debugCanvas = canvas;
+    }
+
+    /**
+     * Set logical size of the stage in Scratch units.
+     * @param {int} xLeft The left edge's x-coordinate. Scratch 2 uses -240.
+     * @param {int} xRight The right edge's x-coordinate. Scratch 2 uses 240.
+     * @param {int} yBottom The bottom edge's y-coordinate. Scratch 2 uses -180.
+     * @param {int} yTop The top edge's y-coordinate. Scratch 2 uses 180.
+     */
+    setStageSize (xLeft, xRight, yBottom, yTop) {
+        this._xLeft = xLeft;
+        this._xRight = xRight;
+        this._yBottom = yBottom;
+        this._yTop = yTop;
+        this._nativeSize = [Math.abs(xRight - xLeft), Math.abs(yBottom - yTop)];
+        this._projection = twgl.m4.ortho(xLeft, xRight, yBottom, yTop, -1, 1);
+    }
+
+    /**
+     * Create a new Drawable and add it to the scene.
+     * @returns {int} The ID of the new Drawable.
+     */
+    createDrawable () {
+        const drawable = new Drawable(this._gl);
+        const drawableID = drawable.getID();
+        this._drawables.push(drawableID);
+        return drawableID;
+    }
+
+    /**
+     * Destroy a Drawable, removing it from the scene.
+     * @param {int} drawableID The ID of the Drawable to remove.
+     * @returns {boolean} True iff the drawable was found and removed.
+     */
+    destroyDrawable (drawableID) {
+        const index = this._drawables.indexOf(drawableID);
+        if (index >= 0) {
+            Drawable.getDrawableByID(drawableID).dispose();
+            this._drawables.splice(index, 1);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set a drawable's order in the drawable list (effectively, z/layer).
+     * Can be used to move drawables to absolute positions in the list,
+     * or relative to their current positions.
+     * "go back N layers": setDrawableOrder(id, -N, true, 1); (assuming stage at 0).
+     * "go to back": setDrawableOrder(id, 1); (assuming stage at 0).
+     * "go to front": setDrawableOrder(id, Infinity);
+     * @param {int} drawableID ID of Drawable to reorder.
+     * @param {number} order New absolute order or relative order adjusment.
+     * @param {boolean=} optIsRelative If set, `order` refers to a relative change.
+     * @param {number=} optMin If set, order constrained to be at least `optMin`.
+     * @return {?number} New order if changed, or null.
+     */
+    setDrawableOrder (drawableID, order, optIsRelative, optMin) {
+        const oldIndex = this._drawables.indexOf(drawableID);
+        if (oldIndex >= 0) {
+            // Remove drawable from the list.
+            const drawable = this._drawables.splice(oldIndex, 1)[0];
+            // Determine new index.
+            let newIndex = order;
+            if (optIsRelative) {
+                newIndex += oldIndex;
+            }
+            if (optMin) {
+                newIndex = Math.max(newIndex, optMin);
+            }
+            newIndex = Math.max(newIndex, 0);
+            // Insert at new index.
+            this._drawables.splice(newIndex, 0, drawable);
+            return this._drawables.indexOf(drawable);
+        }
+        return null;
+    }
+
+    /**
+     * Draw all current drawables and present the frame on the canvas.
+     */
+    draw () {
+        const gl = this._gl;
+
+        twgl.bindFramebufferInfo(gl, null);
+        gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+        gl.clearColor.apply(gl, this._backgroundColor);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        this._drawThese(this._drawables, ShaderManager.DRAW_MODE.default, this._projection);
+    }
+
+    /**
+     * Get the precise bounds for a Drawable.
+     * @param {int} drawableID ID of Drawable to get bounds for.
+     * @return {object} Bounds for a tight box around the Drawable.
+     */
+    getBounds (drawableID) {
+        const drawable = Drawable.getDrawableByID(drawableID);
+        // Tell the Drawable about its updated convex hull, if necessary.
+        if (drawable.needsConvexHullPoints()) {
+            const points = this._getConvexHullPointsForDrawable(drawableID);
+            drawable.setConvexHullPoints(points);
+        }
+        const bounds = drawable.getBounds();
+        // In debug mode, draw the bounds.
+        if (this._debugCanvas) {
+            const gl = this._gl;
+            this._debugCanvas.width = gl.canvas.width;
+            this._debugCanvas.height = gl.canvas.height;
+            const context = this._debugCanvas.getContext('2d');
+            context.drawImage(gl.canvas, 0, 0);
+            context.strokeStyle = '#FF0000';
+            const pr = window.devicePixelRatio;
+            context.strokeRect(
+                pr * (bounds.left + (this._nativeSize[0] / 2)),
+                pr * (-bounds.top + (this._nativeSize[1] / 2)),
+                pr * (bounds.right - bounds.left),
+                pr * (-bounds.bottom + bounds.top)
+            );
+        }
+        return bounds;
+    }
+
+    /**
+     * Get the current skin (costume) size of a Drawable.
+     * @param {int} drawableID The ID of the Drawable to measure.
+     * @return {Array.<number>} Skin size, width and height.
+     */
+    getSkinSize (drawableID) {
+        const drawable = Drawable.getDrawableByID(drawableID);
+        return drawable.getSkinSize();
+    }
+
+    /**
+     * Check if a particular Drawable is touching a particular color.
+     * @param {int} drawableID The ID of the Drawable to check.
+     * @param {int[]} color3b Test if the Drawable is touching this color.
+     * @param {int[]} [mask3b] Optionally mask the check to this part of Drawable.
+     * @returns {boolean} True iff the Drawable is touching the color.
+     */
+    isTouchingColor (drawableID, color3b, mask3b) {
+        const gl = this._gl;
+        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+
+        const bounds = this._touchingBounds(drawableID);
+        if (!bounds) {
+            return;
+        }
+        const candidateIDs = this._filterCandidatesTouching(drawableID, this._drawables, bounds);
+        if (!candidateIDs) {
+            return;
+        }
+
+
+        // Limit size of viewport to the bounds around the target Drawable,
+        // and create the projection matrix for the draw.
+        gl.viewport(0, 0, bounds.width, bounds.height);
+        const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.bottom, bounds.top, -1, 1);
+
+        gl.clearColor.apply(gl, this._backgroundColor);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+
+        let extraUniforms;
+        if (mask3b) {
+            extraUniforms = {
+                u_colorMask: [mask3b[0] / 255, mask3b[1] / 255, mask3b[2] / 255],
+                u_colorMaskTolerance: TOLERANCE_TOUCHING_COLOR / 255
+            };
+        }
+
+        try {
+            gl.enable(gl.STENCIL_TEST);
+            gl.stencilFunc(gl.ALWAYS, 1, 1);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
+            gl.colorMask(false, false, false, false);
+            this._drawThese(
+                [drawableID],
+                mask3b ?
+                    ShaderManager.DRAW_MODE.colorMask :
+                    ShaderManager.DRAW_MODE.silhouette,
+                projection,
+                null,
+                extraUniforms);
+
+            gl.stencilFunc(gl.EQUAL, 1, 1);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+            gl.colorMask(true, true, true, true);
+
+            this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.default, projection,
+                testID => testID !== drawableID
+            );
+        } finally {
+            gl.colorMask(true, true, true, true);
+            gl.disable(gl.STENCIL_TEST);
+        }
+
+        const pixels = new Buffer(bounds.width * bounds.height * 4);
+        gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        if (this._debugCanvas) {
+            this._debugCanvas.width = bounds.width;
+            this._debugCanvas.height = bounds.height;
+            const context = this._debugCanvas.getContext('2d');
+            const imageData = context.getImageData(0, 0, bounds.width, bounds.height);
+            for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
+                imageData.data[i] = pixels[i];
+            }
+            context.putImageData(imageData, 0, 0);
+        }
+
+        for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
+            const pixelDistanceR = Math.abs(pixels[pixelBase] - color3b[0]);
+            const pixelDistanceG = Math.abs(pixels[pixelBase + 1] - color3b[1]);
+            const pixelDistanceB = Math.abs(pixels[pixelBase + 2] - color3b[2]);
+
+            if (pixelDistanceR <= TOLERANCE_TOUCHING_COLOR &&
+                pixelDistanceG <= TOLERANCE_TOUCHING_COLOR &&
+                pixelDistanceB <= TOLERANCE_TOUCHING_COLOR) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a particular Drawable is touching any in a set of Drawables.
+     * @param {int} drawableID The ID of the Drawable to check.
+     * @param {int[]} candidateIDs The Drawable IDs to check, otherwise all.
+     * @returns {boolean} True iff the Drawable is touching one of candidateIDs.
+     */
+    isTouchingDrawables (drawableID, candidateIDs) {
+        candidateIDs = candidateIDs || this._drawables;
+
+        const gl = this._gl;
+
+        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+
+        const bounds = this._touchingBounds(drawableID);
+        if (!bounds) {
+            return;
+        }
+        candidateIDs = this._filterCandidatesTouching(drawableID, candidateIDs, bounds);
+        if (!candidateIDs) {
+            return;
+        }
+
+        // Limit size of viewport to the bounds around the target Drawable,
+        // and create the projection matrix for the draw.
+        gl.viewport(0, 0, bounds.width, bounds.height);
+        const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.bottom, bounds.top, -1, 1);
+
+        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        gl.clearColor.apply(gl, noneColor);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+
+        try {
+            gl.enable(gl.STENCIL_TEST);
+            gl.stencilFunc(gl.ALWAYS, 1, 1);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
+            gl.colorMask(false, false, false, false);
+            this._drawThese([drawableID], ShaderManager.DRAW_MODE.silhouette, projection);
+
+            gl.stencilFunc(gl.EQUAL, 1, 1);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+            gl.colorMask(true, true, true, true);
+
+            this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection,
+                testID => testID !== drawableID
+            );
+        } finally {
+            gl.colorMask(true, true, true, true);
+            gl.disable(gl.STENCIL_TEST);
+        }
+
+        const pixels = new Buffer(bounds.width * bounds.height * 4);
+        gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        if (this._debugCanvas) {
+            this._debugCanvas.width = bounds.width;
+            this._debugCanvas.height = bounds.height;
+            const context = this._debugCanvas.getContext('2d');
+            const imageData = context.getImageData(0, 0, bounds.width, bounds.height);
+            for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
+                imageData.data[i] = pixels[i];
+            }
+            context.putImageData(imageData, 0, 0);
+        }
+
+        for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
+            const pixelID = Drawable.color4bToID(
+                pixels[pixelBase],
+                pixels[pixelBase + 1],
+                pixels[pixelBase + 2],
+                pixels[pixelBase + 3]);
+            if (pixelID > Drawable.NONE) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Detect which sprite, if any, is at the given location.
+     * @param {int} centerX The client x coordinate of the picking location.
+     * @param {int} centerY The client y coordinate of the picking location.
+     * @param {int} touchWidth The client width of the touch event (optional).
+     * @param {int} touchHeight The client height of the touch event (optional).
+     * @param {int[]} candidateIDs The Drawable IDs to pick from, otherwise all.
+     * @returns {int} The ID of the topmost Drawable under the picking location, or
+     * Drawable.NONE if there is no Drawable at that location.
+     */
+    pick (centerX, centerY, touchWidth, touchHeight, candidateIDs) {
+        const gl = this._gl;
+
+        touchWidth = touchWidth || 1;
+        touchHeight = touchHeight || 1;
+        candidateIDs = candidateIDs || this._drawables;
+
+        const clientToGLX = gl.canvas.width / gl.canvas.clientWidth;
+        const clientToGLY = gl.canvas.height / gl.canvas.clientHeight;
+
+        centerX *= clientToGLX;
+        centerY *= clientToGLY;
+        touchWidth *= clientToGLX;
+        touchHeight *= clientToGLY;
+
+        touchWidth = Math.max(1, Math.min(touchWidth, MAX_TOUCH_SIZE[0]));
+        touchHeight = Math.max(1, Math.min(touchHeight, MAX_TOUCH_SIZE[1]));
+
+        const pixelLeft = Math.floor(centerX - Math.floor(touchWidth / 2) + 0.5);
+        const pixelRight = Math.floor(centerX + Math.ceil(touchWidth / 2) + 0.5);
+        const pixelTop = Math.floor(centerY - Math.floor(touchHeight / 2) + 0.5);
+        const pixelBottom = Math.floor(centerY + Math.ceil(touchHeight / 2) + 0.5);
+
+        twgl.bindFramebufferInfo(gl, this._pickBufferInfo);
+        gl.viewport(0, 0, touchWidth, touchHeight);
+
+        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        gl.clearColor.apply(gl, noneColor);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        const widthPerPixel = (this._xRight - this._xLeft) / this._gl.canvas.width;
+        const heightPerPixel = (this._yBottom - this._yTop) / this._gl.canvas.height;
+
+        const pickLeft = this._xLeft + (pixelLeft * widthPerPixel);
+        const pickRight = this._xLeft + (pixelRight * widthPerPixel);
+        const pickTop = this._yTop + (pixelTop * heightPerPixel);
+        const pickBottom = this._yTop + (pixelBottom * heightPerPixel);
+
+        const projection = twgl.m4.ortho(pickLeft, pickRight, pickTop, pickBottom, -1, 1);
+
+        this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection);
+
+        const pixels = new Buffer(touchWidth * touchHeight * 4);
+        gl.readPixels(0, 0, touchWidth, touchHeight, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        if (this._debugCanvas) {
+            this._debugCanvas.width = touchWidth;
+            this._debugCanvas.height = touchHeight;
+            const context = this._debugCanvas.getContext('2d');
+            const imageData = context.getImageData(0, 0, touchWidth, touchHeight);
+            for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
+                imageData.data[i] = pixels[i];
+            }
+            context.putImageData(imageData, 0, 0);
+        }
+
+        const hits = {};
+        for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
+            const pixelID = Drawable.color4bToID(
+                pixels[pixelBase],
+                pixels[pixelBase + 1],
+                pixels[pixelBase + 2],
+                pixels[pixelBase + 3]);
+            hits[pixelID] = (hits[pixelID] || 0) + 1;
+        }
+
+        // Bias toward selecting anything over nothing
+        hits[Drawable.NONE] = 0;
+
+        let hit = Drawable.NONE;
+        for (const hitID in hits) {
+            if (hits.hasOwnProperty(hitID) && (hits[hitID] > hits[hit])) {
+                hit = hitID;
+            }
+        }
+
+        return hit | 0;
+    }
+
+    /**
+     * Get the candidate bounding box for a touching query.
+     * @param {int} drawableID ID for drawable of query.
+     * @return {?Rectangle} Rectangle bounds for touching query, or null.
+     */
+    _touchingBounds (drawableID) {
+        const drawable = Drawable.getDrawableByID(drawableID);
+        const bounds = drawable.getFastBounds();
+
+        // Limit queries to the stage size.
+        bounds.clamp(this._xLeft, this._xRight, this._yBottom, this._yTop);
+
+        // Use integer coordinates for queries - weird things happen
+        // when you provide float width/heights to gl.viewport and projection.
+        bounds.snapToInt();
+
+        if (bounds.width === 0 || bounds.height === 0) {
+            // No space to query.
+            return null;
+        }
+        return bounds;
+    }
+
+    /**
+     * Filter a list of candidates for a touching query into only those that
+     * could possibly intersect the given bounds.
+     * @param {int} drawableID - ID for drawable of query.
+     * @param {Array.<int>} candidateIDs - Candidates for touching query.
+     * @param {Rectangle} bounds - Bounds to limit candidates to.
+     * @return {?Array.<int>} Filtered candidateIDs, or null if none.
+     */
+    _filterCandidatesTouching (drawableID, candidateIDs, bounds) {
+        // Filter candidates by rough bounding box intersection.
+        // Do this before _drawThese, so we can prevent any GL operations
+        // and readback by returning early.
+        candidateIDs = candidateIDs.filter(testID => {
+            if (testID === drawableID) return false;
+            // Only draw items which could possibly overlap target Drawable.
+            const candidate = Drawable.getDrawableByID(testID);
+            const candidateBounds = candidate.getFastBounds();
+            return bounds.intersects(candidateBounds);
+        });
+        if (candidateIDs.length === 0) {
+            // No possible intersections based on bounding boxes.
+            return null;
+        }
+        return candidateIDs;
+    }
+
+    /**
+     * Update the position, direction, scale, or effect properties of this Drawable.
+     * @param {int} drawableID The ID of the Drawable to update.
+     * @param {object.<string,*>} properties The new property values to set.
+     */
+    updateDrawableProperties (drawableID, properties) {
+        const drawable = Drawable.getDrawableByID(drawableID);
+        drawable.updateProperties(properties);
+    }
+
+    /* ******
+     * Truly internal functions: these support the functions above.
+     ********/
+
+    /**
+     * Build geometry (vertex and index) buffers.
+     * @private
+     */
+    _createGeometry () {
+        const quad = {
+            a_position: {
+                numComponents: 2,
+                data: [
+                    -0.5, -0.5,
+                    0.5, -0.5,
+                    -0.5, 0.5,
+                    -0.5, 0.5,
+                    0.5, -0.5,
+                    0.5, 0.5
+                ]
+            },
+            a_texCoord: {
+                numComponents: 2,
+                data: [
+                    1, 0,
+                    0, 0,
+                    1, 1,
+                    1, 1,
+                    0, 0,
+                    0, 1
+                ]
+            }
+        };
+        this._bufferInfo = twgl.createBufferInfoFromArrays(this._gl, quad);
+    }
+
+    /**
+     * Create the frame buffers used for queries such as picking and color-touching.
+     * These buffers are fixed in size regardless of the size of the main render
+     * target. The fixed size allows (more) consistent behavior across devices and
+     * presentation modes.
+     * @private
+     */
+    _createQueryBuffers () {
+        const gl = this._gl;
+        const attachments = [
+            {format: gl.RGBA},
+            {format: gl.DEPTH_STENCIL}
+        ];
+
+        this._pickBufferInfo = twgl.createFramebufferInfo(gl, attachments, MAX_TOUCH_SIZE[0], MAX_TOUCH_SIZE[1]);
+
+        // TODO: should we create this on demand to save memory?
+        // A 480x360 32-bpp buffer is 675 KiB.
+        this._queryBufferInfo = twgl.createFramebufferInfo(gl, attachments, this._nativeSize[0], this._nativeSize[1]);
+    }
+
+    /**
+     * Draw all Drawables, with the possible exception of
+     * @param {int[]} drawables The Drawable IDs to draw, possibly this._drawables.
+     * @param {ShaderManager.DRAW_MODE} drawMode Draw normally, silhouette, etc.
+     * @param {module:twgl/m4.Mat4} projection The projection matrix to use.
+     * @param {Drawable~idFilterFunc} [filter] An optional filter function.
+     * @param {Object.<string,*>} [extraUniforms] Extra uniforms for the shaders.
+     * @private
+     */
+    _drawThese (drawables, drawMode, projection, filter, extraUniforms) {
+        const gl = this._gl;
+        let currentShader = null;
+
+        const numDrawables = drawables.length;
+        for (let drawableIndex = 0; drawableIndex < numDrawables; ++drawableIndex) {
+            const drawableID = drawables[drawableIndex];
+
+            // If we have a filter, check whether the ID fails
+            if (filter && !filter(drawableID)) continue;
+
+            const drawable = Drawable.getDrawableByID(drawableID);
+            // TODO: check if drawable is inside the viewport before anything else
+
+            // Hidden drawables (e.g., by a "hide" block) are never drawn.
+            if (!drawable.getVisible()) continue;
+
+            const effectBits = drawable.getEnabledEffects();
+            const newShader = this._shaderManager.getShader(drawMode, effectBits);
+            if (currentShader !== newShader) {
+                currentShader = newShader;
+                gl.useProgram(currentShader.program);
+                twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
+                twgl.setUniforms(currentShader, {u_projectionMatrix: projection});
+                twgl.setUniforms(currentShader, {u_fudge: window.fudge || 0});
+            }
+
+            twgl.setUniforms(currentShader, drawable.getUniforms());
+
+            // Apply extra uniforms after the Drawable's, to allow overwriting.
+            if (extraUniforms) {
+                twgl.setUniforms(currentShader, extraUniforms);
+            }
+
+            twgl.drawBufferInfo(gl, gl.TRIANGLES, this._bufferInfo);
+        }
+    }
+
+    /**
+     * Get the convex hull points for a particular Drawable.
+     * To do this, draw the Drawable unrotated, unscaled, and untranslated.
+     * Read back the pixels and find all boundary points.
+     * Finally, apply a convex hull algorithm to simplify the set.
+     * @param {int} drawableID The Drawable IDs calculate convex hull for.
+     * @return {Array.<Array.<number>>} points Convex hull points, as [[x, y], ...]
+     */
+    _getConvexHullPointsForDrawable (drawableID) {
+        const drawable = Drawable.getDrawableByID(drawableID);
+        const [width, height] = drawable._uniforms.u_skinSize;
+        // No points in the hull if invisible or size is 0.
+        if (!drawable.getVisible() || width === 0 || height === 0) {
+            return [];
+        }
+
+        // Only draw to the size of the untransformed drawable.
+        const gl = this._gl;
+        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+        gl.viewport(0, 0, width, height);
+
+        // Clear the canvas with Drawable.NONE.
+        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        gl.clearColor.apply(gl, noneColor);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        // Overwrite the model matrix to be unrotated, unscaled, untranslated.
+        const modelMatrix = twgl.m4.identity();
+        twgl.m4.rotateZ(modelMatrix, Math.PI, modelMatrix);
+        twgl.m4.scale(modelMatrix, [width, height], modelMatrix);
+
+        const projection = twgl.m4.ortho(-0.5 * width, 0.5 * width, -0.5 * height, 0.5 * height, -1, 1);
+
+        this._drawThese([drawableID],
+            ShaderManager.DRAW_MODE.silhouette,
+            projection,
+            null,
+            {u_modelMatrix: modelMatrix}
+        );
+
+        const pixels = new Buffer(width * height * 4);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        // Known boundary points on left/right edges of pixels.
+        const boundaryPoints = [];
+
+        /**
+         * Helper method to look up a pixel.
+         * @param {int} x X coordinate of the pixel in `pixels`.
+         * @param {int} y Y coordinate of the pixel in `pixels`.
+         * @return {int} Known ID at that pixel, or Drawable.NONE.
+         */
+        const _getPixel = (x, y) => {
+            const pixelBase = ((width * y) + x) * 4;
+            return Drawable.color4bToID(
+                pixels[pixelBase],
+                pixels[pixelBase + 1],
+                pixels[pixelBase + 2],
+                pixels[pixelBase + 3]);
+        };
+        for (let y = 0; y <= height; y++) {
+            // Scan from left.
+            for (let x = 0; x < width; x++) {
+                if (_getPixel(x, y) > Drawable.NONE) {
+                    boundaryPoints.push([x, y]);
+                    break;
+                }
+            }
+            // Scan from right.
+            for (let x = width - 1; x >= 0; x--) {
+                if (_getPixel(x, y) > Drawable.NONE) {
+                    boundaryPoints.push([x, y]);
+                    break;
+                }
+            }
+        }
+        // Simplify boundary points using convex hull.
+        return hull(boundaryPoints, Infinity);
+    }
 }
 
 module.exports = RenderWebGL;
-
-/**
- * Maximum touch size for a picking check.
- * TODO: Figure out a reasonable max size. Maybe this should be configurable?
- * @type {int[]}
- */
-RenderWebGL.MAX_TOUCH_SIZE = [3, 3];
-
-/**
- * "touching {color}?" or "{color} touching {color}?" tests will be true if the
- * target is touching a color whose components are each within this tolerance of
- * the corresponding component of the query color.
- * @type {int} between 0 (exact matches only) and 255 (match anything).
- */
-RenderWebGL.TOLERANCE_TOUCHING_COLOR = 2;
-
-
-/* *******
-   * Functions called only locally: these are not available from a worker.
-   *********/
-
-/**
- * Set the physical size of the stage in device-independent pixels.
- * This will be multiplied by the device's pixel ratio on high-DPI displays.
- * @param {int} pixelsWide The desired width in device-independent pixels.
- * @param {int} pixelsTall The desired height in device-independent pixels.
- */
-RenderWebGL.prototype.resize = function (pixelsWide, pixelsTall) {
-    const pixelRatio = window.devicePixelRatio || 1;
-    this._gl.canvas.width = pixelsWide * pixelRatio;
-    this._gl.canvas.height = pixelsTall * pixelRatio;
-};
-
-/**
- * Set the background color for the stage. The stage will be cleared with this
- * color each frame.
- * @param {number} red The red component for the background.
- * @param {number} green The green component for the background.
- * @param {number} blue The blue component for the background.
- */
-RenderWebGL.prototype.setBackgroundColor = function (red, green, blue) {
-    this._backgroundColor = [red, green, blue, 1];
-};
-
-/**
- * Tell the renderer to draw various debug information to the provided canvas
- * during certain operations.
- * @param {canvas} canvas The canvas to use for debug output.
- */
-RenderWebGL.prototype.setDebugCanvas = function (canvas) {
-    this._debugCanvas = canvas;
-};
-
-/**
- * Set logical size of the stage in Scratch units.
- * @param {int} xLeft The left edge's x-coordinate. Scratch 2 uses -240.
- * @param {int} xRight The right edge's x-coordinate. Scratch 2 uses 240.
- * @param {int} yBottom The bottom edge's y-coordinate. Scratch 2 uses -180.
- * @param {int} yTop The top edge's y-coordinate. Scratch 2 uses 180.
- */
-RenderWebGL.prototype.setStageSize = function (xLeft, xRight, yBottom, yTop) {
-    this._xLeft = xLeft;
-    this._xRight = xRight;
-    this._yBottom = yBottom;
-    this._yTop = yTop;
-    this._nativeSize = [Math.abs(xRight - xLeft), Math.abs(yBottom - yTop)];
-    this._projection = twgl.m4.ortho(xLeft, xRight, yBottom, yTop, -1, 1);
-};
-
-
-/**
- * Create a new Drawable and add it to the scene.
- * @returns {int} The ID of the new Drawable.
- */
-RenderWebGL.prototype.createDrawable = function () {
-    const drawable = new Drawable(this._gl);
-    const drawableID = drawable.getID();
-    this._drawables.push(drawableID);
-    return drawableID;
-};
-
-/**
- * Destroy a Drawable, removing it from the scene.
- * @param {int} drawableID The ID of the Drawable to remove.
- * @returns {boolean} True iff the drawable was found and removed.
- */
-RenderWebGL.prototype.destroyDrawable = function (drawableID) {
-    const index = this._drawables.indexOf(drawableID);
-    if (index >= 0) {
-        Drawable.getDrawableByID(drawableID).dispose();
-        this._drawables.splice(index, 1);
-        return true;
-    }
-    return false;
-};
-
-/**
- * Set a drawable's order in the drawable list (effectively, z/layer).
- * Can be used to move drawables to absolute positions in the list,
- * or relative to their current positions.
- * "go back N layers": setDrawableOrder(id, -N, true, 1); (assuming stage at 0).
- * "go to back": setDrawableOrder(id, 1); (assuming stage at 0).
- * "go to front": setDrawableOrder(id, Infinity);
- * @param {int} drawableID ID of Drawable to reorder.
- * @param {number} order New absolute order or relative order adjusment.
- * @param {boolean=} optIsRelative If set, `order` refers to a relative change.
- * @param {number=} optMin If set, order constrained to be at least `optMin`.
- * @return {?number} New order if changed, or null.
- */
-RenderWebGL.prototype.setDrawableOrder = function (
-    drawableID, order, optIsRelative, optMin) {
-    const oldIndex = this._drawables.indexOf(drawableID);
-    if (oldIndex >= 0) {
-        // Remove drawable from the list.
-        const drawable = this._drawables.splice(oldIndex, 1)[0];
-        // Determine new index.
-        let newIndex = order;
-        if (optIsRelative) {
-            newIndex += oldIndex;
-        }
-        if (optMin) {
-            newIndex = Math.max(newIndex, optMin);
-        }
-        newIndex = Math.max(newIndex, 0);
-        // Insert at new index.
-        this._drawables.splice(newIndex, 0, drawable);
-        return this._drawables.indexOf(drawable);
-    }
-    return null;
-};
-
-/**
- * Draw all current drawables and present the frame on the canvas.
- */
-RenderWebGL.prototype.draw = function () {
-    const gl = this._gl;
-
-    twgl.bindFramebufferInfo(gl, null);
-    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
-    gl.clearColor.apply(gl, this._backgroundColor);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    this._drawThese(
-        this._drawables, ShaderManager.DRAW_MODE.default, this._projection);
-};
-
-
-/**
- * Get the precise bounds for a Drawable.
- * @param {int} drawableID ID of Drawable to get bounds for.
- * @return {object} Bounds for a tight box around the Drawable.
- */
-RenderWebGL.prototype.getBounds = function (drawableID) {
-    const drawable = Drawable.getDrawableByID(drawableID);
-    // Tell the Drawable about its updated convex hull, if necessary.
-    if (drawable.needsConvexHullPoints()) {
-        const points = this._getConvexHullPointsForDrawable(drawableID);
-        drawable.setConvexHullPoints(points);
-    }
-    const bounds = drawable.getBounds();
-    // In debug mode, draw the bounds.
-    if (this._debugCanvas) {
-        const gl = this._gl;
-        this._debugCanvas.width = gl.canvas.width;
-        this._debugCanvas.height = gl.canvas.height;
-        const context = this._debugCanvas.getContext('2d');
-        context.drawImage(gl.canvas, 0, 0);
-        context.strokeStyle = '#FF0000';
-        const pr = window.devicePixelRatio;
-        context.strokeRect(
-            pr * (bounds.left + (this._nativeSize[0] / 2)),
-            pr * (-bounds.top + (this._nativeSize[1] / 2)),
-            pr * (bounds.right - bounds.left),
-            pr * (-bounds.bottom + bounds.top)
-        );
-    }
-    return bounds;
-};
-
-/**
- * Get the current skin (costume) size of a Drawable.
- * @param {int} drawableID The ID of the Drawable to measure.
- * @return {Array.<number>} Skin size, width and height.
- */
-RenderWebGL.prototype.getSkinSize = function (drawableID) {
-    const drawable = Drawable.getDrawableByID(drawableID);
-    return drawable.getSkinSize();
-};
-
-/**
- * Check if a particular Drawable is touching a particular color.
- * @param {int} drawableID The ID of the Drawable to check.
- * @param {int[]} color3b Test if the Drawable is touching this color.
- * @param {int[]} [mask3b] Optionally mask the check to this part of Drawable.
- * @returns {boolean} True iff the Drawable is touching the color.
- */
-RenderWebGL.prototype.isTouchingColor = function (drawableID, color3b, mask3b) {
-    const gl = this._gl;
-    twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
-
-    const bounds = this._touchingBounds(drawableID);
-    if (!bounds) {
-        return;
-    }
-    const candidateIDs = this._filterCandidatesTouching(
-        drawableID, this._drawables, bounds);
-    if (!candidateIDs) {
-        return;
-    }
-
-
-    // Limit size of viewport to the bounds around the target Drawable,
-    // and create the projection matrix for the draw.
-    gl.viewport(0, 0, bounds.width, bounds.height);
-    const projection = twgl.m4.ortho(
-        bounds.left, bounds.right, bounds.bottom, bounds.top, -1, 1);
-
-    gl.clearColor.apply(gl, this._backgroundColor);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-
-    let extraUniforms;
-    if (mask3b) {
-        extraUniforms = {
-            u_colorMask: [mask3b[0] / 255, mask3b[1] / 255, mask3b[2] / 255],
-            u_colorMaskTolerance: RenderWebGL.TOLERANCE_TOUCHING_COLOR / 255
-        };
-    }
-
-    try {
-        gl.enable(gl.STENCIL_TEST);
-        gl.stencilFunc(gl.ALWAYS, 1, 1);
-        gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
-        gl.colorMask(false, false, false, false);
-        this._drawThese(
-            [drawableID],
-            mask3b ?
-                ShaderManager.DRAW_MODE.colorMask :
-                ShaderManager.DRAW_MODE.silhouette,
-            projection,
-            null,
-            extraUniforms);
-
-        gl.stencilFunc(gl.EQUAL, 1, 1);
-        gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-        gl.colorMask(true, true, true, true);
-
-        this._drawThese(
-            candidateIDs, ShaderManager.DRAW_MODE.default, projection,
-            testID => testID !== drawableID
-        );
-    } finally {
-        gl.colorMask(true, true, true, true);
-        gl.disable(gl.STENCIL_TEST);
-    }
-
-    const pixels = new Buffer(bounds.width * bounds.height * 4);
-    gl.readPixels(
-        0, 0, bounds.width, bounds.height,
-        gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-    if (this._debugCanvas) {
-        this._debugCanvas.width = bounds.width;
-        this._debugCanvas.height = bounds.height;
-        const context = this._debugCanvas.getContext('2d');
-        const imageData = context.getImageData(
-            0, 0, bounds.width, bounds.height);
-        for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
-            imageData.data[i] = pixels[i];
-        }
-        context.putImageData(imageData, 0, 0);
-    }
-
-    for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-        const pixelDistanceR = Math.abs(pixels[pixelBase] - color3b[0]);
-        const pixelDistanceG = Math.abs(pixels[pixelBase + 1] - color3b[1]);
-        const pixelDistanceB = Math.abs(pixels[pixelBase + 2] - color3b[2]);
-
-        if (pixelDistanceR <= RenderWebGL.TOLERANCE_TOUCHING_COLOR &&
-            pixelDistanceG <= RenderWebGL.TOLERANCE_TOUCHING_COLOR &&
-            pixelDistanceB <= RenderWebGL.TOLERANCE_TOUCHING_COLOR) {
-            return true;
-        }
-    }
-
-    return false;
-};
-
-/**
- * Check if a particular Drawable is touching any in a set of Drawables.
- * @param {int} drawableID The ID of the Drawable to check.
- * @param {int[]} candidateIDs The Drawable IDs to check, otherwise all.
- * @returns {boolean} True iff the Drawable is touching one of candidateIDs.
- */
-RenderWebGL.prototype.isTouchingDrawables = function (drawableID, candidateIDs) {
-    candidateIDs = candidateIDs || this._drawables;
-
-    const gl = this._gl;
-
-    twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
-
-    const bounds = this._touchingBounds(drawableID);
-    if (!bounds) {
-        return;
-    }
-    candidateIDs = this._filterCandidatesTouching(
-        drawableID, candidateIDs, bounds);
-    if (!candidateIDs) {
-        return;
-    }
-
-    // Limit size of viewport to the bounds around the target Drawable,
-    // and create the projection matrix for the draw.
-    gl.viewport(0, 0, bounds.width, bounds.height);
-    const projection = twgl.m4.ortho(
-        bounds.left, bounds.right, bounds.bottom, bounds.top, -1, 1);
-
-    const noneColor = Drawable.color4fFromID(Drawable.NONE);
-    gl.clearColor.apply(gl, noneColor);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-
-    try {
-        gl.enable(gl.STENCIL_TEST);
-        gl.stencilFunc(gl.ALWAYS, 1, 1);
-        gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
-        gl.colorMask(false, false, false, false);
-        this._drawThese(
-            [drawableID], ShaderManager.DRAW_MODE.silhouette, projection
-        );
-
-        gl.stencilFunc(gl.EQUAL, 1, 1);
-        gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-        gl.colorMask(true, true, true, true);
-
-        this._drawThese(
-            candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection,
-            testID => testID !== drawableID
-        );
-    } finally {
-        gl.colorMask(true, true, true, true);
-        gl.disable(gl.STENCIL_TEST);
-    }
-
-    const pixels = new Buffer(bounds.width * bounds.height * 4);
-    gl.readPixels(
-        0, 0, bounds.width, bounds.height,
-        gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-    if (this._debugCanvas) {
-        this._debugCanvas.width = bounds.width;
-        this._debugCanvas.height = bounds.height;
-        const context = this._debugCanvas.getContext('2d');
-        const imageData = context.getImageData(
-            0, 0, bounds.width, bounds.height);
-        for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
-            imageData.data[i] = pixels[i];
-        }
-        context.putImageData(imageData, 0, 0);
-    }
-
-    for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-        const pixelID = Drawable.color4bToID(
-            pixels[pixelBase],
-            pixels[pixelBase + 1],
-            pixels[pixelBase + 2],
-            pixels[pixelBase + 3]);
-        if (pixelID > Drawable.NONE) {
-            return true;
-        }
-    }
-
-    return false;
-};
-
-/**
- * Detect which sprite, if any, is at the given location.
- * @param {int} centerX The client x coordinate of the picking location.
- * @param {int} centerY The client y coordinate of the picking location.
- * @param {int} touchWidth The client width of the touch event (optional).
- * @param {int} touchHeight The client height of the touch event (optional).
- * @param {int[]} candidateIDs The Drawable IDs to pick from, otherwise all.
- * @returns {int} The ID of the topmost Drawable under the picking location, or
- * Drawable.NONE if there is no Drawable at that location.
- */
-RenderWebGL.prototype.pick = function (
-    centerX, centerY, touchWidth, touchHeight, candidateIDs) {
-    const gl = this._gl;
-
-    touchWidth = touchWidth || 1;
-    touchHeight = touchHeight || 1;
-    candidateIDs = candidateIDs || this._drawables;
-
-    const clientToGLX = gl.canvas.width / gl.canvas.clientWidth;
-    const clientToGLY = gl.canvas.height / gl.canvas.clientHeight;
-
-    centerX *= clientToGLX;
-    centerY *= clientToGLY;
-    touchWidth *= clientToGLX;
-    touchHeight *= clientToGLY;
-
-    touchWidth =
-        Math.max(1, Math.min(touchWidth, RenderWebGL.MAX_TOUCH_SIZE[0]));
-    touchHeight =
-        Math.max(1, Math.min(touchHeight, RenderWebGL.MAX_TOUCH_SIZE[1]));
-
-    const pixelLeft = Math.floor(centerX - Math.floor(touchWidth / 2) + 0.5);
-    const pixelRight = Math.floor(centerX + Math.ceil(touchWidth / 2) + 0.5);
-    const pixelTop = Math.floor(centerY - Math.floor(touchHeight / 2) + 0.5);
-    const pixelBottom = Math.floor(centerY + Math.ceil(touchHeight / 2) + 0.5);
-
-    twgl.bindFramebufferInfo(gl, this._pickBufferInfo);
-    gl.viewport(0, 0, touchWidth, touchHeight);
-
-    const noneColor = Drawable.color4fFromID(Drawable.NONE);
-    gl.clearColor.apply(gl, noneColor);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    const widthPerPixel = (this._xRight - this._xLeft) / this._gl.canvas.width;
-    const heightPerPixel = (this._yBottom - this._yTop) / this._gl.canvas.height;
-
-    const pickLeft = this._xLeft + (pixelLeft * widthPerPixel);
-    const pickRight = this._xLeft + (pixelRight * widthPerPixel);
-    const pickTop = this._yTop + (pixelTop * heightPerPixel);
-    const pickBottom = this._yTop + (pixelBottom * heightPerPixel);
-
-    const projection = twgl.m4.ortho(
-        pickLeft, pickRight, pickTop, pickBottom, -1, 1);
-
-    this._drawThese(
-        candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection);
-
-    const pixels = new Buffer(touchWidth * touchHeight * 4);
-    gl.readPixels(
-        0, 0, touchWidth, touchHeight, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-    if (this._debugCanvas) {
-        this._debugCanvas.width = touchWidth;
-        this._debugCanvas.height = touchHeight;
-        const context = this._debugCanvas.getContext('2d');
-        const imageData = context.getImageData(0, 0, touchWidth, touchHeight);
-        for (let i = 0, bytes = pixels.length; i < bytes; ++i) {
-            imageData.data[i] = pixels[i];
-        }
-        context.putImageData(imageData, 0, 0);
-    }
-
-    const hits = {};
-    for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-        const pixelID = Drawable.color4bToID(
-            pixels[pixelBase],
-            pixels[pixelBase + 1],
-            pixels[pixelBase + 2],
-            pixels[pixelBase + 3]);
-        hits[pixelID] = (hits[pixelID] || 0) + 1;
-    }
-
-    // Bias toward selecting anything over nothing
-    hits[Drawable.NONE] = 0;
-
-    let hit = Drawable.NONE;
-    for (const hitID in hits) {
-        if (hits.hasOwnProperty(hitID) && (hits[hitID] > hits[hit])) {
-            hit = hitID;
-        }
-    }
-
-    return hit | 0;
-};
-
-/**
- * Get the candidate bounding box for a touching query.
- * @param {int} drawableID ID for drawable of query.
- * @return {?Rectangle} Rectangle bounds for touching query, or null.
- */
-RenderWebGL.prototype._touchingBounds = function (drawableID) {
-    const drawable = Drawable.getDrawableByID(drawableID);
-    const bounds = drawable.getFastBounds();
-
-    // Limit queries to the stage size.
-    bounds.clamp(this._xLeft, this._xRight, this._yBottom, this._yTop);
-
-    // Use integer coordinates for queries - weird things happen
-    // when you provide float width/heights to gl.viewport and projection.
-    bounds.snapToInt();
-
-    if (bounds.width === 0 || bounds.height === 0) {
-        // No space to query.
-        return null;
-    }
-    return bounds;
-};
-
-/**
- * Filter a list of candidates for a touching query into only those that
- * could possibly intersect the given bounds.
- * @param {int} drawableID - ID for drawable of query.
- * @param {Array.<int>} candidateIDs - Candidates for touching query.
- * @param {Rectangle} bounds - Bounds to limit candidates to.
- * @return {?Array.<int>} Filtered candidateIDs, or null if none.
- */
-RenderWebGL.prototype._filterCandidatesTouching = function (
-    drawableID, candidateIDs, bounds) {
-    // Filter candidates by rough bounding box intersection.
-    // Do this before _drawThese, so we can prevent any GL operations
-    // and readback by returning early.
-    candidateIDs = candidateIDs.filter(testID => {
-        if (testID === drawableID) return false;
-        // Only draw items which could possibly overlap target Drawable.
-        const candidate = Drawable.getDrawableByID(testID);
-        const candidateBounds = candidate.getFastBounds();
-        return bounds.intersects(candidateBounds);
-    });
-    if (candidateIDs.length === 0) {
-        // No possible intersections based on bounding boxes.
-        return null;
-    }
-    return candidateIDs;
-};
-
-/**
-* Update the position, direction, scale, or effect properties of this Drawable.
-* @param {int} drawableID The ID of the Drawable to update.
-* @param {object.<string,*>} properties The new property values to set.
- */
-RenderWebGL.prototype.updateDrawableProperties = function (
-        drawableID, properties) {
-    const drawable = Drawable.getDrawableByID(drawableID);
-    drawable.updateProperties(properties);
-};
-
-/* ********
-   * Truly internal functions: these support the functions above.
-   ********/
-
-/**
- * Build geometry (vertex and index) buffers.
- * @private
- */
-RenderWebGL.prototype._createGeometry = function () {
-    const quad = {
-        a_position: {
-            numComponents: 2,
-            data: [
-                -0.5, -0.5,
-                0.5, -0.5,
-                -0.5, 0.5,
-                -0.5, 0.5,
-                0.5, -0.5,
-                0.5, 0.5
-            ]
-        },
-        a_texCoord: {
-            numComponents: 2,
-            data: [
-                1, 0,
-                0, 0,
-                1, 1,
-                1, 1,
-                0, 0,
-                0, 1
-            ]
-        }
-    };
-    this._bufferInfo = twgl.createBufferInfoFromArrays(this._gl, quad);
-};
-
-/**
- * Create the frame buffers used for queries such as picking and color-touching.
- * These buffers are fixed in size regardless of the size of the main render
- * target. The fixed size allows (more) consistent behavior across devices and
- * presentation modes.
- * @private
- */
-RenderWebGL.prototype._createQueryBuffers = function () {
-    const gl = this._gl;
-    const attachments = [
-        {format: gl.RGBA},
-        {format: gl.DEPTH_STENCIL}
-    ];
-
-    this._pickBufferInfo = twgl.createFramebufferInfo(
-        gl, attachments,
-        RenderWebGL.MAX_TOUCH_SIZE[0], RenderWebGL.MAX_TOUCH_SIZE[1]);
-
-    // TODO: should we create this on demand to save memory?
-    // A 480x360 32-bpp buffer is 675 KiB.
-    this._queryBufferInfo = twgl.createFramebufferInfo(
-        gl, attachments, this._nativeSize[0], this._nativeSize[1]);
-};
-
-/**
- * Draw all Drawables, with the possible exception of
- * @param {int[]} drawables The Drawable IDs to draw, possibly this._drawables.
- * @param {ShaderManager.DRAW_MODE} drawMode Draw normally, silhouette, etc.
- * @param {module:twgl/m4.Mat4} projection The projection matrix to use.
- * @param {Drawable~idFilterFunc} [filter] An optional filter function.
- * @param {Object.<string,*>} [extraUniforms] Extra uniforms for the shaders.
- * @private
- */
-RenderWebGL.prototype._drawThese = function (
-    drawables, drawMode, projection, filter, extraUniforms) {
-
-    const gl = this._gl;
-    let currentShader = null;
-
-    const numDrawables = drawables.length;
-    for (let drawableIndex = 0; drawableIndex < numDrawables; ++drawableIndex) {
-        const drawableID = drawables[drawableIndex];
-
-        // If we have a filter, check whether the ID fails
-        if (filter && !filter(drawableID)) continue;
-
-        const drawable = Drawable.getDrawableByID(drawableID);
-        // TODO: check if drawable is inside the viewport before anything else
-
-        // Hidden drawables (e.g., by a "hide" block) are never drawn.
-        if (!drawable.getVisible()) continue;
-
-        const effectBits = drawable.getEnabledEffects();
-        const newShader = this._shaderManager.getShader(drawMode, effectBits);
-        if (currentShader !== newShader) {
-            currentShader = newShader;
-            gl.useProgram(currentShader.program);
-            twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
-            twgl.setUniforms(currentShader, {u_projectionMatrix: projection});
-            twgl.setUniforms(currentShader, {u_fudge: window.fudge || 0});
-        }
-
-        twgl.setUniforms(currentShader, drawable.getUniforms());
-
-        // Apply extra uniforms after the Drawable's, to allow overwriting.
-        if (extraUniforms) {
-            twgl.setUniforms(currentShader, extraUniforms);
-        }
-
-        twgl.drawBufferInfo(gl, gl.TRIANGLES, this._bufferInfo);
-    }
-};
-
-/**
- * Get the convex hull points for a particular Drawable.
- * To do this, draw the Drawable unrotated, unscaled, and untranslated.
- * Read back the pixels and find all boundary points.
- * Finally, apply a convex hull algorithm to simplify the set.
- * @param {int} drawableID The Drawable IDs calculate convex hull for.
- * @return {Array.<Array.<number>>} points Convex hull points, as [[x, y], ...]
- */
-RenderWebGL.prototype._getConvexHullPointsForDrawable = function (drawableID) {
-    const drawable = Drawable.getDrawableByID(drawableID);
-    const [width, height] = drawable._uniforms.u_skinSize;
-    // No points in the hull if invisible or size is 0.
-    if (!drawable.getVisible() || width === 0 || height === 0) {
-        return [];
-    }
-
-    // Only draw to the size of the untransformed drawable.
-    const gl = this._gl;
-    twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
-    gl.viewport(0, 0, width, height);
-
-    // Clear the canvas with Drawable.NONE.
-    const noneColor = Drawable.color4fFromID(Drawable.NONE);
-    gl.clearColor.apply(gl, noneColor);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    // Overwrite the model matrix to be unrotated, unscaled, untranslated.
-    const modelMatrix = twgl.m4.identity();
-    twgl.m4.rotateZ(modelMatrix, Math.PI, modelMatrix);
-    twgl.m4.scale(modelMatrix, [width, height], modelMatrix);
-
-    const projection = twgl.m4.ortho(
-        -0.5 * width, 0.5 * width,
-        -0.5 * height, 0.5 * height,
-        -1, 1
-    );
-
-    this._drawThese([drawableID],
-        ShaderManager.DRAW_MODE.silhouette,
-        projection,
-        null,
-        {u_modelMatrix: modelMatrix}
-    );
-
-    const pixels = new Buffer(width * height * 4);
-    gl.readPixels(
-        0, 0, width, height,
-        gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-    // Known boundary points on left/right edges of pixels.
-    const boundaryPoints = [];
-
-    /**
-     * Helper method to look up a pixel.
-     * @param {int} x X coordinate of the pixel in `pixels`.
-     * @param {int} y Y coordinate of the pixel in `pixels`.
-     * @return {int} Known ID at that pixel, or Drawable.NONE.
-     */
-    const _getPixel = function (x, y) {
-        const pixelBase = ((width * y) + x) * 4;
-        return Drawable.color4bToID(
-            pixels[pixelBase],
-            pixels[pixelBase + 1],
-            pixels[pixelBase + 2],
-            pixels[pixelBase + 3]);
-    };
-    for (let y = 0; y <= height; y++) {
-        // Scan from left.
-        for (let x = 0; x < width; x++) {
-            if (_getPixel(x, y) > Drawable.NONE) {
-                boundaryPoints.push([x, y]);
-                break;
-            }
-        }
-        // Scan from right.
-        for (let x = width - 1; x >= 0; x--) {
-            if (_getPixel(x, y) > Drawable.NONE) {
-                boundaryPoints.push([x, y]);
-                break;
-            }
-        }
-    }
-    // Simplify boundary points using convex hull.
-    return hull(boundaryPoints, Infinity);
-};

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -379,7 +379,7 @@ class RenderWebGL {
         }
 
         for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-            const pixelID = Drawable.color4bToID(
+            const pixelID = Drawable.color3bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
                 pixels[pixelBase + 2]);
@@ -459,7 +459,7 @@ class RenderWebGL {
 
         const hits = {};
         for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-            const pixelID = Drawable.color4bToID(
+            const pixelID = Drawable.color3bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
                 pixels[pixelBase + 2]);
@@ -696,7 +696,7 @@ class RenderWebGL {
          */
         const _getPixel = (x, y) => {
             const pixelBase = ((width * y) + x) * 4;
-            return Drawable.color4bToID(
+            return Drawable.color3bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
                 pixels[pixelBase + 2]);


### PR DESCRIPTION
Also:
- Un-wrap lines which were originally written for an 80-column limit but don't need to wrap now that the limit is 120 columns.
- Get rid of `instance` variables that were being used to save `this` for callbacks now that those callbacks have been converted from `function` to `=>`.

In some ways this is a followup to #64, but these changes aren't specifically related to Webpack or lint config changes.

I highly recommend looking at this with white-space differences ignored. To do so, add "?w=1" (or "&w=1" if there's already a "?") to the end of the URL when on the "Files changed" view.