### PR TITLE
Emulate silhouette rendering for pick and _getConvexHullPointsForDrawable

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -1,6 +1,7 @@
 const twgl = require('twgl.js');
 
 const Skin = require('./Skin');
+const Silhouette = require('./Silhouette');
 
 class BitmapSkin extends Skin {
     /**
@@ -23,6 +24,8 @@ class BitmapSkin extends Skin {
 
         /** @type {Array<int>} */
         this._textureSize = [0, 0];
+
+        this._silhouette = new Silhouette();
     }
 
     /**
@@ -66,6 +69,7 @@ class BitmapSkin extends Skin {
         if (this._texture) {
             gl.bindTexture(gl.TEXTURE_2D, this._texture);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmapData);
+            this._silhouette.update(bitmapData);
         } else {
             const textureOptions = {
                 auto: true,
@@ -77,6 +81,7 @@ class BitmapSkin extends Skin {
             };
 
             this._texture = twgl.createTexture(gl, textureOptions);
+            this._silhouette.update(bitmapData);
         }
 
         // Do these last in case any of the above throws an exception
@@ -105,6 +110,15 @@ class BitmapSkin extends Skin {
 
         // ImageData or HTMLCanvasElement
         return [bitmapData.width, bitmapData.height];
+    }
+
+    /**
+     * Does this point touch an opaque or translucent point on this skin?
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did it touch?
+     */
+    isTouching (vec) {
+        return this._silhouette.isTouching(vec);
     }
 }
 

--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview
+ * A utility to transform a texture coordinate to another texture coordinate
+ * representing how the shaders apply effects.
+ */
+
+const twgl = require('twgl.js');
+
+const ShaderManager = require('./ShaderManager');
+
+/**
+ * A texture coordinate is between 0 and 1. 0.5 is the center position.
+ * @const {number}
+ */
+const CENTER_X = 0.5;
+
+/**
+ * A texture coordinate is between 0 and 1. 0.5 is the center position.
+ * @const {number}
+ */
+const CENTER_Y = 0.5;
+
+class EffectTransform {
+    /**
+     * Transform a texture coordinate to one that would be select after applying shader effects.
+     * @param {Drawable} drawable The drawable whose effects to emulate.
+     * @param {twgl.v3} vec The texture coordinate to transform.
+     * @param {?twgl.v3} dst A place to store the output coordinate.
+     * @return {twgl.v3} The coordinate after being transform by effects.
+     */
+    static transformPoint (drawable, vec, dst) {
+        dst = dst || twgl.v3.create();
+        twgl.v3.copy(vec, dst);
+
+        const uniforms = drawable.getUniforms();
+        const effects = drawable.getEnabledEffects();
+
+        if ((effects & ShaderManager.EFFECT_INFO.mosaic.mask) !== 0) {
+            // texcoord0 = fract(u_mosaic * texcoord0);
+            dst[0] = uniforms.u_mosaic * dst[0] % 1;
+            dst[1] = uniforms.u_mosaic * dst[1] % 1;
+        }
+        if ((effects & ShaderManager.EFFECT_INFO.pixelate.mask) !== 0) {
+            const skinUniforms = drawable.skin.getUniforms();
+            // vec2 pixelTexelSize = u_skinSize / u_pixelate;
+            const texelX = skinUniforms.u_skinSize[0] * uniforms.u_pixelate;
+            const texelY = skinUniforms.u_skinSize[1] * uniforms.u_pixelate;
+            // texcoord0 = (floor(texcoord0 * pixelTexelSize) + kCenter) /
+            //   pixelTexelSize;
+            dst[0] = (Math.floor(dst[0] * texelX) + CENTER_X) / texelX;
+            dst[1] = (Math.floor(dst[1] * texelY) + CENTER_Y) / texelY;
+        }
+        if ((effects & ShaderManager.EFFECT_INFO.whirl.mask) !== 0) {
+            // const float kRadius = 0.5;
+            const RADIUS = 0.5;
+            // vec2 offset = texcoord0 - kCenter;
+            const offsetX = dst[0] - CENTER_X;
+            const offsetY = dst[1] - CENTER_Y;
+            // float offsetMagnitude = length(offset);
+            const offsetMagnitude = twgl.v3.length(dst);
+            // float whirlFactor = max(1.0 - (offsetMagnitude / kRadius), 0.0);
+            const whirlFactor = Math.max(1.0 - (offsetMagnitude / RADIUS), 0.0);
+            // float whirlActual = u_whirl * whirlFactor * whirlFactor;
+            const whirlActual = uniforms.u_whirl * whirlFactor * whirlFactor;
+            // float sinWhirl = sin(whirlActual);
+            const sinWhirl = Math.sin(whirlActual);
+            // float cosWhirl = cos(whirlActual);
+            const cosWhirl = Math.cos(whirlActual);
+            // mat2 rotationMatrix = mat2(
+            //     cosWhirl, -sinWhirl,
+            //     sinWhirl, cosWhirl
+            // );
+            const rot00 = cosWhirl;
+            const rot10 = -sinWhirl;
+            const rot01 = sinWhirl;
+            const rot11 = cosWhirl;
+
+            // texcoord0 = rotationMatrix * offset + kCenter;
+            dst[0] = (rot00 * offsetX) + (rot10 * offsetY) + CENTER_X;
+            dst[1] = (rot01 * offsetX) + (rot11 * offsetY) + CENTER_Y;
+        }
+        if ((effects & ShaderManager.EFFECT_INFO.fisheye.mask) !== 0) {
+            // vec2 vec = (texcoord0 - kCenter) / kCenter;
+            const vX = (dst[0] - CENTER_X) / CENTER_X;
+            const vY = (dst[1] - CENTER_Y) / CENTER_Y;
+            // float vecLength = length(vec);
+            const vLength = Math.sqrt((vX * vX) + (vY * vY));
+            // float r = pow(min(vecLength, 1.0), u_fisheye) * max(1.0, vecLength);
+            const r = Math.pow(Math.min(vLength, 1), uniforms.u_fisheye) * Math.max(1, vLength);
+            // vec2 unit = vec / vecLength;
+            const unitX = vX / vLength;
+            const unitY = vY / vLength;
+            // texcoord0 = kCenter + r * unit * kCenter;
+            dst[0] = CENTER_X + (r * unitX * CENTER_X);
+            dst[1] = CENTER_Y + (r * unitY * CENTER_Y);
+        }
+
+        return dst;
+    }
+}
+
+module.exports = EffectTransform;

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -2,7 +2,7 @@ const twgl = require('twgl.js');
 
 const RenderConstants = require('./RenderConstants');
 const Skin = require('./Skin');
-
+const Silhouette = require('./Silhouette');
 
 /**
  * Attributes to use when drawing with the pen
@@ -49,6 +49,12 @@ class PenSkin extends Skin {
 
         /** @type {WebGLTexture} */
         this._texture = null;
+
+        /** @type {Silhouette} */
+        this._silhouette = new Silhouette();
+
+        /** @type {boolean} */
+        this._silhouetteDirty = false;
 
         this.onNativeSizeChanged = this.onNativeSizeChanged.bind(this);
         this._renderer.on(RenderConstants.Events.NativeSizeChanged, this.onNativeSizeChanged);
@@ -98,6 +104,7 @@ class PenSkin extends Skin {
         const ctx = this._canvas.getContext('2d');
         ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._canvasDirty = true;
+        this._silhouetteDirty = true;
     }
 
     /**
@@ -127,6 +134,7 @@ class PenSkin extends Skin {
         ctx.lineTo(this._rotationCenter[0] + x1, this._rotationCenter[1] - y1);
         ctx.stroke();
         this._canvasDirty = true;
+        this._silhouetteDirty = true;
     }
 
     /**
@@ -139,6 +147,7 @@ class PenSkin extends Skin {
         const ctx = this._canvas.getContext('2d');
         ctx.drawImage(stampElement, this._rotationCenter[0] + x, this._rotationCenter[1] - y);
         this._canvasDirty = true;
+        this._silhouetteDirty = true;
     }
 
     /**
@@ -173,6 +182,7 @@ class PenSkin extends Skin {
             }
         );
         this._canvasDirty = true;
+        this._silhouetteDirty = true;
     }
 
     /**
@@ -194,6 +204,21 @@ class PenSkin extends Skin {
         context.strokeStyle = `rgba(${r},${g},${b},${a})`;
         context.lineCap = 'round';
         context.lineWidth = diameter;
+    }
+
+    /**
+     * Does this point touch an opaque or translucent point on this skin?
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did it touch?
+     */
+    isTouching (vec) {
+        if (this._silhouetteDirty) {
+            if (this._canvasDirty) {
+                this.getTexture();
+            }
+            this._silhouette.update(this._canvas);
+        }
+        return this._silhouette.isTouching(vec);
     }
 }
 

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -3,6 +3,8 @@ const twgl = require('twgl.js');
 const Skin = require('./Skin');
 const SvgRenderer = require('./svg-quirks-mode/svg-renderer');
 
+const Silhouette = require('./Silhouette');
+
 class SVGSkin extends Skin {
     /**
      * Create a new SVG skin.
@@ -22,6 +24,8 @@ class SVGSkin extends Skin {
 
         /** @type {WebGLTexture} */
         this._texture = null;
+
+        this._silhouette = new Silhouette();
     }
 
     /**
@@ -75,6 +79,7 @@ class SVGSkin extends Skin {
             if (this._texture) {
                 gl.bindTexture(gl.TEXTURE_2D, this._texture);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
+                this._silhouette.update(this._svgRenderer.canvas);
             } else {
                 const textureOptions = {
                     auto: true,
@@ -85,11 +90,21 @@ class SVGSkin extends Skin {
                 };
 
                 this._texture = twgl.createTexture(gl, textureOptions);
+                this._silhouette.update(this._svgRenderer.canvas);
             }
             if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
             this.setRotationCenter.apply(this, rotationCenter);
             this.emit(Skin.Events.WasAltered);
         });
+    }
+
+    /**
+     * Does this point touch an opaque or translucent point on this skin?
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did it touch?
+     */
+    isTouching (vec) {
+        return this._silhouette.isTouching(vec);
     }
 }
 

--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview
+ * A representation of a Skin's silhouette that can test if a point on the skin
+ * renders a pixel where it is drawn.
+ */
+
+/**
+ * <canvas> element used to update Silhouette data from skin bitmap data.
+ * @type {CanvasElement}
+ */
+let __SilhouetteUpdateCanvas;
+
+class Silhouette {
+    constructor () {
+        /**
+         * The width of the data representing the current skin data.
+         * @type {number}
+         */
+        this._width = 0;
+
+        /**
+         * The height of the data representing the current skin date.
+         * @type {number}
+         */
+        this._height = 0;
+
+        /**
+         * The data representing a skin's silhouette shape.
+         * @type {Uint8ClampedArray}
+         */
+        this._data = null;
+    }
+
+    /**
+     * Update this silhouette with the bitmapData for a skin.
+     * @param {*} bitmapData An image, canvas or other element that the skin
+     * rendering can be queried from.
+     */
+    update (bitmapData) {
+        const canvas = Silhouette._updateCanvas();
+        const width = this._width = canvas.width = bitmapData.width;
+        const height = this._height = canvas.height = bitmapData.height;
+        const ctx = canvas.getContext('2d');
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.drawImage(bitmapData, 0, 0, width, height);
+        const imageData = ctx.getImageData(0, 0, width, height);
+
+        this._data = new Uint8ClampedArray(imageData.data.length / 4);
+
+        for (let i = 0; i < imageData.data.length; i += 4) {
+            this._data[i / 4] = imageData.data[i + 3];
+        }
+    }
+
+    /**
+     * Does this point touch the silhouette?
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did the point touch?
+     */
+    isTouching (vec) {
+        const x = Math.floor(vec[0] * this._width);
+        const y = Math.floor(vec[1] * this._height);
+        return (
+            x < this._width && x >= 0 &&
+            y < this._height && y >= 0 &&
+            this._data[(y * this._width) + x] !== 0);
+    }
+
+    /**
+     * Get the canvas element reused by Silhouettes to update their data with.
+     * @private
+     * @return {CanvasElement} A canvas to draw bitmap data to.
+     */
+    static _updateCanvas () {
+        if (typeof __SilhouetteUpdateCanvas === 'undefined') {
+            __SilhouetteUpdateCanvas = document.createElement('canvas');
+        }
+        return __SilhouetteUpdateCanvas;
+    }
+}
+
+module.exports = Silhouette;

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -115,6 +115,15 @@ class Skin extends EventEmitter {
         this._uniforms.u_skinSize = this.size;
         return this._uniforms;
     }
+
+    /**
+     * Does this point touch an opaque or translucent point on this skin?
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did it touch?
+     */
+    isTouching () {
+        return false;
+    }
 }
 
 /**


### PR DESCRIPTION
### Resolves

#191 #192

Related to https://github.com/LLK/scratch-vm/issues/738

### Proposed Changes

Emulate silhouette rendering with Silhouette and EffectTransform types.

RenderWebGL, Drawable, and Skins use these types to take world and texture coordinates and query the opacity of a point on a Skin instance. Silhouette uses a texture coordinate to lookup a stored cell in its data to determine if the point on the Skin is opaque or translucent. EffectTransform transforms a texture coordinate into another texture coordinate based on a Drawable's effect values. Drawable.isTouching turns a world coordinate into a drawable coordinate and then into a texture coordinate, transforms that into another texture coordinate with EffectTransform and tests the final coordinate with `this.skin.isTouching`.

`pick` uses Drawable.isTouching in place of its past silhouette rendering and reading.

`_getConvexHullPoitnsForDrawable` uses Skin.isTouching and EffectTransform.transformPoint in place of its past silhouette rendering and reading.

#### Terms

I don't write these terms as official ones but to explain their use above.

**world coordinate** A twgl.v3 object with x and y values in scratch's common -240 to 240 x constraint and -180 to 180 y constraint.
**drawable coordinate** A twgl.v3 object with a x value between -0.5 and 0.5 and a y value between -0.5 and 0.5.
**texture coordinate** A twgl.v3 object with a x value between 0 and 1 and a y value between 0 and 1. Unbounded texture coordinates for isTouching methods return false.

### Reason for Changes

`pick` and `_getConvexHullPointsForDrawable` render drawable silhouettes with webgl and read back the pixels. Without combining the silhouette/touching renderings of RenderWebGL into one render per step, `gl.readPixels` will be a performance blocker while it busy waits for the WebGL context to complete its work and return the produced pixel info.

https://scratch.mit.edu/projects/130041250/ as an example case with usage of the above methods, starts by cloning a target 50 times. Each uses `if on edge, bounce` which builds a bounding box with a convex hull. Without a change like https://github.com/LLK/scratch-render/pull/188, each cloning causes all existing clones to rebuild their convex hull. Adding up that can cause systems like a Samsung Chromebook Plus to take up to **a second (<1fps)** for many of the last steps as it approaches 50 clones.

Each clone also checks if they are currently touching the mouse. So even after the 50 clones are no longer rebuilding their convex hull, they each use `RenderWebGL.pick` to see if they are touching the mouse pointer. The same Samsung Chromebook Plus takes anywhere from **180ms to 300ms (~2-12fps)** for each step.

Testing with this PR's change has shown the Samsung Chromebook Plus can run the same project at **~30fps** while cloning (without https://github.com/LLK/scratch-render/pull/188) and an easy **60fps** after.

### Test Coverage

Existing tests don't yet cover `pick` and `_getConvexHullPointsForDrawable`.

### Further Thoughts

This work could probably be extended in later work to also emulate the silhouette and color testing in methods like `RenderWebGL.isTouchingColor` with a new type called something like `ColorBuffer` which performs behaviour like `Silhouette` but returns color information instead of booleans. If we need to support another rendering behaviour like Multi-Sampling Anti-Aliasing (MSAA) we could do that adding support for that in ColorBuffer where the concern would probably best sit.

`_getConvexHullPointsForDrawable` still takes something like 1ms to run for the blocks in https://scratch.mit.edu/projects/130041250/ on a Samsung Chromebook Plus. Some further strategies could be looked into and probably added to Silhouette to cache `boundaryPoints` data. Possibly looping counter clockwise over every row and column finding the "left" most point that isn't empty. Another option may be to build less accurate hulls by stepping over a downscaled version of the same Silhouette data.
