### PR TITLE
Feature fencing

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -739,7 +739,8 @@ class RenderWebGL extends EventEmitter {
     /**
      * Update the position object's x & y members to keep the drawable fenced in view.
      * @param {int} drawableID - The ID of the Drawable to update.
-     * @param {object} position - An object with x & y members to be fenced - These values are updated in the object to become fenced
+     * @param {object} position - An object with x & y members to be fenced
+     *                          - These values are updated in the object to become fenced
      */
     getFencedPositionOfDrawable (drawableID, position) {
         const drawable = this._allDrawables[drawableID];
@@ -753,7 +754,8 @@ class RenderWebGL extends EventEmitter {
 
         const aabb = drawable.getFastBounds();
 
-        // This is my best guess at the fencing in Scratch 2, but I suspect it may need further work to be precisely the same?
+        // This is my best guess at the fencing in Scratch 2,
+        // but I suspect it may need further work to be precisely the same?
         const sx = this._xRight - Math.min(15, Math.floor((aabb.right - aabb.left) / 2));
         if (aabb.right + dx < -sx) {
             position.x = drawable._position[0] - (sx + aabb.right);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -737,6 +737,38 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
+     * Update the position object's x & y members to keep the drawable fenced in view.
+     * @param {int} drawableID - The ID of the Drawable to update.
+     * @param {object} position - An object with x & y members to be fenced - These values are updated in the object to become fenced
+     */
+    getFencedPositionOfDrawable (drawableID, position) {
+        const drawable = this._allDrawables[drawableID];
+        if (!drawable) {
+            // TODO: fix whatever's wrong in the VM which causes this, then add a warning or throw here.
+            // Right now this happens so much on some projects that a warning or exception here can hang the browser.
+            return;
+        }
+        const dx = position.x - drawable._position[0];
+        const dy = position.y - drawable._position[1];
+
+        const aabb = drawable.getFastBounds();
+
+        // This is my best guess at the fencing in Scratch 2, but I suspect it may need further work to be precisely the same?
+        const sx = this._xRight - Math.min(15, Math.floor((aabb.right - aabb.left) / 2));
+        if (aabb.right + dx < -sx) {
+            position.x = drawable._position[0] - (sx + aabb.right);
+        } else if (aabb.left + dx > sx) {
+            position.x = drawable._position[0] + (sx - aabb.left);
+        }
+        const sy = this._yTop - Math.min(15, Math.floor((aabb.top - aabb.bottom) / 2));
+        if (aabb.top + dy < -sy) {
+            position.y = drawable._position[1] - (sy + aabb.top);
+        } else if (aabb.bottom + dy > sy) {
+            position.y = drawable._position[1] + (sy - aabb.bottom);
+        }
+    }
+
+    /**
      * Clear a pen layer.
      * @param {int} penSkinID - the unique ID of a Pen Skin.
      */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -742,6 +742,7 @@ class RenderWebGL extends EventEmitter {
      * @param {object} position - An object with x & y members to be fenced
      *                          - These values are updated in the object to become fenced
      */
+    fencePositionOfDrawable (drawableID, position) {
         const drawable = this._allDrawables[drawableID];
         if (!drawable) {
             // TODO: fix whatever's wrong in the VM which causes this, then add a warning or throw here.

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -742,7 +742,6 @@ class RenderWebGL extends EventEmitter {
      * @param {object} position - An object with x & y members to be fenced
      *                          - These values are updated in the object to become fenced
      */
-    getFencedPositionOfDrawable (drawableID, position) {
         const drawable = this._allDrawables[drawableID];
         if (!drawable) {
             // TODO: fix whatever's wrong in the VM which causes this, then add a warning or throw here.

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -739,18 +739,23 @@ class RenderWebGL extends EventEmitter {
     /**
      * Update the position object's x & y members to keep the drawable fenced in view.
      * @param {int} drawableID - The ID of the Drawable to update.
-     * @param {object} position - An object with x & y members to be fenced
-     *                          - These values are updated in the object to become fenced
+     * @param {Array.<number, number>} position to be fenced - An array of type [x, y]
+     * @return {Array.<number, number>} The fenced position as an array [x, y]
      */
-    fencePositionOfDrawable (drawableID, position) {
+    getFencedPositionOfDrawable (drawableID, position) {
+
+        let x = position[0];
+        let y = position[1];
+
         const drawable = this._allDrawables[drawableID];
         if (!drawable) {
             // TODO: fix whatever's wrong in the VM which causes this, then add a warning or throw here.
             // Right now this happens so much on some projects that a warning or exception here can hang the browser.
-            return;
+            return [x, y];
         }
-        const dx = position.x - drawable._position[0];
-        const dy = position.y - drawable._position[1];
+
+        const dx = x - drawable._position[0];
+        const dy = y - drawable._position[1];
 
         const aabb = drawable.getFastBounds();
 
@@ -758,16 +763,17 @@ class RenderWebGL extends EventEmitter {
         // but I suspect it may need further work to be precisely the same?
         const sx = this._xRight - Math.min(15, Math.floor((aabb.right - aabb.left) / 2));
         if (aabb.right + dx < -sx) {
-            position.x = drawable._position[0] - (sx + aabb.right);
+            x = drawable._position[0] - (sx + aabb.right);
         } else if (aabb.left + dx > sx) {
-            position.x = drawable._position[0] + (sx - aabb.left);
+            x = drawable._position[0] + (sx - aabb.left);
         }
         const sy = this._yTop - Math.min(15, Math.floor((aabb.top - aabb.bottom) / 2));
         if (aabb.top + dy < -sy) {
-            position.y = drawable._position[1] - (sy + aabb.top);
+            y = drawable._position[1] - (sy + aabb.top);
         } else if (aabb.bottom + dy > sy) {
-            position.y = drawable._position[1] + (sy - aabb.bottom);
+            y = drawable._position[1] + (sy - aabb.bottom);
         }
+        return [x, y];
     }
 
     /**


### PR DESCRIPTION
Provide a method in the scratch-render to return the fenced coordinates of a drawable moving to a given position.