### PR TITLE
Match Scratch 2.0 threshold for `isTouchingColor`

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -29,10 +29,15 @@ const MAX_TOUCH_SIZE = [3, 3];
  * target is touching a color whose components are each within this tolerance of
  * the corresponding component of the query color.
  * between 0 (exact matches only) and 255 (match anything).
- * @type {int}
+ * @type {object.<string,int>}
  * @memberof RenderWebGL
  */
-const TOLERANCE_TOUCHING_COLOR = 2;
+const TOLERANCE_TOUCHING_COLOR = {
+    R: 7,
+    G: 7,
+    B: 15,
+    Mask: 2
+};
 
 /**
  * Sprite Fencing - The number of pixels a sprite is required to leave remaining
@@ -384,7 +389,7 @@ class RenderWebGL extends EventEmitter {
         if (mask3b) {
             extraUniforms = {
                 u_colorMask: [mask3b[0] / 255, mask3b[1] / 255, mask3b[2] / 255],
-                u_colorMaskTolerance: TOLERANCE_TOUCHING_COLOR / 255
+                u_colorMaskTolerance: TOLERANCE_TOUCHING_COLOR.Mask / 255
             };
         }
 
@@ -430,9 +435,9 @@ class RenderWebGL extends EventEmitter {
             const pixelDistanceG = Math.abs(pixels[pixelBase + 1] - color3b[1]);
             const pixelDistanceB = Math.abs(pixels[pixelBase + 2] - color3b[2]);
 
-            if (pixelDistanceR <= TOLERANCE_TOUCHING_COLOR &&
-                pixelDistanceG <= TOLERANCE_TOUCHING_COLOR &&
-                pixelDistanceB <= TOLERANCE_TOUCHING_COLOR) {
+            if (pixelDistanceR <= TOLERANCE_TOUCHING_COLOR.R &&
+                pixelDistanceG <= TOLERANCE_TOUCHING_COLOR.G &&
+                pixelDistanceB <= TOLERANCE_TOUCHING_COLOR.B) {
                 return true;
             }
         }


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-gui/issues/426: 2.0 project's sprite touching color/ another sprite doesn't trigger; ball falls through floor

### Proposed Changes

Update `isTouchingColor` to use [the same tolerance as Scratch 2.0](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/scratch/ScratchStage.as#L643-L655):
```actionscript
var mask:uint = 0x00F8F8F0;
```

### Reason for Changes

Fixes https://llk.github.io/scratch-gui/#161606350.  Note that the `backdrop9` level still isn't passable in Scratch 3.0.

![color-tolerance](https://user-images.githubusercontent.com/413693/29906209-4506c74e-8dc8-11e7-9ffb-acb946ec3632.gif)

### Test Coverage

None 🙁.  I've verified the change manually for the broken project.  In order to run this with `tap` we'd need to mock a lot of twgl.js inside Node.  An alternative might be to run tests with Karma + Chrome Headless.