### PR TITLE
Fix ify-loader test on Windows / Cygwin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ const base = {
                 }
             },
             {
-                test: /node_modules\/(linebreak|grapheme-breaker)\/.*\.js$/,
+                test: /node_modules[\\/](linebreak|grapheme-breaker)[\\/].*\.js$/,
                 loader: 'ify-loader'
             }
         ]


### PR DESCRIPTION
### Resolves

This resolves a Windows-specific build problem mentioned by @griffpatch in #193 

### Proposed Changes

This change alters the regex used to determine whether or not to use `ify-loader` for a particular JS source file. The regex is altered such that either forward or backslashes are accepted as path separators, where previously only forward slashes were recognized.

### Reason for Changes

Without this change, attempting to build on Windows will fail in most configurations.
