### PR TITLE
Use bilinear filtering except when we shouldn't

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -40,6 +40,13 @@ class BitmapSkin extends Skin {
     }
 
     /**
+     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
+     */
+    get isRaster () {
+        return true;
+    }
+
+    /**
      * @return {Array<number>} the "native" size, in texels, of this skin.
      */
     get size () {
@@ -71,11 +78,9 @@ class BitmapSkin extends Skin {
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmapData);
             this._silhouette.update(bitmapData);
         } else {
+            // TODO: mipmaps?
             const textureOptions = {
                 auto: true,
-                mag: gl.NEAREST,
-                /** @todo mipmaps, linear (except pixelate) */
-                min: gl.NEAREST,
                 wrap: gl.CLAMP_TO_EDGE,
                 src: bitmapData
             };

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -73,6 +73,13 @@ class PenSkin extends Skin {
     }
 
     /**
+     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
+     */
+    get isRaster () {
+        return true;
+    }
+
+    /**
      * @return {Array<number>} the "native" size, in texels, of this skin. [width, height]
      */
     get size () {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -902,7 +902,6 @@ class RenderWebGL extends EventEmitter {
      * @return {Array.<number, number>} The fenced position as an array [x, y]
      */
     getFencedPositionOfDrawable (drawableID, position) {
-
         let x = position[0];
         let y = position[1];
 
@@ -1096,7 +1095,6 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {
-
         const near = function (a, b, relativeTolerance = 0.01) {
             const absA = Math.abs(a);
             const absB = Math.abs(b);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1096,6 +1096,14 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {
+
+        const near = function (a, b, relativeTolerance = 0.01) {
+            const absA = Math.abs(a);
+            const absB = Math.abs(b);
+            const error = Math.abs(a - b) / Math.max(absA, absB);
+            return error < relativeTolerance;
+        };
+
         const gl = this._gl;
         let currentShader = null;
 
@@ -1117,6 +1125,8 @@ class RenderWebGL extends EventEmitter {
             // If the skin or texture isn't ready yet, skip it.
             if (!drawable.skin || !drawable.skin.getTexture(drawableScale)) continue;
 
+            const uniforms = {};
+
             let effectBits = drawable.getEnabledEffects();
             effectBits &= opts.hasOwnProperty('effectMask') ? opts.effectMask : effectBits;
             const newShader = this._shaderManager.getShader(drawMode, effectBits);
@@ -1124,17 +1134,28 @@ class RenderWebGL extends EventEmitter {
                 currentShader = newShader;
                 gl.useProgram(currentShader.program);
                 twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
-                twgl.setUniforms(currentShader, {u_projectionMatrix: projection});
-                twgl.setUniforms(currentShader, {u_fudge: window.fudge || 0});
+                Object.assign(uniforms, {
+                    u_projectionMatrix: projection,
+                    u_fudge: window.fudge || 0
+                });
             }
 
-            twgl.setUniforms(currentShader, drawable.skin.getUniforms(drawableScale));
-            twgl.setUniforms(currentShader, drawable.getUniforms());
+            Object.assign(uniforms,
+                drawable.skin.getUniforms(drawableScale),
+                drawable.getUniforms());
 
             // Apply extra uniforms after the Drawable's, to allow overwriting.
             if (opts.extraUniforms) {
-                twgl.setUniforms(currentShader, opts.extraUniforms);
+                Object.assign(uniforms, opts.extraUniforms);
             }
+
+            if (uniforms.u_skin) {
+                const useNearest =
+                    (drawable._direction % 90 === 0) && (near(drawableScale, 100) || drawable.skin.isRaster);
+                twgl.setTextureParameters(gl, uniforms.u_skin, {minMag: useNearest ? gl.NEAREST : gl.LINEAR});
+            }
+
+            twgl.setUniforms(currentShader, uniforms);
 
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -81,10 +81,9 @@ class SVGSkin extends Skin {
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
                 this._silhouette.update(this._svgRenderer.canvas);
             } else {
+                // TODO: mipmaps?
                 const textureOptions = {
                     auto: true,
-                    mag: gl.NEAREST,
-                    min: gl.NEAREST, /** @todo mipmaps, linear (except pixelate) */
                     wrap: gl.CLAMP_TO_EDGE,
                     src: this._svgRenderer.canvas
                 };

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -63,6 +63,13 @@ class Skin extends EventEmitter {
     }
 
     /**
+     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
+     */
+    get isRaster () {
+        return false;
+    }
+
+    /**
      * @return {int} the unique ID for this Skin.
      */
     get id () {

--- a/src/util/text-wrapper.js
+++ b/src/util/text-wrapper.js
@@ -20,7 +20,6 @@ const GraphemeBreaker = require('grapheme-breaker');
  * - "JavaScript has a Unicode problem" by Mathias Bynens: https://mathiasbynens.be/notes/javascript-unicode
  */
 class TextWrapper {
-
     /**
      * Construct a text wrapper which will measure text using the specified measurement provider.
      * @param {MeasurementProvider} measurementProvider - a helper object to provide text measurement services.


### PR DESCRIPTION
### Resolves

This resolves #77 and generally makes rendering look a bit better in many situations.

### Proposed Changes

Use bilinear filtering unless the `Drawable` is angled by a multiple of 90 degrees and is either a raster image (like a `BitmapSkin`) or is around its native resoluion. This makes both bitmaps and vectors look better in most cases. This is roughly the same logic that Scratch 2.0 used; we may want to tweak it over time to see if we can make it even better.

### Reason for Changes

Bilinear filtering helps with the "jaggy" appearance that sprites sometimes have, especially bitmap images when rotated to non-right angles (wrong angles?). On the other hand, Scratch has a lot of pixel art that looks fuzzy when bilinear filtering is enabled. This logic offers a decent compromise: use nearest-neighbor filtering when the image is capable of looking sharp on its own, and switch to bilinear filtering when nearest-neighbor is likely to look bad.

### Test Coverage

We have no automated tests for image quality. I set up project 143486954 to help with manual testing of this issue. Press 1, 2, or 3 to toggle the pixelate effect, 45 degree rotation, or 150% scale, respectively, and click the sprite to switch between its costumes.

The main thing to watch out for is a result like this (pixelate and scale on, rotate off). I've tested locally in both high-DPI and normal-DPI screen resolutions and haven't seen this problem with these changes in place.
![image](https://cloud.githubusercontent.com/assets/7019101/22848437/3a48ca7c-efa9-11e6-84c0-cd2b22ec6c40.png)