### PR TITLE
Add initial test coverage for Drawable.prototype.getAABB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "4.2"
+- 6
 - "node"
 sudo: false
 cache:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepublish": "npm run build",
     "prepublish-watch": "npm run watch",
     "start": "webpack-dev-server",
-    "test": "npm run lint && npm run docs",
+    "tap": "./node_modules/.bin/tap ./test/unit/*.js",
+    "test": "npm run lint && npm run docs && npm run tap",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "watch": "webpack --progress --colors --watch --watch-poll"
   },

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -1,8 +1,5 @@
 const twgl = require('twgl.js');
 
-const vertexShaderText = require('raw-loader!./shaders/sprite.vert');
-const fragmentShaderText = require('raw-loader!./shaders/sprite.frag');
-
 
 class ShaderManager {
     /**
@@ -65,8 +62,11 @@ class ShaderManager {
         }
 
         const definesText = `${defines.join('\n')}\n`;
-        const vsFullText = definesText + vertexShaderText;
-        const fsFullText = definesText + fragmentShaderText;
+
+        /* eslint-disable global-require */
+        const vsFullText = definesText + require('raw-loader!./shaders/sprite.vert');
+        const fsFullText = definesText + require('raw-loader!./shaders/sprite.frag');
+        /* eslint-enable global-require */
 
         return twgl.createProgramInfo(this._gl, [vsFullText, fsFullText]);
     }

--- a/test/fixtures/MockSkin.js
+++ b/test/fixtures/MockSkin.js
@@ -1,0 +1,13 @@
+const Skin = require('../../src/Skin');
+
+class MockSkin extends Skin {
+    set size (dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    get size () {
+        return this.dimensions || [0, 0];
+    }
+}
+
+module.exports = MockSkin;

--- a/test/unit/DrawableTests.js
+++ b/test/unit/DrawableTests.js
@@ -1,0 +1,102 @@
+const test = require('tap').test;
+
+// Mock `window` and `document.createElement` for twgl.js.
+global.window = {};
+global.document = {
+    createElement: () => ({getContext: () => {}})
+};
+
+const Drawable = require('../../src/Drawable');
+const MockSkin = require('../fixtures/MockSkin');
+const Rectangle = require('../../src/Rectangle');
+
+/**
+ * Returns a Rectangle-like object, with dimensions rounded to the given number
+ * of digits.
+ * @param {Rectangle} rect The source rectangle.
+ * @param {int} decimals The number of decimal points to snap to.
+ * @returns {object} An object with left/right/top/bottom attributes.
+ */
+const snapToNearest = function (rect, decimals = 3) {
+    return {
+        left: rect.left.toFixed(decimals),
+        right: rect.right.toFixed(decimals),
+        bottom: rect.bottom.toFixed(decimals),
+        top: rect.top.toFixed(decimals)
+    };
+};
+
+test('translate by position', t => {
+    const expected = new Rectangle();
+    const drawable = new Drawable();
+    drawable.skin = new MockSkin();
+    drawable.skin.size = [200, 50];
+
+    expected.initFromBounds(0, 200, -50, 0);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.updateProperties({position: [1, 2]});
+    expected.initFromBounds(1, 201, -48, 2);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    t.end();
+});
+
+test('translate by costume center', t => {
+    const expected = new Rectangle();
+    const drawable = new Drawable();
+    drawable.skin = new MockSkin();
+    drawable.skin.size = [200, 50];
+
+    drawable.skin.setRotationCenter(1, 0);
+    expected.initFromBounds(-1, 199, -50, 0);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.skin.setRotationCenter(0, -2);
+    expected.initFromBounds(0, 200, -52, -2);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    t.end();
+});
+
+test('translate and rotate', t => {
+    const expected = new Rectangle();
+    const drawable = new Drawable();
+    drawable.skin = new MockSkin();
+    drawable.skin.size = [200, 50];
+
+    drawable.updateProperties({position: [1, 2], direction: 0});
+    expected.initFromBounds(1, 51, 2, 202);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.updateProperties({direction: 180});
+    expected.initFromBounds(-49, 1, -198, 2);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.skin.setRotationCenter(100, 25);
+    drawable.updateProperties({direction: 270, position: [0, 0]});
+    expected.initFromBounds(-100, 100, -25, 25);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.updateProperties({direction: 90});
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    t.end();
+});
+
+test('rotate by non-right-angles', t => {
+    const expected = new Rectangle();
+    const drawable = new Drawable();
+    drawable.skin = new MockSkin();
+    drawable.skin.size = [10, 10];
+    drawable.skin.setRotationCenter(5, 5);
+
+    expected.initFromBounds(-5, 5, -5, 5);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    drawable.updateProperties({direction: 45});
+    expected.initFromBounds(-7.071, 7.071, -7.071, 7.071);
+    t.same(snapToNearest(drawable.getAABB()), expected);
+
+    t.end();
+});


### PR DESCRIPTION
Add a bit of test coverage for `_calculateTransform`.

I have a few additional tests for rotate + scale, but those aren't passing yet.  I'll create a separate PR with those changes!

### Test Coverage

```> scratch-render@0.1.0 tap /Users/joshlory/Work/2k14/scratch-render
> tap ./test/unit/*.js

./test/unit/DrawableTests.js ........................ 10/10
total ............................................... 10/10

  10 passing (466.848ms)

  ok
```