### PR TITLE
Scratch 2.0 compat: don't modify rotation center of empty sprites

### DIFF
--- a/src/Skin.js
+++ b/src/Skin.js
@@ -78,7 +78,9 @@ class Skin extends EventEmitter {
      * @fires Skin.event:WasAltered
      */
     setRotationCenter (x, y) {
-        if (x !== this._rotationCenter[0] || y !== this._rotationCenter[1]) {
+        const emptySkin = this.size[0] === 0 && this.size[1] === 0;
+        const changed = x !== this._rotationCenter[0] || y !== this._rotationCenter[1];
+        if (!emptySkin && changed) {
             this._rotationCenter[0] = x;
             this._rotationCenter[1] = y;
             this.emit(Skin.Events.WasAltered);


### PR DESCRIPTION
I believe the 0x0 costume issue is solved by ignoring `rotationCenterX` and `rotationCenterY` for empty costumes.  Unfortunately I don't have an easy way to attach a debugger to Scratch 2.0 to verify.

### Resolves

https://github.com/LLK/scratch-gui/issues/207: 2.0 project confined to lower right quadrant in 3.0
https://github.com/LLK/scratch-vm/issues/520: Clock face draws incorrectly

### Before

<img width="1507" alt="before" src="https://user-images.githubusercontent.com/413693/29156738-562ba6b4-7d58-11e7-98b5-46e48fb8f8df.png">

### After

<img width="1520" alt="after" src="https://user-images.githubusercontent.com/413693/29156866-c20aeea8-7d58-11e7-95ab-82d54b116d8e.png">