### PR TITLE
Round pixelBase

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -992,7 +992,7 @@ class RenderWebGL extends EventEmitter {
          * @return {int} Known ID at that pixel, or RenderConstants.ID_NONE.
          */
         const _getPixel = (x, y) => {
-            const pixelBase = ((width * y) + x) * 4;
+            const pixelBase = Math.round(((width * y) + x) * 4); // Sometimes SVGs don't have int width and height
             return Drawable.color3bToID(
                 pixels[pixelBase],
                 pixels[pixelBase + 1],


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-vm#455

### Proposed Changes

Round pixelBase to allow for non-integer SVG widths in _getConvexHullPointsForDrawable

### Reason for Changes
SVGs don't always have int widths, so using said widths in getting specific pixels fails. 
At some point it may be desired to truncate skin width to integer values, but I don't know what effect that might have on other things. So instead rounding was added so that getPixel doesn't fail.

### Test Coverage

None added.