### PR TITLE
Use zero if cannot parse stroke width

### DIFF
--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -197,7 +197,10 @@ class SvgRenderer {
                     largestStrokeWidth = Math.max(largestStrokeWidth, 1);
                 }
                 if (domElement.getAttribute('stroke-width')) {
-                    largestStrokeWidth = Math.max(largestStrokeWidth, Number(domElement.getAttribute('stroke-width')));
+                    largestStrokeWidth = Math.max(
+                        largestStrokeWidth,
+                        Number(domElement.getAttribute('stroke-width')) || 0
+                    );
                 }
             }
             for (let i = 0; i < domElement.childNodes.length; i++) {


### PR DESCRIPTION
Fixes an issue with the svg renderer where non-number stroke-widths (for example, "none", which is bizarrely used in the paint editor), would break by giving NaN. Use zero instead. 