### PR TITLE
Offer unpacked code from package.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.md text eol=lf
 *.vert text eol=lf
 *.xml text eol=lf
+*.yml text eol=lf
 
 # Prefer LF for these files
 .editorconfig text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- "4.2"
-- "stable"
+- "6"
+- "node"
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-render.git"
   },
-  "main": "./dist/node/scratch-render.js",
+  "main": "./src/index.js",
   "scripts": {
     "build": "webpack --progress --colors",
     "docs": "jsdoc -c .jsdoc.json",
@@ -21,30 +21,32 @@
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "watch": "webpack --progress --colors --watch --watch-poll"
   },
+  "dependencies": {
+    "base64-loader": "^1.0.0",
+    "hull.js": "0.2.10",
+    "raw-loader": "^0.5.1",
+    "scratch-render-fonts": "git+https://github.com/LLK/scratch-render-fonts.git",
+    "twgl.js": "3.2.0",
+    "xhr": "2.4.0"
+  },
   "devDependencies": {
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.3.2",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
-    "base64-loader": "^1.0.0",
     "copy-webpack-plugin": "^4.0.1",
     "docdash": "^0.4.0",
     "eslint": "^3.16.1",
     "eslint-config-scratch": "^3.1.0",
     "gh-pages": "^0.12.0",
-    "hull.js": "0.2.10",
     "jsdoc": "^3.4.3",
     "json": "9.0.4",
     "json-loader": "^0.5.4",
     "lodash.defaultsdeep": "4.6.0",
-    "raw-loader": "^0.5.1",
-    "scratch-render-fonts": "git+https://github.com/LLK/scratch-render-fonts.git",
     "tap": "^10.3.0",
     "travis-after-all": "^1.4.4",
-    "twgl.js": "3.2.0",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.4.1",
-    "xhr": "2.4.0"
+    "webpack-dev-server": "^2.4.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const base = {
         host: '0.0.0.0',
         port: process.env.PORT || 8361
     },
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
     module: {
         rules: [
             {
@@ -60,19 +60,6 @@ module.exports = [
         },
         output: {
             path: path.resolve(__dirname, 'dist/web'),
-            filename: '[name].js'
-        }
-    }),
-    // Node-compatible
-    Object.assign({}, base, {
-        target: 'node',
-        entry: {
-            'scratch-render': './src/index.js'
-        },
-        output: {
-            library: 'ScratchRender',
-            libraryTarget: 'commonjs2',
-            path: path.resolve(__dirname, 'dist/node'),
             filename: '[name].js'
         }
     })


### PR DESCRIPTION
### Proposed Changes

This change declares `./src/index.js` as the "main" script in `package.json`, and stops building `dist/node/*` with webpack.

### Reason for Changes

This sets us up to build `scratch-gui` in a single step, allowing webpack to better optimize our files and reducing the duplication of code within our output bundles.

### Test Coverage

Test coverage has not changed.
