### PR TITLE
Add "get bounds for bubble" method.

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -304,26 +304,32 @@ class Drawable {
         if (this._transformDirty) {
             this._calculateTransform();
         }
-        // First, transform all the convex hull points by the current Drawable's
-        // transform. This allows us to skip recalculating the convex hull
-        // for many Drawable updates, including translation, rotation, scaling.
-        const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
-        const skinSize = this.skin.size;
-        const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
-        const transformedHullPoints = [];
-        for (let i = 0; i < this._convexHullPoints.length; i++) {
-            const point = this._convexHullPoints[i];
-            const glPoint = twgl.v3.create(
-                0.5 + (-point[0] / skinSize[0]),
-                0.5 + (-point[1] / skinSize[1]),
-                0
-            );
-            twgl.m4.transformPoint(tm, glPoint, glPoint);
-            transformedHullPoints.push(glPoint);
-        }
+        const transformedHullPoints = this._getTransformedHullPoints();
         // Search through transformed points to generate box on axes.
         const bounds = new Rectangle();
         bounds.initFromPointsAABB(transformedHullPoints);
+        return bounds;
+    }
+    /**
+     * Get the precise bounds for the upper 8px slice of the Drawable.
+     * Used for calculating where to position a text bubble.
+     * Before calling this, ensure the renderer has updated convex hull points.
+     * @return {!Rectangle} Bounds for a tight box around a slice of the Drawable.
+     */
+    getBoundsForBubble () {
+        if (this.needsConvexHullPoints()) {
+            throw new Error('Needs updated convex hull points before bubble bounds calculation.');
+        }
+        if (this._transformDirty) {
+            this._calculateTransform();
+        }
+        const slice = 8; // px, how tall the top slice to measure should be.
+        const transformedHullPoints = this._getTransformedHullPoints();
+        const maxY = Math.max.apply(null, transformedHullPoints.map(p => p[1]));
+        const filteredHullPoints = transformedHullPoints.filter(p => p[1] > maxY - slice);
+        // Search through filtered points to generate box on axes.
+        const bounds = new Rectangle();
+        bounds.initFromPointsAABB(filteredHullPoints);
         return bounds;
     }
 
@@ -362,6 +368,31 @@ class Drawable {
             return this.getBounds();
         }
         return this.getAABB();
+    }
+
+    /**
+     * Transform all the convex hull points by the current Drawable's
+     * transform. This allows us to skip recalculating the convex hull
+     * for many Drawable updates, including translation, rotation, scaling.
+     * @return {!Array.<!Array.number>} Array of glPoints which are Array<x, y>
+     * @private
+     */
+    _getTransformedHullPoints () {
+        const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
+        const skinSize = this.skin.size;
+        const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
+        const transformedHullPoints = [];
+        for (let i = 0; i < this._convexHullPoints.length; i++) {
+            const point = this._convexHullPoints[i];
+            const glPoint = twgl.v3.create(
+                0.5 + (-point[0] / skinSize[0]),
+                (point[1] / skinSize[1]) - 0.5,
+                0
+            );
+            twgl.m4.transformPoint(tm, glPoint, glPoint);
+            transformedHullPoints.push(glPoint);
+        }
+        return transformedHullPoints;
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -441,6 +441,39 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
+     * Get the precise bounds for a Drawable around the top slice.
+     * Used for positioning speech bubbles more closely to the sprite.
+     * @param {int} drawableID ID of Drawable to get bubble bounds for.
+     * @return {object} Bounds for a tight box around the Drawable top slice.
+     */
+    getBoundsForBubble (drawableID) {
+        const drawable = this._allDrawables[drawableID];
+        // Tell the Drawable about its updated convex hull, if necessary.
+        if (drawable.needsConvexHullPoints()) {
+            const points = this._getConvexHullPointsForDrawable(drawableID);
+            drawable.setConvexHullPoints(points);
+        }
+        const bounds = drawable.getBoundsForBubble();
+        // In debug mode, draw the bounds.
+        if (this._debugCanvas) {
+            const gl = this._gl;
+            this._debugCanvas.width = gl.canvas.width;
+            this._debugCanvas.height = gl.canvas.height;
+            const context = this._debugCanvas.getContext('2d');
+            context.drawImage(gl.canvas, 0, 0);
+            context.strokeStyle = '#FF0000';
+            const pr = window.devicePixelRatio;
+            context.strokeRect(
+                pr * (bounds.left + (this._nativeSize[0] / 2)),
+                pr * (-bounds.top + (this._nativeSize[1] / 2)),
+                pr * (bounds.right - bounds.left),
+                pr * (-bounds.bottom + bounds.top)
+            );
+        }
+        return bounds;
+    }
+
+    /**
      * Get the current skin (costume) size of a Drawable.
      * @param {int} drawableID The ID of the Drawable to measure.
      * @return {Array<number>} Skin size, width and height.


### PR DESCRIPTION
Note there was an inconsequential coordinate flip in the original
transformation code, which was fixed in order for the sliced bounds to
work. The change is at line 388

### Resolves

_What Github issue does this resolve (please include link)?_

Part of fixing https://github.com/LLK/scratch-gui/issues/1591 and https://github.com/LLK/scratch-gui/issues/1568

### Proposed Changes

_Describe what this Pull Request does_

Add a new method for retrieving the bounds around a thin strip at the top of a drawable.
