### PR TITLE
Add method for getting the size of a skin by skin id.

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -478,9 +478,19 @@ class RenderWebGL extends EventEmitter {
      * @param {int} drawableID The ID of the Drawable to measure.
      * @return {Array<number>} Skin size, width and height.
      */
-    getSkinSize (drawableID) {
+    getCurrentSkinSize (drawableID) {
         const drawable = this._allDrawables[drawableID];
-        return drawable.skin.size;
+        return this.getSkinSize(drawable.skin.id);
+    }
+
+    /**
+     * Get the size of a skin by ID.
+     * @param {int} skinID The ID of the Skin to measure.
+     * @return {Array<number>} Skin size, width and height.
+     */
+    getSkinSize (skinID) {
+        const skin = this._allSkins[skinID];
+        return skin.size;
     }
 
     /**


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Required to complete https://github.com/LLK/scratch-gui/pull/1754

### Proposed Changes

_Describe what this Pull Request does_

Renamed the `getSkinSize` method to `getCurrentSkinSize`, since it was
using the drawables current skin. Added a new `getSkinSize` method that
works by skin id.

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
