### PR TITLE
Move `Skin` functionality out of `Drawable` into its own classes

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -11,6 +11,9 @@ class BitmapSkin extends Skin {
     constructor (id, renderer) {
         super(id);
 
+        /** @type {!int} */
+        this._costumeResolution = 1;
+
         /** @type {!RenderWebGL} */
         this._renderer = renderer;
 
@@ -21,6 +24,9 @@ class BitmapSkin extends Skin {
         this._textureSize = [0, 0];
     }
 
+    /**
+     * Dispose of this object. Do not use it after calling this method.
+     */
     dispose () {
         if (this._texture) {
             this._renderer.gl.deleteTexture(this._texture);
@@ -38,7 +44,7 @@ class BitmapSkin extends Skin {
 
     /**
      * @param {[number,number]} scale - The scaling factors to be used.
-     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given size.
+     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given scale.
      */
     // eslint-disable-next-line no-unused-vars
     getTexture (scale) {
@@ -52,9 +58,6 @@ class BitmapSkin extends Skin {
      */
     setBitmap (bitmapData, costumeResolution) {
         const gl = this._renderer.gl;
-
-        /** @type {!int} */
-        this._costumeResolution = costumeResolution || 1;
 
         if (this._texture) {
             gl.bindTexture(gl.TEXTURE_2D, this._texture);
@@ -71,7 +74,8 @@ class BitmapSkin extends Skin {
             this._texture = twgl.createTexture(gl, textureOptions);
         }
 
-        // Do this last in case any of the above throws an exception
+        // Do these last in case any of the above throws an exception
+        this._costumeResolution = costumeResolution || 1;
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
     }
 

--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -1,0 +1,97 @@
+const twgl = require('twgl.js');
+
+const Skin = require('./Skin');
+
+class BitmapSkin extends Skin {
+    /**
+     * Create a new Bitmap Skin.
+     * @param {!int} id - The ID for this Skin.
+     * @param {!RenderWebGL} renderer - The renderer which will use this skin.
+     */
+    constructor (id, renderer) {
+        super(id);
+
+        /** @type {!RenderWebGL} */
+        this._renderer = renderer;
+
+        /** @type {WebGLTexture} */
+        this._texture = null;
+
+        /** @type {[int, int]} */
+        this._textureSize = [0, 0];
+    }
+
+    dispose () {
+        if (this._texture) {
+            this._renderer.gl.deleteTexture(this._texture);
+            this._texture = null;
+        }
+        super.dispose();
+    }
+
+    /**
+     * @return {[number,number]} the "native" size, in texels, of this skin.
+     */
+    get size () {
+        return [this._textureSize[0] / this._costumeResolution, this._textureSize[1] / this._costumeResolution];
+    }
+
+    /**
+     * @param {[number,number]} scale - The scaling factors to be used.
+     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given size.
+     */
+    // eslint-disable-next-line no-unused-vars
+    getTexture (scale) {
+        return this._texture;
+    }
+
+    /**
+     * Set the contents of this skin to a snapshot of the provided bitmap data.
+     * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} bitmapData - new contents for this skin.
+     * @param {int} [costumeResolution=1] - The resolution to use for this bitmap.
+     */
+    setBitmap (bitmapData, costumeResolution) {
+        const gl = this._renderer.gl;
+
+        /** @type {!int} */
+        this._costumeResolution = costumeResolution || 1;
+
+        if (this._texture) {
+            gl.bindTexture(gl.TEXTURE_2D, this._texture);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmapData);
+        } else {
+            const textureOptions = {
+                auto: true,
+                mag: gl.NEAREST,
+                min: gl.NEAREST, // TODO: mipmaps, linear (except pixelate)
+                wrap: gl.CLAMP_TO_EDGE,
+                src: bitmapData
+            };
+
+            this._texture = twgl.createTexture(gl, textureOptions);
+        }
+
+        // Do this last in case any of the above throws an exception
+        this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
+    }
+
+    /**
+     * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} bitmapData - bitmap data to inspect.
+     * @returns {[int,int]} the width and height of the bitmap data, in pixels.
+     * @private
+     */
+    static _getBitmapSize (bitmapData) {
+        if (bitmapData instanceof HTMLImageElement) {
+            return [bitmapData.naturalWidth || bitmapData.width, bitmapData.naturalHeight || bitmapData.height];
+        }
+
+        if (bitmapData instanceof HTMLVideoElement) {
+            return [bitmapData.videoWidth || bitmapData.width, bitmapData.videoHeight || bitmapData.height];
+        }
+
+        // ImageData or HTMLCanvasElement
+        return [bitmapData.width, bitmapData.height];
+    }
+}
+
+module.exports = BitmapSkin;

--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -77,6 +77,8 @@ class BitmapSkin extends Skin {
         // Do these last in case any of the above throws an exception
         this._costumeResolution = costumeResolution || 1;
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
+
+        this.emit(Skin.Events.WasAltered);
     }
 
     /**

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -69,9 +69,8 @@ class Drawable {
      * Dispose of this Drawable. Do not use it after calling this method.
      */
     dispose () {
-        if (this._id >= 0) {
-            delete Drawable[this._id];
-        }
+        // Use the setter: disconnect events
+        this.skin = null;
     }
 
     /**

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -2,6 +2,7 @@ const twgl = require('twgl.js');
 const xhr = require('xhr');
 
 const Rectangle = require('./Rectangle');
+const RenderConstants = require('./RenderConstants');
 const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
 const ShaderManager = require('./ShaderManager');
 
@@ -84,14 +85,6 @@ class Drawable {
 
         // Load a real skin
         this.setSkin(Drawable._DEFAULT_SKIN);
-    }
-
-    /**
-     * An invalid Drawable ID which can be used to signify absence, etc.
-     * @type {int}
-     */
-    static get NONE () {
-        return -1;
     }
 
     /**
@@ -496,12 +489,12 @@ class Drawable {
 
     /**
      * Calculate a color to represent the given ID number. At least one component of
-     * the resulting color will be non-zero if the ID is not Drawable.NONE.
+     * the resulting color will be non-zero if the ID is not RenderConstants.ID_NONE.
      * @param {int} id The ID to convert.
      * @returns {number[]} An array of [r,g,b,a], each component in the range [0,1].
      */
     static color4fFromID (id) {
-        id -= Drawable.NONE;
+        id -= RenderConstants.ID_NONE;
         const r = ((id >> 0) & 255) / 255.0;
         const g = ((id >> 8) & 255) / 255.0;
         const b = ((id >> 16) & 255) / 255.0;
@@ -510,7 +503,7 @@ class Drawable {
 
     /**
      * Calculate the ID number represented by the given color. If all components of
-     * the color are zero, the result will be Drawable.NONE; otherwise the result
+     * the color are zero, the result will be RenderConstants.ID_NONE; otherwise the result
      * will be a valid ID.
      * @param {int} r The red value of the color, in the range [0,255].
      * @param {int} g The green value of the color, in the range [0,255].
@@ -522,7 +515,7 @@ class Drawable {
         id = (r & 255) << 0;
         id |= (g & 255) << 8;
         id |= (b & 255) << 16;
-        return id + Drawable.NONE;
+        return id + RenderConstants.ID_NONE;
     }
 }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -15,15 +15,12 @@ class Drawable {
     /**
      * An object which can be drawn by the renderer.
      * TODO: double-buffer all rendering state (position, skin, effects, etc.)
-     * @param {WebGLRenderingContext} gl The OpenGL context.
+     * @param {!int} id - This Drawable's unique ID.
      * @constructor
      */
-    constructor (gl) {
-        this._id = Drawable._nextDrawable++;
-        Drawable._allDrawables[this._id] = this;
-
-        /** @type {WebGLRenderingContext} */
-        this._gl = gl;
+    constructor (id) {
+        /** @type {!int} */
+        this._id = id;
 
         /**
          * The uniforms to be used by the vertex and pixel shaders.
@@ -60,17 +57,9 @@ class Drawable {
         this._visible = true;
         this._effectBits = 0;
 
+        // TODO: move convex hull functionality, maybe bounds functionality overall, to Skin classes
         this._convexHullPoints = null;
         this._convexHullDirty = true;
-    }
-
-    /**
-     * Fetch a Drawable by its ID number.
-     * @param {int} drawableID The ID of the Drawable to fetch.
-     * @returns {?Drawable} The specified Drawable if found, otherwise null.
-     */
-    static getDrawableByID (drawableID) {
-        return Drawable._allDrawables[drawableID];
     }
 
     /**
@@ -91,10 +80,9 @@ class Drawable {
     }
 
     /**
-     * Retrieve the ID for this Drawable.
      * @returns {number} The ID for this Drawable.
      */
-    getID () {
+    get id () {
         return this._id;
     }
 
@@ -212,10 +200,7 @@ class Drawable {
         twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
 
         // Adjust rotation center relative to the skin.
-        const rotationAdjusted = twgl.v3.subtract(
-            this.skin.rotationCenter,
-            twgl.v3.divScalar(this.skin.size, 2)
-        );
+        const rotationAdjusted = twgl.v3.subtract(this.skin.rotationCenter, twgl.v3.divScalar(this.skin.size, 2));
         rotationAdjusted[1] *= -1; // Y flipped to Scratch coordinate.
         rotationAdjusted[2] = 0; // Z coordinate is 0.
 
@@ -358,19 +343,5 @@ class Drawable {
         return id + RenderConstants.ID_NONE;
     }
 }
-
-/**
- * The ID to be assigned next time the Drawable constructor is called.
- * @type {number}
- * @private
- */
-Drawable._nextDrawable = 0;
-
-/**
- * All current Drawables, by ID.
- * @type {Object.<int, Drawable>}
- * @private
- */
-Drawable._allDrawables = {};
 
 module.exports = Drawable;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -1,9 +1,7 @@
 const twgl = require('twgl.js');
-const xhr = require('xhr');
 
 const Rectangle = require('./Rectangle');
 const RenderConstants = require('./RenderConstants');
-const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
 const ShaderManager = require('./ShaderManager');
 
 /**
@@ -41,19 +39,6 @@ class Drawable {
             u_modelMatrix: twgl.m4.identity(),
 
             /**
-             * The nominal (not necessarily current) size of the current skin.
-             * This is scaled by _costumeResolution.
-             * @type {number[]}
-             */
-            u_skinSize: [0, 0],
-
-            /**
-             * The actual WebGL texture object for the skin.
-             * @type {WebGLTexture}
-             */
-            u_skin: null,
-
-            /**
              * The color to use in the silhouette draw mode.
              * @type {number[]}
              */
@@ -70,7 +55,6 @@ class Drawable {
 
         this._position = twgl.v3.create(0, 0);
         this._scale = twgl.v3.create(100, 100);
-        this._rotationCenter = twgl.v3.create(0, 0);
         this._direction = 90;
         this._transformDirty = true;
         this._visible = true;
@@ -78,13 +62,6 @@ class Drawable {
 
         this._convexHullPoints = null;
         this._convexHullDirty = true;
-
-        // Create a transparent 1x1 texture for temporary use
-        const tempTexture = twgl.createTexture(gl, {src: [0, 0, 0, 0]});
-        this._useSkin(tempTexture, 0, 0, 1, true);
-
-        // Load a real skin
-        this.setSkin(Drawable._DEFAULT_SKIN);
     }
 
     /**
@@ -100,7 +77,6 @@ class Drawable {
      * Dispose of this Drawable. Do not use it after calling this method.
      */
     dispose () {
-        this.setSkin(null);
         if (this._id >= 0) {
             delete Drawable[this._id];
         }
@@ -123,52 +99,28 @@ class Drawable {
     }
 
     /**
-     * Set this Drawable's skin.
-     * The Drawable will continue using the existing skin until the new one loads.
-     * If there is no existing skin, the Drawable will use a 1x1 transparent image.
-     * @param {string} skinUrl The URL of the skin.
-     * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
+     * @returns {Skin} the current skin for this Drawable.
      */
-    setSkin (skinUrl, optCostumeResolution) {
-        // TODO: cache Skins instead of loading each time. Ref count them?
-        // TODO: share Skins across Drawables - see also destroy()
-        if (skinUrl) {
-            const ext = skinUrl.substring(skinUrl.lastIndexOf('.') + 1);
-            switch (ext) {
-            case 'svg':
-            case 'svg/get/':
-            case 'svgz':
-            case 'svgz/get/':
-                this._setSkinSVG(skinUrl);
-                break;
-            default:
-                this._setSkinBitmap(skinUrl, optCostumeResolution);
-                break;
-            }
-        } else {
-            this._useSkin(null, 0, 0, 1, true);
+    get skin () {
+        return this._skin;
+    }
+
+    /**
+     * @param {Skin} newSkin - A new Skin for this Drawable.
+     */
+    set skin (newSkin) {
+        if (this._skin !== newSkin) {
+            this._skin = newSkin;
+            this.setConvexHullDirty();
+            this.setTransformDirty();
         }
     }
 
     /**
-     * Use a skin if it is the currently-pending skin, or if skipPendingCheck==true.
-     * If the passed skin is used (for either reason) _pendingSkin will be cleared.
-     * @param {WebGLTexture} skin The skin to use.
-     * @param {int} width The width of the skin.
-     * @param {int} height The height of the skin.
-     * @param {int} costumeResolution The resolution to use for this skin.
-     * @param {boolean} [skipPendingCheck] If true, don't compare to _pendingSkin.
-     * @private
+     * @returns {[number,number]} the current scaling percentages applied to this Drawable. [100,100] is normal size.
      */
-    _useSkin (skin, width, height, costumeResolution, skipPendingCheck) {
-        if (skipPendingCheck || (skin === this._pendingSkin)) {
-            this._pendingSkin = null;
-            if (this._uniforms.u_skin && (this._uniforms.u_skin !== skin)) {
-                this._gl.deleteTexture(this._uniforms.u_skin);
-            }
-            this._setSkinSize(width, height, costumeResolution);
-            this._uniforms.u_skin = skin;
-        }
+    get scale () {
+        return [this._scale[0], this._scale[1]];
     }
 
     /**
@@ -176,79 +128,6 @@ class Drawable {
      */
     getEnabledEffects () {
         return this._effectBits;
-    }
-
-    /**
-     * Load a bitmap skin. Supports the same formats as the Image element.
-     * @param {string} skinMd5ext The MD5 and file extension of the bitmap skin.
-     * @param {number=} optCostumeResolution Optionally, a resolution for the skin.
-     * @private
-     */
-    _setSkinBitmap (skinMd5ext, optCostumeResolution) {
-        const url = skinMd5ext;
-        this._setSkinCore(url, optCostumeResolution);
-    }
-
-    /**
-     * Load an SVG-based skin. This still needs quite a bit of work to match the
-     * level of quality found in Scratch 2.0:
-     * - We should detect when a skin is being scaled up and render the SVG at a
-     *   higher resolution in those cases.
-     * - Colors seem a little off. This may be browser-specific.
-     * - This method works in Chrome, Firefox, Safari, and Edge but causes a
-     *   security error in IE.
-     * @param {string} skinMd5ext The MD5 and file extension of the SVG skin.
-     * @private
-     */
-    _setSkinSVG (skinMd5ext) {
-        const url = skinMd5ext;
-
-        const svgCanvas = document.createElement('canvas');
-        const svgRenderer = new SvgRenderer(svgCanvas);
-
-        const gotSVG = (err, response, body) => {
-            if (!err) {
-                svgRenderer.fromString(body, () => {
-                    this._setSkinCore(svgCanvas, svgRenderer.getDrawRatio());
-                });
-            }
-        };
-        xhr.get({
-            useXDR: true,
-            url: url
-        }, gotSVG);
-        // TODO: if there's no current u_skin, install *something* before returning
-    }
-
-    /**
-     * Common code for setting all skin types.
-     * @param {string|Image} source The source of image data for the skin.
-     * @param {int} costumeResolution The resolution to use for this skin.
-     * @private
-     */
-    _setSkinCore (source, costumeResolution) {
-        const callback = (err, texture, sourceInCallback) => {
-            if (!err && (this._pendingSkin === texture)) {
-                this._useSkin(texture, sourceInCallback.width, sourceInCallback.height, costumeResolution);
-            }
-        };
-
-        const gl = this._gl;
-        const options = {
-            auto: true,
-            mag: gl.NEAREST,
-            min: gl.NEAREST, // TODO: mipmaps, linear (except pixelate)
-            wrap: gl.CLAMP_TO_EDGE,
-            src: source
-        };
-        const willCallCallback = typeof source === 'string';
-        this._pendingSkin = twgl.createTexture(gl, options, willCallCallback ? callback : null);
-
-        // If we won't get a callback, start using the skin immediately.
-        // This will happen if the data is already local.
-        if (!willCallCallback) {
-            callback(null, this._pendingSkin, source);
-        }
     }
 
     /**
@@ -274,10 +153,6 @@ class Drawable {
      */
     updateProperties (properties) {
         let dirty = false;
-        if ('skin' in properties) {
-            this.setSkin(properties.skin, properties.costumeResolution);
-            this.setConvexHullDirty();
-        }
         if ('position' in properties && (
             this._position[0] !== properties.position[0] ||
             this._position[1] !== properties.position[1])) {
@@ -294,13 +169,6 @@ class Drawable {
             this._scale[1] !== properties.scale[1])) {
             this._scale[0] = properties.scale[0];
             this._scale[1] = properties.scale[1];
-            dirty = true;
-        }
-        if ('rotationCenter' in properties && (
-            this._rotationCenter[0] !== properties.rotationCenter[0] ||
-            this._rotationCenter[1] !== properties.rotationCenter[1])) {
-            this._rotationCenter[0] = properties.rotationCenter[0];
-            this._rotationCenter[1] = properties.rotationCenter[1];
             dirty = true;
         }
         if ('visible' in properties) {
@@ -331,33 +199,6 @@ class Drawable {
     }
 
     /**
-     * Set the dimensions of this Drawable's skin.
-     * @param {int} width The width of the new skin.
-     * @param {int} height The height of the new skin.
-     * @param {int} [costumeResolution] The resolution to use for this skin.
-     * @private
-     */
-    _setSkinSize (width, height, costumeResolution) {
-        costumeResolution = costumeResolution || 1;
-        width /= costumeResolution;
-        height /= costumeResolution;
-        if (this._uniforms.u_skinSize[0] !== width || this._uniforms.u_skinSize[1] !== height) {
-            this._uniforms.u_skinSize[0] = width;
-            this._uniforms.u_skinSize[1] = height;
-            this.setTransformDirty();
-        }
-        this.setConvexHullDirty();
-    }
-
-    /**
-     * Get the size of the Drawable's current skin.
-     * @return {Array.<number>} Skin size, width and height.
-     */
-    getSkinSize () {
-        return this._uniforms.u_skinSize.slice();
-    }
-
-    /**
      * Calculate the transform to use when rendering this Drawable.
      * @private
      */
@@ -370,18 +211,17 @@ class Drawable {
         const rotation = (270 - this._direction) * Math.PI / 180;
         twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
 
-
         // Adjust rotation center relative to the skin.
         const rotationAdjusted = twgl.v3.subtract(
-            this._rotationCenter,
-            twgl.v3.divScalar(this._uniforms.u_skinSize, 2)
+            this.skin.rotationCenter,
+            twgl.v3.divScalar(this.skin.size, 2)
         );
         rotationAdjusted[1] *= -1; // Y flipped to Scratch coordinate.
         rotationAdjusted[2] = 0; // Z coordinate is 0.
 
         twgl.m4.translate(modelMatrix, rotationAdjusted, modelMatrix);
 
-        const scaledSize = twgl.v3.divScalar(twgl.v3.multiply(this._uniforms.u_skinSize, this._scale), 100);
+        const scaledSize = twgl.v3.divScalar(twgl.v3.multiply(this.skin.size, this._scale), 100);
         scaledSize[2] = 0; // was NaN because the vectors have only 2 components.
         twgl.m4.scale(modelMatrix, scaledSize, modelMatrix);
 
@@ -431,7 +271,7 @@ class Drawable {
         // transform. This allows us to skip recalculating the convex hull
         // for many Drawable updates, including translation, rotation, scaling.
         const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
-        const skinSize = this._uniforms.u_skinSize;
+        const skinSize = this.skin.size;
         const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
         const transformedHullPoints = [];
         for (let i = 0; i < this._convexHullPoints.length; i++) {
@@ -532,13 +372,5 @@ Drawable._nextDrawable = 0;
  * @private
  */
 Drawable._allDrawables = {};
-
-// TODO: fall back on a built-in skin to protect against network problems
-Drawable._DEFAULT_SKIN = {
-    squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/',
-    bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/66895930177178ea01d9e610917f8acf.png/get/',
-    scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/09dc888b0b7df19f70d81588ae73420e.svg/get/',
-    gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/a49ff276b9b8f997a1ae163992c2c145.png/get/'
-}.squirrel;
 
 module.exports = Drawable;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -3,6 +3,7 @@ const twgl = require('twgl.js');
 const Rectangle = require('./Rectangle');
 const RenderConstants = require('./RenderConstants');
 const ShaderManager = require('./ShaderManager');
+const Skin = require('./Skin');
 
 /**
  * @callback Drawable~idFilterFunc
@@ -60,6 +61,8 @@ class Drawable {
         // TODO: move convex hull functionality, maybe bounds functionality overall, to Skin classes
         this._convexHullPoints = null;
         this._convexHullDirty = true;
+
+        this._skinWasAltered = this._skinWasAltered.bind(this);
     }
 
     /**
@@ -98,9 +101,14 @@ class Drawable {
      */
     set skin (newSkin) {
         if (this._skin !== newSkin) {
+            if (this._skin) {
+                this._skin.removeListener(Skin.Events.WasAltered, this._skinWasAltered);
+            }
             this._skin = newSkin;
-            this.setConvexHullDirty();
-            this.setTransformDirty();
+            if (this._skin) {
+                this._skin.addListener(Skin.Events.WasAltered, this._skinWasAltered);
+            }
+            this._skinWasAltered();
         }
     }
 
@@ -310,6 +318,15 @@ class Drawable {
             return this.getBounds();
         }
         return this.getAABB();
+    }
+
+    /**
+     * Respond to an internal change in the current Skin.
+     * @private
+     */
+    _skinWasAltered () {
+        this.setConvexHullDirty();
+        this.setTransformDirty();
     }
 
     /**

--- a/src/RenderConstants.js
+++ b/src/RenderConstants.js
@@ -1,3 +1,10 @@
+const DEFAULT_SKIN = {
+    squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/',
+    bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/66895930177178ea01d9e610917f8acf.png/get/',
+    scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/09dc888b0b7df19f70d81588ae73420e.svg/get/',
+    gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/a49ff276b9b8f997a1ae163992c2c145.png/get/'
+}.squirrel;
+
 /**
  * Various constants meant for use throughout the renderer.
  * @type {object}
@@ -7,5 +14,12 @@ module.exports = {
      * The ID value to use for "no item" or when an object has been disposed.
      * @type {int}
      */
-    ID_NONE: -1
+    ID_NONE: -1,
+
+    /**
+     * The URL to use as the default skin for a Drawable.
+     * TODO: Remove this in favor of falling back on a built-in skin.
+     * @type {string}
+     */
+    DEFAULT_SKIN: DEFAULT_SKIN
 };

--- a/src/RenderConstants.js
+++ b/src/RenderConstants.js
@@ -21,5 +21,11 @@ module.exports = {
      * TODO: Remove this in favor of falling back on a built-in skin.
      * @type {string}
      */
-    DEFAULT_SKIN: DEFAULT_SKIN
+    DEFAULT_SKIN: DEFAULT_SKIN,
+
+    /**
+     * Optimize for fewer than this number of Drawables sharing the same Skin.
+     * Going above this may cause middleware warnings or a performance penalty but should otherwise behave correctly.
+     */
+    SKIN_SHARE_SOFT_LIMIT: 300
 };

--- a/src/RenderConstants.js
+++ b/src/RenderConstants.js
@@ -1,0 +1,11 @@
+/**
+ * Various constants meant for use throughout the renderer.
+ * @type {object}
+ */
+module.exports = {
+    /**
+     * The ID value to use for "no item" or when an object has been disposed.
+     * @type {int}
+     */
+    ID_NONE: -1
+};

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2,6 +2,7 @@ const hull = require('hull.js');
 const twgl = require('twgl.js');
 
 const Drawable = require('./Drawable');
+const RenderConstants = require('./RenderConstants');
 const ShaderManager = require('./ShaderManager');
 
 /**
@@ -341,7 +342,7 @@ class RenderWebGL {
         gl.viewport(0, 0, bounds.width, bounds.height);
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.bottom, bounds.top, -1, 1);
 
-        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        const noneColor = Drawable.color4fFromID(RenderConstants.ID_NONE);
         gl.clearColor.apply(gl, noneColor);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
 
@@ -383,7 +384,7 @@ class RenderWebGL {
                 pixels[pixelBase],
                 pixels[pixelBase + 1],
                 pixels[pixelBase + 2]);
-            if (pixelID > Drawable.NONE) {
+            if (pixelID > RenderConstants.ID_NONE) {
                 return true;
             }
         }
@@ -399,7 +400,7 @@ class RenderWebGL {
      * @param {int} touchHeight The client height of the touch event (optional).
      * @param {int[]} candidateIDs The Drawable IDs to pick from, otherwise all.
      * @returns {int} The ID of the topmost Drawable under the picking location, or
-     * Drawable.NONE if there is no Drawable at that location.
+     * RenderConstants.ID_NONE if there is no Drawable at that location.
      */
     pick (centerX, centerY, touchWidth, touchHeight, candidateIDs) {
         const gl = this._gl;
@@ -427,7 +428,7 @@ class RenderWebGL {
         twgl.bindFramebufferInfo(gl, this._pickBufferInfo);
         gl.viewport(0, 0, touchWidth, touchHeight);
 
-        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        const noneColor = Drawable.color4fFromID(RenderConstants.ID_NONE);
         gl.clearColor.apply(gl, noneColor);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
@@ -467,9 +468,9 @@ class RenderWebGL {
         }
 
         // Bias toward selecting anything over nothing
-        hits[Drawable.NONE] = 0;
+        hits[RenderConstants.ID_NONE] = 0;
 
-        let hit = Drawable.NONE;
+        let hit = RenderConstants.ID_NONE;
         for (const hitID in hits) {
             if (hits.hasOwnProperty(hitID) && (hits[hitID] > hits[hit])) {
                 hit = hitID;
@@ -663,8 +664,8 @@ class RenderWebGL {
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
         gl.viewport(0, 0, width, height);
 
-        // Clear the canvas with Drawable.NONE.
-        const noneColor = Drawable.color4fFromID(Drawable.NONE);
+        // Clear the canvas with RenderConstants.ID_NONE.
+        const noneColor = Drawable.color4fFromID(RenderConstants.ID_NONE);
         gl.clearColor.apply(gl, noneColor);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
@@ -692,7 +693,7 @@ class RenderWebGL {
          * Helper method to look up a pixel.
          * @param {int} x X coordinate of the pixel in `pixels`.
          * @param {int} y Y coordinate of the pixel in `pixels`.
-         * @return {int} Known ID at that pixel, or Drawable.NONE.
+         * @return {int} Known ID at that pixel, or RenderConstants.ID_NONE.
          */
         const _getPixel = (x, y) => {
             const pixelBase = ((width * y) + x) * 4;
@@ -704,14 +705,14 @@ class RenderWebGL {
         for (let y = 0; y <= height; y++) {
             // Scan from left.
             for (let x = 0; x < width; x++) {
-                if (_getPixel(x, y) > Drawable.NONE) {
+                if (_getPixel(x, y) > RenderConstants.ID_NONE) {
                     boundaryPoints.push([x, y]);
                     break;
                 }
             }
             // Scan from right.
             for (let x = width - 1; x >= 0; x--) {
-                if (_getPixel(x, y) > Drawable.NONE) {
+                if (_getPixel(x, y) > RenderConstants.ID_NONE) {
                     boundaryPoints.push([x, y]);
                     break;
                 }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -672,10 +672,8 @@ class RenderWebGL {
             drawable.skin = this._allSkins[properties.skinId];
         }
         if ('rotationCenter' in properties) {
-            const centerChanged = drawable.skin.setRotationCenter(properties.rotationCenter);
-            if (centerChanged) {
-                drawable.setTransformDirty();
-            }
+            const newRotationCenter = properties.rotationCenter;
+            drawable.skin.setRotationCenter(newRotationCenter[0], newRotationCenter[1]);
         }
         drawable.updateProperties(properties);
     }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -665,7 +665,7 @@ class RenderWebGL {
             const {skin, costumeResolution} = properties;
             const skinId = this._skinUrlMap.hasOwnProperty(skin) ?
                 this._skinUrlMap[skin] :
-                this.createSkinFromURL(skin, costumeResolution);
+                this._skinUrlMap[skin] = this.createSkinFromURL(skin, costumeResolution);
             drawable.skin = this._allSkins[skinId];
         }
         if ('skinId' in properties) {

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -4,6 +4,11 @@ const Skin = require('./Skin');
 const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
 
 class SVGSkin extends Skin {
+    /**
+     * Create a new SVG skin.
+     * @param {!int} id - The ID for this Skin.
+     * @param {!RenderWebGL} renderer - The renderer which will use this skin.
+     */
     constructor (id, renderer) {
         super(id);
 
@@ -17,6 +22,9 @@ class SVGSkin extends Skin {
         this._texture = null;
     }
 
+    /**
+     * Dispose of this object. Do not use it after calling this method.
+     */
     dispose () {
         if (this._texture) {
             this._renderer.gl.deleteTexture(this._texture);
@@ -34,7 +42,7 @@ class SVGSkin extends Skin {
 
     /**
      * @param {[number,number]} scale - The scaling factors to be used.
-     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given size.
+     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given scale.
      */
     // eslint-disable-next-line no-unused-vars
     getTexture (scale) {

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -71,6 +71,7 @@ class SVGSkin extends Skin {
 
                 this._texture = twgl.createTexture(gl, textureOptions);
             }
+            this.emit(Skin.Events.WasAltered);
         });
     }
 }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -1,0 +1,70 @@
+const twgl = require('twgl.js');
+
+const Skin = require('./Skin');
+const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
+
+class SVGSkin extends Skin {
+    constructor (id, renderer) {
+        super(id);
+
+        /** @type {RenderWebGL} */
+        this._renderer = renderer;
+
+        /** @type {SvgRenderer} */
+        this._svgRenderer = new SvgRenderer();
+
+        /** @type {WebGLTexture} */
+        this._texture = null;
+    }
+
+    dispose () {
+        if (this._texture) {
+            this._renderer.gl.deleteTexture(this._texture);
+            this._texture = null;
+        }
+        super.dispose();
+    }
+
+    /**
+     * @return {[number,number]} the "native" size, in texels, of this skin.
+     */
+    get size () {
+        return [this._svgRenderer.canvas.width, this._svgRenderer.canvas.height];
+    }
+
+    /**
+     * @param {[number,number]} scale - The scaling factors to be used.
+     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given size.
+     */
+    // eslint-disable-next-line no-unused-vars
+    getTexture (scale) {
+        // TODO: re-render a scaled version if the requested scale is significantly larger than the current render
+        return this._texture;
+    }
+
+    /**
+     * Set the contents of this skin to a snapshot of the provided SVG data.
+     * @param {string} svgData - new SVG to use.
+     */
+    setSVG (svgData) {
+        this._svgRenderer.fromString(svgData, () => {
+            const gl = this._renderer.gl;
+            if (this._texture) {
+                gl.bindTexture(gl.TEXTURE_2D, this._texture);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
+            } else {
+                const textureOptions = {
+                    auto: true,
+                    mag: gl.NEAREST,
+                    min: gl.NEAREST, // TODO: mipmaps, linear (except pixelate)
+                    wrap: gl.CLAMP_TO_EDGE,
+                    src: this._svgRenderer.canvas
+                };
+
+                this._texture = twgl.createTexture(gl, textureOptions);
+            }
+        });
+    }
+}
+
+module.exports = SVGSkin;

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -64,12 +64,19 @@ class Skin {
         return [0, 0];
     }
 
+    /**
+     * Set the origin, in object space, about which this Skin should rotate.
+     * @param {number} x - The x coordinate of the new rotation center.
+     * @param {number} y - The y coordinate of the new rotation center.
+     * @returns {boolean} true iff the new rotation center differs from the old one.
+     */
     setRotationCenter (x, y) {
         if (x !== this._rotationCenter[0] || y !== this._rotationCenter[1]) {
             this._rotationCenter[0] = x;
             this._rotationCenter[1] = y;
             return true;
         }
+        return false;
     }
 
     /**
@@ -84,12 +91,11 @@ class Skin {
 
     /**
      * Update and returns the uniforms for this skin.
-     * @param {int} pixelsWide - The width that the skin will be rendered at, in GPU pixels.
-     * @param {int} pixelsTall - The height that the skin will be rendered at, in GPU pixels.
+     * @param {[number,number]} scale - The scaling factors to be used.
      * @returns {object.<string, *>} the shader uniforms to be used when rendering with this Skin.
      */
-    getUniforms (pixelsWide, pixelsTall) {
-        this._uniforms.u_skin = this.getTexture(pixelsWide, pixelsTall);
+    getUniforms (scale) {
+        this._uniforms.u_skin = this.getTexture(scale);
         this._uniforms.u_skinSize = this.size;
         return this._uniforms;
     }

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -37,6 +37,8 @@ class Skin extends EventEmitter {
              */
             u_skin: null
         };
+
+        this.setMaxListeners(RenderConstants.SKIN_SHARE_SOFT_LIMIT);
     }
 
     /**

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -1,0 +1,98 @@
+const twgl = require('twgl.js');
+
+const RenderConstants = require('./RenderConstants');
+
+class Skin {
+    /**
+     * Create a Skin, which stores and/or generates textures for use in rendering.
+     * @param {int} id - The unique ID for this Skin.
+     */
+    constructor (id) {
+        /** @type {int} */
+        this._id = id;
+
+        /** @type {Vec3} */
+        this._rotationCenter = twgl.v3.create(0, 0);
+
+        /**
+         * The uniforms to be used by the vertex and pixel shaders.
+         * Some of these are used by other parts of the renderer as well.
+         * @type {Object.<string,*>}
+         * @private
+         */
+        this._uniforms = {
+            /**
+             * The nominal (not necessarily current) size of the current skin.
+             * @type {number[]}
+             */
+            u_skinSize: [0, 0],
+
+            /**
+             * The actual WebGL texture object for the skin.
+             * @type {WebGLTexture}
+             */
+            u_skin: null
+        };
+    }
+
+    /**
+     * Dispose of this object. Do not use it after calling this method.
+     */
+    dispose () {
+        this._id = RenderConstants.ID_NONE;
+    }
+
+    /**
+     * @return {int} the unique ID for this Skin.
+     */
+    get id () {
+        return this._id;
+    }
+
+    /**
+     * @returns {Vec3} the origin, in object space, about which this Skin should rotate.
+     */
+    get rotationCenter () {
+        return this._rotationCenter;
+    }
+
+    /**
+     * @abstract
+     * @return {[number,number]} the "native" size, in texels, of this skin.
+     */
+    get size () {
+        return [0, 0];
+    }
+
+    setRotationCenter (x, y) {
+        if (x !== this._rotationCenter[0] || y !== this._rotationCenter[1]) {
+            this._rotationCenter[0] = x;
+            this._rotationCenter[1] = y;
+            return true;
+        }
+    }
+
+    /**
+     * @abstract
+     * @param {[number,number]} scale - The scaling factors to be used.
+     * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given size.
+     */
+    // eslint-disable-next-line no-unused-vars
+    getTexture (scale) {
+        return null;
+    }
+
+    /**
+     * Update and returns the uniforms for this skin.
+     * @param {int} pixelsWide - The width that the skin will be rendered at, in GPU pixels.
+     * @param {int} pixelsTall - The height that the skin will be rendered at, in GPU pixels.
+     * @returns {object.<string, *>} the shader uniforms to be used when rendering with this Skin.
+     */
+    getUniforms (pixelsWide, pixelsTall) {
+        this._uniforms.u_skin = this.getTexture(pixelsWide, pixelsTall);
+        this._uniforms.u_skinSize = this.size;
+        return this._uniforms;
+    }
+}
+
+module.exports = Skin;

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -1,13 +1,17 @@
+const EventEmitter = require('events');
+
 const twgl = require('twgl.js');
 
 const RenderConstants = require('./RenderConstants');
 
-class Skin {
+class Skin extends EventEmitter {
     /**
      * Create a Skin, which stores and/or generates textures for use in rendering.
      * @param {int} id - The unique ID for this Skin.
      */
     constructor (id) {
+        super();
+
         /** @type {int} */
         this._id = id;
 
@@ -68,15 +72,13 @@ class Skin {
      * Set the origin, in object space, about which this Skin should rotate.
      * @param {number} x - The x coordinate of the new rotation center.
      * @param {number} y - The y coordinate of the new rotation center.
-     * @returns {boolean} true iff the new rotation center differs from the old one.
      */
     setRotationCenter (x, y) {
         if (x !== this._rotationCenter[0] || y !== this._rotationCenter[1]) {
             this._rotationCenter[0] = x;
             this._rotationCenter[1] = y;
-            return true;
+            this.emit(Skin.Events.WasAltered);
         }
-        return false;
     }
 
     /**
@@ -100,5 +102,16 @@ class Skin {
         return this._uniforms;
     }
 }
+
+/**
+ * These are the events which can be emitted by instances of this class.
+ * @type {object.<string,string>}
+ */
+Skin.Events = {
+    /**
+     * Emitted when anything about the Skin has been altered, such as the appearance or rotation center.
+     */
+    WasAltered: 'WasAltered'
+};
 
 module.exports = Skin;

--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -30,12 +30,20 @@ document.body.insertBefore(documentStyleTag, document.body.firstChild);
 class SvgRenderer {
     /**
      * Create a quirks-mode SVG renderer for a particular canvas.
-     * @param {!HTMLCanvasElement} canvas A canvas element to draw to.
+     * @param {HTMLCanvasElement} [canvas] An optional canvas element to draw to. If this is not provided, the renderer
+     * will create a new canvas.
      * @constructor
      */
     constructor (canvas) {
-        this._canvas = canvas;
-        this._context = canvas.getContext('2d');
+        this._canvas = canvas || document.createElement('canvas');
+        this._context = this._canvas.getContext('2d');
+    }
+
+    /**
+     * @returns {!HTMLCanvasElement} this renderer's target canvas.
+     */
+    get canvas () {
+        return this._canvas;
     }
 
     /**


### PR DESCRIPTION
Moving `Skin` functionality (corresponding to costumes) out of `Drawable` (corresponding to sprites & clones) allows multiple `Drawable` instances to share the same `Skin` and allows a `Drawable` to change between `Skin`s without loading the image fresh each time.

In addition, this change moves management of `Drawable` IDs out of `Drawable` and into the renderer, which means that `Drawable` no longer has a "split personality" (static vs. instance). It also makes debugging easier: if you can access the renderer you can inspect all relevant state.

Setting a `Skin` from a URL has been improved dramatically by this change, but really the renderer shouldn't be responsible for downloading and parsing image files. The new `createBitmapSkin` and `createSVGSkin` methods should be used after the renderer's client (the VM, GUI, etc.) obtains an image through a download, the paint editor, etc.

This resolves LLK/scratch-vm#372