### PR TITLE
Fix picking when input size is different from native size

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -623,15 +623,19 @@ class RenderWebGL extends EventEmitter {
         const drawable = this._allDrawables[drawableID];
         if (!drawable) return null;
 
+        // Convert client coordinates into absolute scratch units
+        const scratchX = this._nativeSize[0] * ((x / this._gl.canvas.clientWidth) - 0.5);
+        const scratchY = this._nativeSize[1] * ((y / this._gl.canvas.clientHeight) - 0.5);
+
         const gl = this._gl;
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
 
         const bounds = drawable.getFastBounds();
         bounds.snapToInt();
 
-        // Translate input x and y to coordinates relative to the drawable
-        const pickX = x - ((this._nativeSize[0] / 2) + bounds.left);
-        const pickY = y - ((this._nativeSize[1] / 2) - bounds.top);
+        // Translate to scratch units relative to the drawable
+        const pickX = scratchX - bounds.left;
+        const pickY = scratchY + bounds.top;
 
         // Limit size of viewport to the bounds around the target Drawable,
         // and create the projection matrix for the draw.
@@ -672,8 +676,8 @@ class RenderWebGL extends EventEmitter {
             width: bounds.width,
             height: bounds.height,
             scratchOffset: [
-                (this._nativeSize[0] / 2) - x + drawable._position[0],
-                (this._nativeSize[1] / 2) - y - drawable._position[1]
+                -scratchX + drawable._position[0],
+                -scratchY - drawable._position[1]
             ],
             x: pickX,
             y: pickY


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Part of being able to resize the stage.

### Proposed Changes

_Describe what this Pull Request does_

Correctly scale the inputs to the `extractDrawable` function so that the input coords do not have to be the same as the native coords. This happens when you are interacting with a canvas that is at a different size from the "native" size. 
