### PR TITLE
Add Contribution Guidelines and Issue / PR Templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+## Contributing
+The development of Scratch is an ongoing process, and we love to have people in the Scratch and open source communities help us along the way.
+
+If you're interested in contributing, please take a look at the [issues](https://github.com/LLK/scratch-render/issues) on this repository.
+Two great ways of helping are by identifying bugs and documenting them as issues, or fixing issues and creating pull requests. When looking for bugs to fix, please look for the ["Help Wanted" label](https://github.com/LLK/scratch-render/issues?q=label%3A%22help+wanted%22). Bugs with this label have been specifically set aside for Open Source contributors. Issues without the label can also be worked on but we ask that you comment on the issue prior to starting work. When submitting pull requests please be patient -- it can take a while to find time to review them. The organization and class structures can't be radically changed without significant coordination and collaboration from the Scratch Team, so these types of changes should be avoided.
+
+It's been said that the Scratch Team spends about one hour of design discussion for every pixel in Scratch, but some think that estimate is a little low. While we welcome suggestions for new features in our [suggestions forum](https://scratch.mit.edu/discuss/1/) (especially ones that come with mockups), we are unlikely to accept PRs with new features that haven't been thought through and discussed as a group. Why? Because we have a strong belief in the value of keeping things simple for new users. To learn more about our design philosophy, see [the Scratch Developers page](https://scratch.mit.edu/developers), or [this paper](http://web.media.mit.edu/~mres/papers/Scratch-CACM-final.pdf).
+
+Beyond this repo, there are also some other resources that you might want to take a look at:
+* [Community Guidelines](https://github.com/LLK/scratch-www/wiki/Community-Guidelines) (we find it important to maintain a constructive and welcoming community, just like on Scratch)
+* [Open Source forum](https://scratch.mit.edu/discuss/49/) on Scratch
+* [Suggestions forum](https://scratch.mit.edu/discuss/1/) on Scratch
+* [Bugs & Glitches forum](https://scratch.mit.edu/discuss/3/) on Scratch

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Expected Behavior
+
+_Please describe what should happen_
+
+### Actual Behavior
+
+_Describe what actually happens_
+
+### Steps to Reproduce
+
+_Explain what someone needs to do in order to see what's described in *Actual behavior* above_
+
+### Operating System and Browser
+
+_e.g. Mac OS 10.11.6 Safari 10.0_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Resolves
+
+_What Github issue does this resolve (please include link)?_
+
+### Proposed Changes
+
+_Describe what this Pull Request does_
+
+### Reason for Changes
+
+_Explain why these changes should be made_
+
+### Test Coverage
+
+_Please show how you have added tests to cover your changes_


### PR DESCRIPTION
This adds Github related templates and documents to a `.github` directory and attempts to clarify some of our policies:

- Directs contributors towards the "Help Wanted" label
- Asks that contributors explicitly request to work on an issue prior to starting work or submitting a PR
- Provides an issue template
- Provides a pull request template