### PR TITLE
Add scratchOffset data to extractDrawable

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -675,6 +675,8 @@ class RenderWebGL extends EventEmitter {
      * @property {Uint8Array} data Raw pixel data for the drawable
      * @property {int} width Drawable bounding box width
      * @property {int} height Drawable bounding box height
+     * @property {Array<number>} scratchOffset [x, y] offset in Scratch coordinates
+     * from the drawable position to the client x, y coordinate
      * @property {int} x The x coordinate relative to drawable bounding box
      * @property {int} y The y coordinate relative to drawable bounding box
      */
@@ -738,6 +740,10 @@ class RenderWebGL extends EventEmitter {
             data: data,
             width: bounds.width,
             height: bounds.height,
+            scratchOffset: [
+                (this._nativeSize[0] / 2) - x + drawable._position[0],
+                (this._nativeSize[1] / 2) - y - drawable._position[1]
+            ],
             x: pickX,
             y: pickY
         };


### PR DESCRIPTION
Makes it easier to translate between canvas coordinates and scratch coordinates

/fyi @thisandagain @cwillisf 