### PR TITLE
Escape xml before putting user text into text bubble

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "travis-after-all": "^1.4.4",
     "twgl.js": "3.7.0",
     "webpack": "^3.10.0",
-    "webpack-dev-server": "^2.8.2"
+    "webpack-dev-server": "^2.8.2",
+    "xml-escape": "1.1.0"
   }
 }

--- a/src/util/svg-text-bubble.js
+++ b/src/util/svg-text-bubble.js
@@ -1,5 +1,6 @@
 const SVGTextWrapper = require('./svg-text-wrapper');
 const SVGRenderer = require('../svg-quirks-mode/svg-renderer');
+const xmlescape = require('xml-escape');
 
 const MAX_LINE_LENGTH = 170;
 const MIN_WIDTH = 50;
@@ -148,7 +149,7 @@ class SVGTextBubble {
     }
 
     _textFragment () {
-        return `<text fill="#575E75">${this.lines.join('\n')}</text>`;
+        return `<text fill="#575E75">${xmlescape(this.lines.join('\n'))}</text>`;
     }
 
     buildString (type, text, pointsLeft) {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-render/issues/222

### Proposed Changes

_Describe what this Pull Request does_
Use `escape-xml` package to escape the input text before putting it into the svg template.

### Reason for Changes

_Explain why these changes should be made_
Previously, this would throw errors:

![image](https://user-images.githubusercontent.com/654102/34731206-a9db5b0c-f52f-11e7-91b2-ad6e5d59f459.png)

### Test Coverage

_Please show how you have added tests to cover your changes_

Above project ^