### PR TITLE
Fix getBounds for Hidden Sprites

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -219,7 +219,7 @@ class Drawable {
      * @return {boolean} True when no convex hull known, or it's dirty.
      */
     needsConvexHullPoints () {
-        return !this._convexHullPoints || this._convexHullDirty;
+        return !this._convexHullPoints || this._convexHullDirty || this._convexHullPoints.length === 0;
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -375,7 +375,7 @@ class RenderWebGL extends EventEmitter {
             const points = this._getConvexHullPointsForDrawable(drawableID);
             drawable.setConvexHullPoints(points);
         }
-        const bounds = drawable.getBounds();
+        const bounds = drawable.getFastBounds();
         // In debug mode, draw the bounds.
         if (this._debugCanvas) {
             const gl = this._gl;


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#453 & LLK/scratch-vm#450

### Proposed Changes

Switch to getFastBounds from getBounds in RenderWebGL, and add check for if the hull points are empty in needsConvexHullPoints.

### Reason for Changes

When sprites are hidden, they often have empty hull point sets (especially when loaded hidden), thus getBounds fails. By changing needsConvexHullPoints to check if the set is empty, it should correctly ID when the bounds cannot be calculated from hull points. And by switching RenderWebGL's calls to getBounds with getFastBounds, if no hull points exist, it will get bounds from getAABB. This allows hidden sprites to bounce and to not throw errors because the bounds aren't empty.

### Test Coverage

None added.