### PR TITLE
Exclude hidden drawables from picking.

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -594,7 +594,8 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
-     * Detect which sprite, if any, is at the given location.
+     * Detect which sprite, if any, is at the given location. This function will not
+     * pick drawables that are not visible or have ghost set all the way up.
      * @param {int} centerX The client x coordinate of the picking location.
      * @param {int} centerY The client y coordinate of the picking location.
      * @param {int} touchWidth The client width of the touch event (optional).
@@ -608,7 +609,11 @@ class RenderWebGL extends EventEmitter {
 
         touchWidth = touchWidth || 1;
         touchHeight = touchHeight || 1;
-        candidateIDs = candidateIDs || this._drawList;
+        candidateIDs = (candidateIDs || this._drawList).filter(id => {
+            const drawable = this._allDrawables[id];
+            const uniforms = drawable.getUniforms();
+            return drawable.getVisible() && uniforms.u_ghost !== 0;
+        });
 
         const clientToGLX = gl.canvas.width / gl.canvas.clientWidth;
         const clientToGLY = gl.canvas.height / gl.canvas.clientHeight;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/1007. That project specifically suffered from the "ghost at 100" problem, but also noticed and fixed the "invisible overlay" problem also. 

### Proposed Changes

_Describe what this Pull Request does_

Filter out non-visible drawables from the default pick list (and from a passed in pick list). Don't pick invisible things. They aren't visible. So don't pick them. How could you? :)

### Reason for Changes

_Explain why these changes should be made_

Incompatible with scratch 2. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested the projects that were giving us problems with compatibility in linked issue.