### PR TITLE
Fix webpack dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-*
 # Build
 /dist
 /playground/scratch-render.js
+/playground/scratch-render.js.map

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,20 +48,30 @@ const base = {
 };
 
 module.exports = [
+    // Playground
+    Object.assign({}, base, {
+        target: 'web',
+        entry: {
+            'scratch-render': './src/index-web.js'
+        },
+        output: {
+            path: path.resolve(__dirname, 'playground'),
+            filename: '[name].js'
+        }
+    }),
     // Web-compatible
     Object.assign({}, base, {
         target: 'web',
         entry: {
-            'dist/web/scratch-render': './src/index-web.js',
-            'dist/web/scratch-render.min': './src/index-web.js',
-            'playground/scratch-render': './src/index-web.js'
+            'scratch-render': './src/index-web.js',
+            'scratch-render.min': './src/index-web.js'
         },
         output: {
-            path: __dirname,
+            path: path.resolve(__dirname, 'dist/web'),
             filename: '[name].js'
         }
     }),
-    // Webpack-compatible
+    // Node-compatible
     Object.assign({}, base, {
         target: 'node',
         entry: {
@@ -70,8 +80,8 @@ module.exports = [
         output: {
             library: 'ScratchRender',
             libraryTarget: 'commonjs2',
-            path: __dirname,
-            filename: 'dist/node/[name].js'
+            path: path.resolve(__dirname, 'dist/node'),
+            filename: '[name].js'
         }
     })
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const base = {
             colors: true
         }
     },
+    devtool: 'source-map',
     module: {
         loaders: [
             {


### PR DESCRIPTION
This change tweaks the expression of paths in the Webpack config to make `webpack-dev-server` work again. This opened the door for some minor cleanup of `path` & `filename` in the `output` configuration entries.
Thanks to @rschamp for help resolving the `webpack-dev-server` problems.
Also, enable source maps.

@rschamp and I discussed removing the Node target since we're not really using it right now, but I decided not to do that just yet. If/when we do remove it we should also make a few other changes, such as simplifying `src/index*.js`.