### PR TITLE
Check & report if browser supports this renderer

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -59,6 +59,31 @@ const FENCE_WIDTH = 15;
 
 class RenderWebGL extends EventEmitter {
     /**
+     * Check if this environment appears to support this renderer before attempting to create an instance.
+     * Catching an exception from the constructor is also a valid way to test for (lack of) support.
+     * @param {canvas} [optCanvas] - An optional canvas to use for the test. Otherwise a temporary canvas will be used.
+     * @returns {boolean} - True if this environment appears to support this renderer, false otherwise.
+     */
+    static isSupported (optCanvas) {
+        try {
+            // Create the context the same way that the constructor will: attributes may make the difference.
+            return !!RenderWebGL._getContext(optCanvas || document.createElement('canvas'));
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
+     * Ask TWGL to create a rendering context with the attributes used by this renderer.
+     * @param {canvas} canvas - attach the context to this canvas.
+     * @returns {WebGLRenderingContext} - a TWGL rendering context (backed by either WebGL 1.0 or 2.0).
+     * @private
+     */
+    static _getContext (canvas) {
+        return twgl.getContext(canvas, {alpha: false, stencil: true});
+    }
+
+    /**
      * Create a renderer for drawing Scratch sprites to a canvas using WebGL.
      * Coordinates will default to Scratch 2.0 values if unspecified.
      * The stage's "native" size will be calculated from the these coordinates.
@@ -77,6 +102,12 @@ class RenderWebGL extends EventEmitter {
     constructor (canvas, xLeft, xRight, yBottom, yTop) {
         super();
 
+        /** @type {WebGLRenderingContext} */
+        const gl = this._gl = RenderWebGL._getContext(canvas);
+        if (!gl) {
+            throw new Error('Could not get WebGL context: this browser or environment may not support WebGL.');
+        }
+
         /** @type {Drawable[]} */
         this._allDrawables = [];
 
@@ -85,9 +116,6 @@ class RenderWebGL extends EventEmitter {
 
         /** @type {Array<int>} */
         this._drawList = [];
-
-        /** @type {WebGLRenderingContext} */
-        const gl = this._gl = twgl.getWebGLContext(canvas, {alpha: false, stencil: true});
 
         /** @type {int} */
         this._nextDrawableId = RenderConstants.ID_NONE + 1;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -80,7 +80,7 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     static _getContext (canvas) {
-        return twgl.getContext(canvas, {alpha: false, stencil: true});
+        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true});
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves #220 

### Proposed Changes

`RenderWebGL`'s constructor will now throw if TWGL init fails. There's also a new static method to check whether or not we expect TWGL init to succeed.

### Reason for Changes

This will prevent a flood of errors if the renderer thinks it's working but has no WebGL context. The new `isSupported` method can be used by client code (such as in `scratch-gui`) to provide feedback to the user outside of renderer-construction time. 

### Test Coverage

Because this code depends on the browser so heavily it's not possible to test it automatically on our current test framework. I did test it in a few situations, with and without WebGL, WebGL 1 and 2, and it seems to do the right thing.