### PR TITLE
Fix double render issue by clearing canvas just before drawing

### DIFF
--- a/src/svg-quirks-mode/svg-renderer.js
+++ b/src/svg-quirks-mode/svg-renderer.js
@@ -299,15 +299,14 @@ class SvgRenderer {
         const ratio = this.getDrawRatio();
         const bbox = this._measurements;
 
-        // Set up the canvas for drawing.
-        this._canvas.width = bbox.width * ratio;
-        this._canvas.height = bbox.height * ratio;
-        this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
-        this._context.scale(ratio, ratio);
-
         // Convert the SVG text to an Image, and then draw it to the canvas.
         const img = new Image();
         img.onload = () => {
+            // Set up the canvas for drawing.
+            this._canvas.width = bbox.width * ratio;
+            this._canvas.height = bbox.height * ratio;
+            this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+            this._context.scale(ratio, ratio);
             this._context.drawImage(img, 0, 0);
             // Reset the canvas transform after drawing.
             this._context.setTransform(1, 0, 0, 1, 0, 0);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-render/issues/200

### Proposed Changes

_Describe what this Pull Request does_

Instead of clearing/scaling the canvas and then waiting for the image to load, clear and scale the canvas after the image has loaded and directly before drawing the image. That makes sure loading two things very quickly doesn't cause two things from being rendered, or scaling in crazy ways. 

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_

I can't actually repro the exact issue from chris' demo in the issue, but I can get a similar thing if I load a say/think at the same time and I can see both. 

Before
![image](https://user-images.githubusercontent.com/654102/33489683-95f44fc0-d682-11e7-8c8d-ccf22f3a3019.png)

After this fix
![image](https://user-images.githubusercontent.com/654102/33489660-85426afe-d682-11e7-9203-a783cbd435ec.png)


If you are playing along at home, you can also get this to happen by rendering two svg skins in the playground with this code:
```
    var url1 = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/09dc888b0b7df19f70d81588ae73420e.svg/get/';
    var url2 = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/a01d31caaab3b14b9bb0e2cd5a86c70c.svg/get/'
    fetch(url1).then((d) => {
        return d.text();
    }).then((svg1) => {
        fetch(url2).then((d) => {
            return d.text();
        }).then((svg2) => {
            renderer.updateSVGSkin(skinId, svg1, [0, 0]);
            renderer.updateSVGSkin(skinId, svg2, [0, 0]);
        });
    })
```

Which results in a monstrous cat-dinosaur frankanimal before the fix
![image](https://user-images.githubusercontent.com/654102/33489912-67f1889e-d683-11e7-8444-b112768d6209.png)

And a normal (subdued? forlorn perhaps?) dinosaur after this fix
![image](https://user-images.githubusercontent.com/654102/33489974-8e807ca4-d683-11e7-8fa9-dfa18ab3466b.png)

