### PR TITLE
Fix SVG size calculation

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -34,10 +34,10 @@ class SVGSkin extends Skin {
     }
 
     /**
-     * @return {[number,number]} the "native" size, in texels, of this skin.
+     * @return {[number,number]} the natural size, in Scratch units, of this skin.
      */
     get size () {
-        return [this._svgRenderer.canvas.width, this._svgRenderer.canvas.height];
+        return this._svgRenderer.size;
     }
 
     /**

--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -73,6 +73,13 @@ class SvgRenderer {
     }
 
     /**
+     * @return {[number,number]} the natural size, in Scratch units, of this SVG.
+     */
+    get size () {
+        return [this._measurements.width, this._measurements.height];
+    }
+
+    /**
      * Transforms an SVG's text elements for Scratch 2.0 quirks.
      * These quirks include:
      * 1. `x` and `y` properties are removed/ignored.


### PR DESCRIPTION
It was being incorrectly calculated based on devicePixelRatio.

Fixes LLK/scratch-gui#73. Thanks to @cwillisf for figuring it out!
