### PR TITLE
Standardize repository settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.md text eol=lf
 *.vert text eol=lf
 *.xml text eol=lf
+*.yml text eol=lf
 
 # Prefer LF for these files
 .editorconfig text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - "4.2"
-- "stable"
+- "node"
 sudo: false
 cache:
   directories:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const base = {
         host: '0.0.0.0',
         port: process.env.PORT || 8361
     },
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
     module: {
         rules: [
             {


### PR DESCRIPTION
### Proposed Changes

This change ensures that line endings, Travis CI settings, and source map settings are similar to other Scratch 3.0 repositories. These were previously part of #126.
