### PR TITLE
fix the bug #131 Rotation center is incorrect while sprite is scaled by "changeSize" block or "setSize" block

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -201,7 +201,9 @@ class Drawable {
         twgl.m4.rotateZ(modelMatrix, rotation, modelMatrix);
 
         // Adjust rotation center relative to the skin.
-        const rotationAdjusted = twgl.v3.subtract(this.skin.rotationCenter, twgl.v3.divScalar(this.skin.size, 2));
+        var rotationAdjusted = twgl.v3.subtract(this.skin.rotationCenter, twgl.v3.divScalar(this.skin.size, 2));
+        rotationAdjusted = twgl.v3.multiply(rotationAdjusted, this.scale);
+        rotationAdjusted = twgl.v3.divScalar(rotationAdjusted, 100);
         rotationAdjusted[1] *= -1; // Y flipped to Scratch coordinate.
         rotationAdjusted[2] = 0; // Z coordinate is 0.
 


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/131

### Proposed Changes

the "rotationAdjusted" should be scaled while the drawable target is scaled.

rotationAdjusted = twgl.v3.multiply(rotationAdjusted, this.scale);
rotationAdjusted = twgl.v3.divScalar(rotationAdjusted, 100);

