### PR TITLE
Add color extraction method to renderer

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -5,6 +5,7 @@ const twgl = require('twgl.js');
 
 const BitmapSkin = require('./BitmapSkin');
 const Drawable = require('./Drawable');
+const Rectangle = require('./Rectangle');
 const PenSkin = require('./PenSkin');
 const RenderConstants = require('./RenderConstants');
 const ShaderManager = require('./ShaderManager');
@@ -681,6 +682,79 @@ class RenderWebGL extends EventEmitter {
             ],
             x: pickX,
             y: pickY
+        };
+    }
+
+    /**
+     * @typedef ColorExtraction
+     * @property {Uint8Array} data Raw pixel data for the drawable
+     * @property {int} width Drawable bounding box width
+     * @property {int} height Drawable bounding box height
+     * @property {object} color Color object with RGBA properties at picked location
+     */
+
+    /**
+     * Return drawable pixel data and color at a given position
+     * @param {int} x The client x coordinate of the picking location.
+     * @param {int} y The client y coordinate of the picking location.
+     * @param {int} radius The client radius to extract pixels with.
+     * @return {?ColorExtraction} Data about the picked color
+     */
+    extractColor (x, y, radius) {
+        // @todo this doesn't seem to work for retina screens
+        const scratchX = Math.round(this._nativeSize[0] * ((x / this._gl.canvas.clientWidth) - 0.5));
+        const scratchY = Math.round(-this._nativeSize[1] * ((y / this._gl.canvas.clientHeight) - 0.5));
+
+        const gl = this._gl;
+        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+
+        const bounds = new Rectangle();
+        bounds.initFromBounds(scratchX - radius, scratchX + radius, scratchY - radius, scratchY + radius);
+
+        const pickX = scratchX - bounds.left;
+        const pickY = bounds.top - scratchY;
+
+        gl.viewport(0, 0, bounds.width, bounds.height);
+        const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
+
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        try {
+            gl.disable(gl.BLEND);
+            this._drawThese(this._drawList, ShaderManager.DRAW_MODE.default, projection);
+        } finally {
+            gl.enable(gl.BLEND);
+        }
+
+        const data = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
+        gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, data);
+
+        const color = {
+            r: data[Math.floor(4 * (pickY * bounds.width + pickX))],
+            g: data[Math.floor(4 * (pickY * bounds.width + pickX)) + 1],
+            b: data[Math.floor(4 * (pickY * bounds.width + pickX)) + 2],
+            a: data[Math.floor(4 * (pickY * bounds.width + pickX)) + 3]
+        };
+
+        if (this._debugCanvas) {
+            this._debugCanvas.width = bounds.width;
+            this._debugCanvas.height = bounds.height;
+            const ctx = this._debugCanvas.getContext('2d');
+            const imageData = ctx.createImageData(bounds.width, bounds.height);
+            imageData.data.set(data);
+            ctx.putImageData(imageData, 0, 0);
+            ctx.strokeStyle = 'black';
+            ctx.fillStyle = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`;
+            ctx.rect(pickX - 4, pickY - 4, 8, 8);
+            ctx.fill();
+            ctx.stroke();
+        }
+
+        return {
+            data: data,
+            width: bounds.width,
+            height: bounds.height,
+            color: color
         };
     }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -716,7 +716,7 @@ class RenderWebGL extends EventEmitter {
         gl.viewport(0, 0, bounds.width, bounds.height);
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
 
-        gl.clearColor(0, 0, 0, 0);
+        gl.clearColor.apply(gl, this._backgroundColor);
         gl.clear(gl.COLOR_BUFFER_BIT);
         this._drawThese(this._drawList, ShaderManager.DRAW_MODE.default, projection);
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -701,7 +701,6 @@ class RenderWebGL extends EventEmitter {
      * @return {?ColorExtraction} Data about the picked color
      */
     extractColor (x, y, radius) {
-        // @todo this doesn't seem to work for retina screens
         const scratchX = Math.round(this._nativeSize[0] * ((x / this._gl.canvas.clientWidth) - 0.5));
         const scratchY = Math.round(-this._nativeSize[1] * ((y / this._gl.canvas.clientHeight) - 0.5));
 
@@ -719,12 +718,7 @@ class RenderWebGL extends EventEmitter {
 
         gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
-        try {
-            gl.disable(gl.BLEND);
-            this._drawThese(this._drawList, ShaderManager.DRAW_MODE.default, projection);
-        } finally {
-            gl.enable(gl.BLEND);
-        }
+        this._drawThese(this._drawList, ShaderManager.DRAW_MODE.default, projection);
 
         const data = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
         gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, data);

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -126,6 +126,11 @@
         };
     }
 
+    canvas.onmousemove = function(event) {
+        var mousePos = getMousePos(event, canvas);
+        renderer.extractColor(mousePos.x, mousePos.y, 30);
+    };
+
     canvas.onclick = function(event) {
         var mousePos = getMousePos(event, canvas);
         var pickID = renderer.pick(mousePos.x, mousePos.y);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves https://github.com/LLK/scratch-render/issues/158

### Proposed Changes

_Describe what this Pull Request does_

Adds an API similar to `extractDrawable` for picking a color and getting back pixel data from around it. 

### Reason for Changes

_Explain why these changes should be made_

Needed for color picking in scratch 3. 

Notes for @cwillisf, we may want to just pair for a little on these:
- Is x, y, radius an ok way to call this method? radius is a bit unusual because it returns a box...
- I didn't use ImageData just because I was sticking closely with the `extractDrawable` code, we should probably update both at the same time.
- The coordinate system stuff is a little strange, probably could be refactored to be more clear. It also doesn't seem to work right with retina screens, but for the same reason as extractDrawable probably doesn't. Maybe we could pair on fixing both of those before merging this?

I also added it as a mousemove effect on the playground, click still does extract drawable. 

![simple-eyedropper](https://user-images.githubusercontent.com/654102/29717533-7d8c8ed6-897d-11e7-913b-18caa1cc3854.gif)
