### PR TITLE
Increase SKIN_SHARE_SOFT_LIMIT to 301 to avoid sprite clone limit warning

### DIFF
--- a/src/RenderConstants.js
+++ b/src/RenderConstants.js
@@ -16,7 +16,7 @@ module.exports = {
      * Going above this may cause middleware warnings or a performance penalty but should otherwise behave correctly.
      * @const {int}
      */
-    SKIN_SHARE_SOFT_LIMIT: 300,
+    SKIN_SHARE_SOFT_LIMIT: 301,
 
     /**
      * @enum {string}


### PR DESCRIPTION
scratch-vm will not throw a EventEmitter memory leak warning.

### Reason
the max number of clones is 300, plus 1 for itself.
Then the shared skin will exceed it's limit.
Changing the number from 300 to 301 fixes this issue.

### Resolves

This resolves [this issue in scratch-gui](https://github.com/LLK/scratch-gui/issues/203)
