### PR TITLE
Touching color white always returns "true"

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -43,7 +43,8 @@ const TOLERANCE_TOUCHING_COLOR = {
 
 /**
  * Constant used for masking when detecting the color white
- * @type {[number,number,number,number]}
+ * @type {Array<int>}
+ * @memberof RenderWebGL
  */
 const COLOR_BLACK = [0, 0, 0, 1];
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -42,6 +42,12 @@ const TOLERANCE_TOUCHING_COLOR = {
 };
 
 /**
+ * Constant used for masking when detecting the color white
+ * @type {[number,number,number,number]}
+ */
+const COLOR_BLACK = [0, 0, 0, 1];
+
+/**
  * Sprite Fencing - The number of pixels a sprite is required to leave remaining
  * onscreen around the edge of the staging area.
  * @type {number}
@@ -439,7 +445,15 @@ class RenderWebGL extends EventEmitter {
         gl.viewport(0, 0, bounds.width, bounds.height);
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
 
-        gl.clearColor.apply(gl, this._backgroundColor);
+        let fillBackgroundColor = this._backgroundColor;
+
+        // When using masking such that the background fill color will showing through, ensure we don't
+        // fill using the same color that we are trying to detect!
+        if (mask3b && color3b[0] > 196 && color3b[1] > 196 && color3b[2] > 196) {
+            fillBackgroundColor = COLOR_BLACK;
+        }
+
+        gl.clearColor.apply(gl, fillBackgroundColor);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
 
         let extraUniforms;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -450,7 +450,7 @@ class RenderWebGL extends EventEmitter {
 
         // When using masking such that the background fill color will showing through, ensure we don't
         // fill using the same color that we are trying to detect!
-        if (mask3b && color3b[0] > 196 && color3b[1] > 196 && color3b[2] > 196) {
+        if (color3b[0] > 196 && color3b[1] > 196 && color3b[2] > 196) {
             fillBackgroundColor = COLOR_BLACK;
         }
 


### PR DESCRIPTION
Speculative fix for https://github.com/LLK/scratch-vm/issues/710

I've submitted this pull request, but I am very sorry to say I am completely unable to test my own fix as I am unable to get scratch-render to compile under windows.

Please do not therefore pull this into develop until someone can varified that it works and has no side effects? Thanks.

This is the error I get when I try to build:

ERROR in ./node_modules/grapheme-breaker/src/GraphemeBreaker.js
    Module not found: Error: Can't resolve 'fs' in 'C:\Users\andrew.griffin\Documents\GitHub\scratch-render\node_modules\grapheme-breaker\src'
     @ ./node_modules/grapheme-breaker/src/GraphemeBreaker.js 9:7-20