### PR TITLE
Fix convex hull calculation bug

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1205,7 +1205,7 @@ class RenderWebGL extends EventEmitter {
             // If x is equal to the width there are no touchable points in the
             // skin. Nothing we can add to L. And looping for R would find the
             // same thing.
-            if (x === width) {
+            if (x >= width) {
                 continue;
             }
             // Decrement ll until Q is clockwise (CCW returns negative) from the


### PR DESCRIPTION
Fixes a bug with the convex hull calculation where the bounds could not
be calculated for certain costumes with non-integer sizes.

### Resolves

_What Github issue does this resolve (please include link)?_
Resolves https://github.com/LLK/scratch-render/issues/205

### Proposed Changes

_Describe what this Pull Request does_

Because `width` can be non-integer, check if x has gotten to or surpassed the width value while incrementing.

---
@cwillisf @mzgoddard as I mentioned in the linked issue, this fixes the bug, but I wanted to make sure this doesn't ring any alarm bells or follow-up work. 
