### PR TITLE
Add method to retrieve drawable pixel data

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -8,8 +8,8 @@
     </style>
 </head>
 <body style="background: lightsteelblue">
-<canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
 <canvas id="scratch-stage" width="10" height="10" style="border:3px dashed black"></canvas>
+<canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
 <p>
     <select id="fudgeproperty" onchange="onFudgePropertyChanged(this.value)">
         <option value="posx">Position X</option>
@@ -124,12 +124,15 @@
         var mousePos = getMousePos(event, canvas);
         var pickID = renderer.pick(mousePos.x, mousePos.y);
         console.log('You clicked on ' + (pickID < 0 ? 'nothing' : 'ID# ' + pickID));
+        if (pickID >= 0) {
+            console.dir(renderer.extractDrawable(pickID, mousePos.x, mousePos.y));
+        }
     };
 
     function drawStep() {
         renderer.draw();
-        //renderer.getBounds(drawableID2);
-        renderer.isTouchingColor(drawableID2, [255,255,255]);
+        // renderer.getBounds(drawableID2);
+        // renderer.isTouchingColor(drawableID2, [255,255,255]);
         requestAnimationFrame(drawStep);
     }
     drawStep();

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -672,7 +672,7 @@ class RenderWebGL extends EventEmitter {
      */
     extractDrawable (drawableID, x, y) {
         const drawable = this._allDrawables[drawableID];
-        if (!drawable) return;
+        if (!drawable) return null;
 
         const gl = this._gl;
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -693,7 +693,8 @@ class RenderWebGL extends EventEmitter {
         gl.clear(gl.COLOR_BUFFER_BIT);
         try {
             gl.disable(gl.BLEND);
-            this._drawThese([drawableID], ShaderManager.DRAW_MODE.default, projection);
+            this._drawThese([drawableID], ShaderManager.DRAW_MODE.default, projection,
+                {effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask});
         } finally {
             gl.enable(gl.BLEND);
         }
@@ -965,6 +966,7 @@ class RenderWebGL extends EventEmitter {
      * @param {object} [opts] Options for drawing
      * @param {idFilterFunc} opts.filter An optional filter function.
      * @param {object.<string,*>} opts.extraUniforms Extra uniforms for the shaders.
+     * @param {int} opts.effectMask Bitmask for effects to allow
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {
@@ -989,7 +991,8 @@ class RenderWebGL extends EventEmitter {
             // If the texture isn't ready yet, skip it.
             if (!drawable.skin.getTexture(drawableScale)) continue;
 
-            const effectBits = drawable.getEnabledEffects();
+            let effectBits = drawable.getEnabledEffects();
+            effectBits &= opts.hasOwnProperty('effectMask') ? opts.effectMask : effectBits;
             const newShader = this._shaderManager.getShader(drawMode, effectBits);
             if (currentShader !== newShader) {
                 currentShader = newShader;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -677,8 +677,8 @@ class RenderWebGL extends EventEmitter {
         const gl = this._gl;
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
 
-        const bounds = this._touchingBounds(drawableID);
-        if (!bounds) return;
+        const bounds = drawable.getFastBounds();
+        bounds.snapToInt();
 
         // Translate input x and y to coordinates relative to the drawable
         const pickX = x - ((this._nativeSize[0] / 2) + bounds.left);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -452,15 +452,14 @@ class RenderWebGL extends EventEmitter {
                     ShaderManager.DRAW_MODE.colorMask :
                     ShaderManager.DRAW_MODE.silhouette,
                 projection,
-                null,
-                extraUniforms);
+                {extraUniforms});
 
             gl.stencilFunc(gl.EQUAL, 1, 1);
             gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
             gl.colorMask(true, true, true, true);
 
             this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.default, projection,
-                testID => testID !== drawableID
+                {idFilterFunc: testID => testID !== drawableID}
             );
         } finally {
             gl.colorMask(true, true, true, true);
@@ -537,7 +536,7 @@ class RenderWebGL extends EventEmitter {
             gl.colorMask(true, true, true, true);
 
             this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection,
-                testID => testID !== drawableID
+                {idFilterFunc: testID => testID !== drawableID}
             );
         } finally {
             gl.colorMask(true, true, true, true);
@@ -963,11 +962,12 @@ class RenderWebGL extends EventEmitter {
      * @param {int[]} drawables The Drawable IDs to draw, possibly this._drawList.
      * @param {ShaderManager.DRAW_MODE} drawMode Draw normally, silhouette, etc.
      * @param {module:twgl/m4.Mat4} projection The projection matrix to use.
-     * @param {idFilterFunc} [filter] An optional filter function.
-     * @param {Object.<string,*>} [extraUniforms] Extra uniforms for the shaders.
+     * @param {object} [opts] Options for drawing
+     * @param {idFilterFunc} opts.filter An optional filter function.
+     * @param {object.<string,*>} opts.extraUniforms Extra uniforms for the shaders.
      * @private
      */
-    _drawThese (drawables, drawMode, projection, filter, extraUniforms) {
+    _drawThese (drawables, drawMode, projection, opts = {}) {
         const gl = this._gl;
         let currentShader = null;
 
@@ -976,7 +976,7 @@ class RenderWebGL extends EventEmitter {
             const drawableID = drawables[drawableIndex];
 
             // If we have a filter, check whether the ID fails
-            if (filter && !filter(drawableID)) continue;
+            if (opts.filter && !opts.filter(drawableID)) continue;
 
             const drawable = this._allDrawables[drawableID];
             // TODO: check if drawable is inside the viewport before anything else
@@ -1003,8 +1003,8 @@ class RenderWebGL extends EventEmitter {
             twgl.setUniforms(currentShader, drawable.getUniforms());
 
             // Apply extra uniforms after the Drawable's, to allow overwriting.
-            if (extraUniforms) {
-                twgl.setUniforms(currentShader, extraUniforms);
+            if (opts.extraUniforms) {
+                twgl.setUniforms(currentShader, opts.extraUniforms);
             }
 
             twgl.drawBufferInfo(gl, gl.TRIANGLES, this._bufferInfo);
@@ -1047,8 +1047,7 @@ class RenderWebGL extends EventEmitter {
         this._drawThese([drawableID],
             ShaderManager.DRAW_MODE.silhouette,
             projection,
-            null,
-            {u_modelMatrix: modelMatrix}
+            {extraUniforms: {u_modelMatrix: modelMatrix}}
         );
 
         const pixels = new Uint8Array(width * height * 4);


### PR DESCRIPTION
Towards LLK/scratch-gui#66

Add `extractDrawable`, which returns raw pixel data and other data convenient for dragging this image, for a `drawableID` picked at `x`, `y`.