### PR TITLE
Update references to the old skin

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -239,6 +239,13 @@ class RenderWebGL extends EventEmitter {
         newSkin.setSVG(svgData, rotationCenter);
         const oldSkin = this._allSkins[skinId];
         this._allSkins[skinId] = newSkin;
+
+        // Tell drawables to update
+        for (const drawable of this._allDrawables) {
+            if (drawable && drawable.skin === oldSkin) {
+                drawable.skin = newSkin;
+            }
+        }
         oldSkin.dispose();
     }
 


### PR DESCRIPTION
Sorry about sending a pull request on this again so soon. This is an amendment to https://github.com/LLK/scratch-vm/pull/671 . I forgot to test the relevant thing after the last edits. When converting from a bitmap to SVG skin, the renderer didn't actually update to the new skin. The set skin() function is what marks the dirty bits and actually causes the costumes showing on stage to re-render.