### PR TITLE
Ignore sprite visibility when testing for touching color

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1118,7 +1118,8 @@ class RenderWebGL extends EventEmitter {
             const drawable = this._allDrawables[drawableID];
             /** @todo check if drawable is inside the viewport before anything else */
 
-            // Hidden drawables (e.g., by a "hide" block) are not drawn unless stamping
+            // Hidden drawables (e.g., by a "hide" block) are not drawn unless
+            // the ignoreVisibility flag is used (e.g. for stamping or touchingColor).
             if (!drawable.getVisible() && !opts.ignoreVisibility) continue;
 
             const drawableScale = drawable.scale;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -436,11 +436,11 @@ class RenderWebGL extends EventEmitter {
 
         const bounds = this._touchingBounds(drawableID);
         if (!bounds) {
-            return;
+            return false;
         }
         const candidateIDs = this._filterCandidatesTouching(drawableID, this._drawList, bounds);
         if (!candidateIDs) {
-            return;
+            return false;
         }
 
         // Limit size of viewport to the bounds around the target Drawable,
@@ -537,11 +537,11 @@ class RenderWebGL extends EventEmitter {
 
         const bounds = this._touchingBounds(drawableID);
         if (!bounds) {
-            return;
+            return false;
         }
         candidateIDs = this._filterCandidatesTouching(drawableID, candidateIDs, bounds);
         if (!candidateIDs) {
-            return;
+            return false;
         }
 
         // Limit size of viewport to the bounds around the target Drawable,

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -424,6 +424,7 @@ class RenderWebGL extends EventEmitter {
 
     /**
      * Check if a particular Drawable is touching a particular color.
+     * Unlike touching drawable, touching color tests invisible sprites.
      * @param {int} drawableID The ID of the Drawable to check.
      * @param {Array<int>} color3b Test if the Drawable is touching this color.
      * @param {Array<int>} [mask3b] Optionally mask the check to this part of Drawable.
@@ -477,7 +478,10 @@ class RenderWebGL extends EventEmitter {
                     ShaderManager.DRAW_MODE.colorMask :
                     ShaderManager.DRAW_MODE.silhouette,
                 projection,
-                {extraUniforms});
+                {
+                    extraUniforms,
+                    ignoreVisibility: true // Touching color ignores sprite visibility
+                });
 
             gl.stencilFunc(gl.EQUAL, 1, 1);
             gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
@@ -1003,7 +1007,7 @@ class RenderWebGL extends EventEmitter {
 
         try {
             gl.disable(gl.BLEND);
-            this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection, {isStamping: true});
+            this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection, {ignoreVisibility: true});
         } finally {
             gl.enable(gl.BLEND);
         }
@@ -1097,7 +1101,7 @@ class RenderWebGL extends EventEmitter {
      * @param {idFilterFunc} opts.filter An optional filter function.
      * @param {object.<string,*>} opts.extraUniforms Extra uniforms for the shaders.
      * @param {int} opts.effectMask Bitmask for effects to allow
-     * @param {boolean} opts.isStamping Stamp mode ignores sprite visibility, always drawing.
+     * @param {boolean} opts.ignoreVisibility Draw all, despite visibility (e.g. stamping, touching color)
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {
@@ -1115,7 +1119,7 @@ class RenderWebGL extends EventEmitter {
             /** @todo check if drawable is inside the viewport before anything else */
 
             // Hidden drawables (e.g., by a "hide" block) are not drawn unless stamping
-            if (!drawable.getVisible() && !opts.isStamping) continue;
+            if (!drawable.getVisible() && !opts.ignoreVisibility) continue;
 
             const drawableScale = drawable.scale;
 


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-render/issues/212

### Proposed Changes

_Describe what this Pull Request does_

Make the draw step of the touching color test ignore sprite visibility. Use the same flag as `isStamping` but rename for more general use case.

Also return `false` when there are no candidate sprites to test nearby, instead of returning undefined.

### Reason for Changes

_Explain why these changes should be made_

To bring the touching color behavior in line with scratch 2. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Tested the demo project I made in the linked issue. Now it matches scratch 2

![image](https://user-images.githubusercontent.com/654102/33777609-8514c946-dc13-11e7-95ac-b47dbcef6aa7.png)

![image](https://user-images.githubusercontent.com/654102/33777613-86612952-dc13-11e7-9c3f-927f5e5724b1.png)

