### PR TITLE
Add stamping flag to make draw ignore visibility

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1029,6 +1029,7 @@ class RenderWebGL extends EventEmitter {
      * @param {idFilterFunc} opts.filter An optional filter function.
      * @param {object.<string,*>} opts.extraUniforms Extra uniforms for the shaders.
      * @param {int} opts.effectMask Bitmask for effects to allow
+     * @param {boolean} opts.isStamping Stamp mode ignores sprite visibility, always drawing.
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -935,7 +935,7 @@ class RenderWebGL extends EventEmitter {
 
         try {
             gl.disable(gl.BLEND);
-            this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection);
+            this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection, {isStamping: true});
         } finally {
             gl.enable(gl.BLEND);
         }
@@ -1045,8 +1045,8 @@ class RenderWebGL extends EventEmitter {
             const drawable = this._allDrawables[drawableID];
             /** @todo check if drawable is inside the viewport before anything else */
 
-            // Hidden drawables (e.g., by a "hide" block) are never drawn.
-            if (!drawable.getVisible()) continue;
+            // Hidden drawables (e.g., by a "hide" block) are not drawn unless stamping
+            if (!drawable.getVisible() && !opts.isStamping) continue;
 
             const drawableScale = drawable.scale;
 


### PR DESCRIPTION
_@cwillisf let me know what you think about this solution. It _seems_ to go along with the existing style, but let me know._

### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-vm/issues/492

### Proposed Changes

_Describe what this Pull Request does_

Allows stamping of hidden sprites. Makes the `_drawThese` function ignore visibility when stamping by passing in an `isStamping` flag. 

### Reason for Changes

_Explain why these changes should be made_

Match functionality of Scratch 2

### Test Coverage

_Please show how you have added tests to cover your changes_

There don't seem to be any tests on the renderer. Let me know if you think this is a good opportunity to add any. Here are a few gifs showing it working.

#### Scratch 2
![stamp-working-2](https://cloud.githubusercontent.com/assets/654102/23666305/9fd34c54-0328-11e7-97e3-8116c11f703d.gif)

#### Production Scratch 3 doesn't do the same thing
![stamp-not-working](https://cloud.githubusercontent.com/assets/654102/23666322/abaa30ce-0328-11e7-8135-e4f4832f4a05.gif)

#### This change brings it back
![stamp-working](https://cloud.githubusercontent.com/assets/654102/23666333/b5c02cf8-0328-11e7-8a63-79641937c51d.gif)
