### PR TITLE
Enlarge bounding box by the largest stroke width.

### DIFF
--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -234,11 +234,11 @@ class SvgRenderer {
         // Enlarge the bbox from the largest found stroke width
         // This may have false-positives, but at least the bbox will always
         // contain the full graphic including strokes.
-        const largestStrokeWidth = this._findLargestStrokeWidth(this._svgTag);
-        bbox.width += largestStrokeWidth * 2;
-        bbox.height += largestStrokeWidth * 2;
-        bbox.x -= largestStrokeWidth;
-        bbox.y -= largestStrokeWidth;
+        const halfStrokeWidth = this._findLargestStrokeWidth(this._svgTag) / 2;
+        bbox.width += halfStrokeWidth * 2;
+        bbox.height += halfStrokeWidth * 2;
+        bbox.x -= halfStrokeWidth;
+        bbox.y -= halfStrokeWidth;
 
         // Set the correct measurements on the SVG tag, and save them.
         this._svgTag.setAttribute('width', bbox.width);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-render/issues/175

### Proposed Changes

_Describe what this Pull Request does_

Enlarge the bounding box that is read from the DOM method `getBBox()` which doesn't take into account the strokes by the largest found stroke width. As mentioned in the code comment, this may have false positives, as in it may enlarge an SVG viewbox that didn't need it (if, for example, the largest shape was a fill, not a stroke). But it will always make the viewbox large enough to include the strokes, which seems like an ok trade-off. 

### Reason for Changes

_Explain why these changes should be made_

Clipping of SVG's, which is impacting project rendering and also messes with the upcoming speech bubble rendering.

### Test Coverage

_Please show how you have added tests to cover your changes_

None.

/cc @tmickel since it looks like a lot of this code was yours. 