### PR TITLE
Remove `createSkinFromURL` and related code

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "travis-after-all": "^1.4.4",
     "twgl.js": "3.2.0",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.4.1",
-    "xhr": "2.4.0"
+    "webpack-dev-server": "^2.4.1"
   }
 }

--- a/src/RenderConstants.js
+++ b/src/RenderConstants.js
@@ -1,10 +1,4 @@
 /** @module RenderConstants */
-const DEFAULT_SKIN = {
-    squirrel: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/',
-    bus: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/66895930177178ea01d9e610917f8acf.png/get/',
-    scratch_cat: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/09dc888b0b7df19f70d81588ae73420e.svg/get/',
-    gradient: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/a49ff276b9b8f997a1ae163992c2c145.png/get/'
-}.squirrel;
 
 /**
  * Various constants meant for use throughout the renderer.
@@ -16,13 +10,6 @@ module.exports = {
      * @const {int}
      */
     ID_NONE: -1,
-
-    /**
-     * The URL to use as the default skin for a Drawable.
-     * @todo Remove this in favor of falling back on a built-in skin.
-     * @const {string}
-     */
-    DEFAULT_SKIN: DEFAULT_SKIN,
 
     /**
      * Optimize for fewer than this number of Drawables sharing the same Skin.


### PR DESCRIPTION
NOTE: LLK/scratch-vm#498 must be merged before this.

### Resolves

This could be considered part of LLK/scratch-vm#427

### Proposed Changes

- Remove the `createSkinFromURL` method.
- Remove `skin` property handling from `updateDrawableProperties`.
- Remove the URL-to-skin mapping cache.
- Remove `RenderConstants` items related to choosing a default skin.
- Remove `xhr` package dependency.
- `Drawable` now starts with a `null` skin instead of a default skin.
- `DrawThese` now skips any item with a `null` skin.

### Reason for Changes

The renderer should not be responsible for file access. These changes remove all explicit file handling from the renderer in favor of allowing the client to supply data that has already been loaded (say, using scratch-storage).

### Test Coverage

The renderer doesn't yet have unit tests, but using the new (non-URL) API could make it easier to implement tests which don't depend on network state.