### PR TITLE
SVG: compensate for viewbox offset

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -41,6 +41,16 @@ class SVGSkin extends Skin {
     }
 
     /**
+     * Set the origin, in object space, about which this Skin should rotate.
+     * @param {number} x - The x coordinate of the new rotation center.
+     * @param {number} y - The y coordinate of the new rotation center.
+     */
+    setRotationCenter (x, y) {
+        const viewOffset = this._svgRenderer.viewOffset;
+        super.setRotationCenter(x - viewOffset[0], y - viewOffset[1]);
+    }
+
+    /**
      * @param {[number,number]} scale - The scaling factors to be used.
      * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given scale.
      */

--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -81,6 +81,13 @@ class SvgRenderer {
     }
 
     /**
+     * @return {[number,number]} the offset (upper left corner) of the SVG's view box.
+     */
+    get viewOffset () {
+        return [this._measurements.x, this._measurements.y];
+    }
+
+    /**
      * Transforms an SVG's text elements for Scratch 2.0 quirks.
      * These quirks include:
      * 1. `x` and `y` properties are removed/ignored.


### PR DESCRIPTION
### Resolves

Resolves #62

Sprite alignment is still not 100% perfect in comparison to Scratch 2.0, but I don't think the remaining problems are related to the SVG viewbox.

### Proposed Changes

This change adjusts the rotation center of an `SVGSkin` by an amount corresponding to the origin of the SVG's viewbox. The math wasn't as tricky as I expected ;)

### Reason for Changes

In Scratch 2.0, an SVG costume's origin is stored relative to that SVG's viewbox. In order to use the origin values correctly, then, we need to compensate for the viewbox offset. Visually, this change is necessary to make sure SVG costumes appear in the correct place whether they were authored in Scratch (which always uses a viewbox origin of [0,0]) or another tool (which may use other coordinates).
