### PR TITLE
Fix scratch-render playground

### DIFF
--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -44,10 +44,16 @@
         direction: 90
     });
     var drawableID2 = renderer.createDrawable();
-    renderer.updateDrawableProperties(drawableID2, {
-        skin: 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
-            '09dc888b0b7df19f70d81588ae73420e.svg/get/'
-    });
+    var image = new Image();
+    image.onload = function () {
+        var skinId = renderer.createBitmapSkin(image);
+        renderer.updateDrawableProperties(drawableID2, {
+            skinId: skinId
+        });
+    };
+    image.crossOrigin = 'anonymous';
+    image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/' +
+        '09dc888b0b7df19f70d81588ae73420e.svg/get/';
 
     var fudgeSelect = document.getElementById('fudgeproperty');
     var posX = 0;


### PR DESCRIPTION
It looks like loading skin by URL is deprecated (see: https://github.com/LLK/scratch-render/commit/64c59914861a47162aee48a8e9f60854118617e8).

### Before

![screen shot 2017-08-07 at 3 53 23 pm](https://user-images.githubusercontent.com/413693/29049154-309648a8-7b89-11e7-9705-7002b2bfba95.png)

### After

![screen shot 2017-08-07 at 3 53 07 pm](https://user-images.githubusercontent.com/413693/29049158-3406486c-7b89-11e7-85e0-1f28971a74cf.png)