### PR TITLE
Fix 'draw a point' typo in drawLine doc

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -112,7 +112,7 @@ class PenSkin extends Skin {
     }
 
     /**
-     * Draw a point on the pen layer.
+     * Draw a line on the pen layer.
      * @param {PenAttributes} penAttributes - how the line should be drawn.
      * @param {number} x0 - the X coordinate of the beginning of the line.
      * @param {number} y0 - the Y coordinate of the beginning of the line.


### PR DESCRIPTION
### Proposed Changes

Fixes a typo in `PenSkin.drawLine`'s documentation comment.

### Reason for Changes

`drawLine`'s documentation should say "draw a *line* on the pen layer", not "draw a *point* on the pen layer". The comment text was probably copy/pasted from `drawPoint`.

### Test Coverage

Not applicable.
