### PR TITLE
Whirl and Fisheye shaders without conditions

### DIFF
--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -102,7 +102,7 @@ void main()
 		const float kRadius = 0.5;
 		vec2 offset = texcoord0 - kCenter;
 		float offsetMagnitude = length(offset);
-		float whirlFactor = 1.0 - (offsetMagnitude / kRadius);
+		float whirlFactor = max(1.0 - (offsetMagnitude / kRadius), 0.0);
 		float whirlActual = u_whirl * whirlFactor * whirlFactor;
 		float sinWhirl = sin(whirlActual);
 		float cosWhirl = cos(whirlActual);
@@ -111,12 +111,7 @@ void main()
 			sinWhirl, cosWhirl
 		);
 
-		// TODO: tweak this algorithm such that texture coordinates don't depend on conditionals.
-		// see: https://www.opengl.org/wiki/Sampler_%28GLSL%29#Non-uniform_flow_control
-		if (offsetMagnitude <= kRadius)
-		{
-			texcoord0 = rotationMatrix * offset + kCenter;
-		}
+		texcoord0 = rotationMatrix * offset + kCenter;
 	}
 	#endif // ENABLE_whirl
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -118,14 +118,11 @@ void main()
 	#ifdef ENABLE_fisheye
 	{
 		vec2 vec = (texcoord0 - kCenter) / kCenter;
-		float r = pow(length(vec), u_fisheye);
-		float angle = atan(vec.y, vec.x);
-		// TODO: tweak this algorithm such that texture coordinates don't depend on conditionals.
-		// see: https://www.opengl.org/wiki/Sampler_%28GLSL%29#Non-uniform_flow_control
-		if (r <= 1.0)
-		{
-			texcoord0 = kCenter + r * vec2(cos(angle), sin(angle)) * kCenter;
-		}
+		float vecLength = length(vec);
+		float r = pow(min(vecLength, 1.0), u_fisheye) * max(1.0, vecLength);
+		vec2 unit = vec / vecLength;
+
+		texcoord0 = kCenter + r * unit * kCenter;
 	}
 	#endif // ENABLE_fisheye
 


### PR DESCRIPTION
### Resolves

TODO comments in the shader about removing the need for the conditional test.

### Proposed Changes

- Compute `whirlFactor` with a `max(..., 0.0)` call to constrain `whirlFactor` to zero if it would have been less than 0. With a `whirlFactor` of 0 the computer whirl angle will be 0, not changing the original `texcoord0` when its beyond the `kRadius`, as the condition did before.
- Compute fisheye's `r` with `pow(min(vecLength, 1.0), u_fisheye) * max(1.0, vecLength)`. The left hand side of the multiplication cancels out if vector length is greater than 1. The right hand side of the multiplication cancels out if vector length is less than one. This way `r`, `vecLength` inputs greater than 1 stay one, resulting with fisheye having no effect as the condition originally did.

### Reason for Changes

Conditions in shaders generally result in slower shaders as the GPU pipelines can't know if they perform a single instruction to all of the relevant pipes.

### Test Coverage

Current render tests are headless and don't test shaders.
