### PR TITLE
Fix mobile color bug

### DIFF
--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -43,24 +43,44 @@ varying vec2 v_texCoord;
 // Branchless color conversions based on code from:
 // http://www.chilliant.com/rgb2hsv.html by Ian Taylor
 // Based in part on work by Sam Hocevar and Emil Persson
+// See also: https://en.wikipedia.org/wiki/HSL_and_HSV#Formal_derivation
 
+// Smaller values can cause problems with "color" and "brightness" effects on some mobile devices
 const float kEpsilon = 1e-4;
 
-vec3 convertRGB2HCV(vec3 rgb)
-{
-	vec4 p = (rgb.g < rgb.b) ? vec4(rgb.bg, -1, 2.0/3.0) : vec4(rgb.gb, 0, -1.0/3.0);
-	vec4 q = (rgb.r < p.x) ? vec4(p.xyw, rgb.r) : vec4(rgb.r, p.yzx);
-	float c = q.x - min(q.w, q.y);
-	float h = abs((q.w - q.y) / (6.0 * c + kEpsilon) + q.z);
-	return vec3(h, c, q.x);
-}
-
+// Convert an RGB color to Hue, Saturation, and Lightness.
+// All components of input and output are expected to be in the [0,1] range.
 vec3 convertRGB2HSL(vec3 rgb)
 {
-	vec3 hcv = convertRGB2HCV(rgb);
-	float l = hcv.z - hcv.y * 0.5;
-	float s = hcv.y / (1.0 - abs(l * 2.0 - 1.0) + kEpsilon);
-	return vec3(hcv.x, s, l);
+	// Hue calculation has 3 cases, depending on which RGB component is largest, and one of those cases involves a "mod"
+	// operation. In order to avoid that "mod" we split the M==R case in two: one for G<B and one for B>G. The B>G case
+	// will be calculated in the negative and fed through abs() in the hue calculation at the end.
+	// See also: https://en.wikipedia.org/wiki/HSL_and_HSV#Hue_and_chroma
+	const vec4 hueOffsets = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+
+	// temp1.xy = sort B & G (largest first)
+	// temp1.z = the hue offset we'll use if it turns out that R is the largest component (M==R)
+	// temp1.w = the hue offset we'll use if it turns out that R is not the largest component (M==G or M==B)
+	vec4 temp1 = rgb.b > rgb.g ? vec4(rgb.bg, hueOffsets.wz) : vec4(rgb.gb, hueOffsets.xy);
+
+	// temp2.x = the largest component of RGB ("M" / "Max")
+	// temp2.yw = the smaller components of RGB, ordered for the hue calculation (not necessarily sorted by magnitude!)
+	// temp2.z = the hue offset we'll use in the hue calculation
+	vec4 temp2 = rgb.r > temp1.x ? vec4(rgb.r, temp1.yzx) : vec4(temp1.xyw, rgb.r);
+
+	// m = the smallest component of RGB ("min")
+	float m = min(temp2.y, temp2.w);
+
+	// Chroma = M - m
+	float C = temp2.x - m;
+
+	// Lightness = 1/2 * (M + m)
+	float L = 0.5 * (temp2.x + m);
+
+	return vec3(
+		abs(temp2.z + (temp2.w - temp2.y) / (6.0 * C + kEpsilon)), // Hue
+		C / (1.0 - abs(2.0 * L - 1.0) + kEpsilon), // Saturation
+		L); // Lightness
 }
 
 vec3 convertHue2RGB(float hue)

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -44,7 +44,7 @@ varying vec2 v_texCoord;
 // http://www.chilliant.com/rgb2hsv.html by Ian Taylor
 // Based in part on work by Sam Hocevar and Emil Persson
 
-const float kEpsilon = 1e-6;
+const float kEpsilon = 1e-4;
 
 vec3 convertRGB2HCV(vec3 rgb)
 {

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -46,7 +46,7 @@ varying vec2 v_texCoord;
 // See also: https://en.wikipedia.org/wiki/HSL_and_HSV#Formal_derivation
 
 // Smaller values can cause problems with "color" and "brightness" effects on some mobile devices
-const float kEpsilon = 1e-4;
+const float epsilon = 1e-4;
 
 // Convert an RGB color to Hue, Saturation, and Lightness.
 // All components of input and output are expected to be in the [0,1] range.
@@ -78,8 +78,8 @@ vec3 convertRGB2HSL(vec3 rgb)
 	float L = 0.5 * (temp2.x + m);
 
 	return vec3(
-		abs(temp2.z + (temp2.w - temp2.y) / (6.0 * C + kEpsilon)), // Hue
-		C / (1.0 - abs(2.0 * L - 1.0) + kEpsilon), // Saturation
+		abs(temp2.z + (temp2.w - temp2.y) / (6.0 * C + epsilon)), // Hue
+		C / (1.0 - abs(2.0 * L - 1.0) + epsilon), // Saturation
 		L); // Lightness
 }
 


### PR DESCRIPTION
### Resolves

Resolves #168

### Proposed Changes

This PR includes two changes:
- Adjust the value of `kEpsilon` for compatibility with mobile GPUs operating at a lower precision
- Simplify the `convertRGB2HSL` function and add comments explaining each step of the algorithm

### Reason for Changes

The `convertRGB2HSL` function does a few division operations where the denominator can sometimes be zero. In the formal definition these steps are defined piecewise, such as "S = { 0 if L=1, or C/(1-abs(2*L-1)) otherwise," which avoids the possibility of a division by zero. Since these cases always correspond to numerator of zero as well, though, we can avoid the conditional by adding a small "epsilon" value to the denominator. If the value is small enough it won't cause a significant difference in the output of the function, which will eventually (after adjustment by the color or brightness effect and conversion back to RGB) be quantized to 8 bits per channel anyway.

The problem with the old epsilon value is that on some mobile devices -- whether it's because they ignore the precision specification at the top of the shader, or perform certain operations at a lower precision, or maybe even just contain bugs -- the old value was too small to "count" as a non-zero denominator. This led to a divide-by-zero, resulting in `NaN`, which "infected" all components during the HSL-to-RGB conversion later. This would be rendered as black, when generally this case was triggered by white (L=1) as the input color.

I also simplified and commented the shader code for three reasons:
- The more of our code that can be understood by contributors and ATers, the better.
- I didn't fully understand the algorithm before, and I wanted to make it easier for myself and for others on the team to work on this code later.
- The new version may execute slightly faster, depending on details of the shader compiler (part of the video driver), but certainly shouldn't execute any slower.

### Test Coverage

We don't currently have any way to test visual output automatically, but I have tested this on a few mobile devices which previously exhibited the problem in #168 but now give correct results.

To test this yourself you can load project 24542731 in the Scratch 3.0 editor or `player.html` and press the green flag. Expected results:
- the orange areas of the cat should turn blue
- the black and white areas of the cat should remain unchanged
