### PR TITLE
Calculate bitmap resolution

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -100,6 +100,12 @@ class BitmapSkin extends Skin {
         this.emit(Skin.Events.WasAltered);
     }
 
+    /**
+     * Calculate the bitmap resolution for the skin based on its texture size.
+     * @return {number} The bitmap resolution -
+     * 1 - if the skin is smaller than double the native stage size
+     * 2 - if the skin is double the native stage size or larger
+     */
     calculateBitmapResolution () {
         // Calculate what the bitmap resolution should be given the texture size
         const textureWidth = this._textureSize[0];
@@ -107,9 +113,7 @@ class BitmapSkin extends Skin {
         const [stageNativeWidth, stageNativeHeight] = this._renderer.getNativeSize();
         const doubleStageWidth = 2 * stageNativeWidth;
         const doubleStageHeight = 2 * stageNativeHeight;
-        if (textureWidth >= doubleStageWidth && textureHeight >= doubleStageHeight) {
-            return 2;
-        }
+        if (textureWidth >= doubleStageWidth && textureHeight >= doubleStageHeight) return 2;
         return 1;
     }
 

--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -90,13 +90,27 @@ class BitmapSkin extends Skin {
         }
 
         // Do these last in case any of the above throws an exception
-        this._costumeResolution = costumeResolution || 1;
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
+        this._costumeResolution = costumeResolution || this.calculateBitmapResolution();
+
 
         if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
         this.setRotationCenter.apply(this, rotationCenter);
 
         this.emit(Skin.Events.WasAltered);
+    }
+
+    calculateBitmapResolution () {
+        // Calculate what the bitmap resolution should be given the texture size
+        const textureWidth = this._textureSize[0];
+        const textureHeight = this._textureSize[1];
+        const [stageNativeWidth, stageNativeHeight] = this._renderer.getNativeSize();
+        const doubleStageWidth = 2 * stageNativeWidth;
+        const doubleStageHeight = 2 * stageNativeHeight;
+        if (textureWidth >= doubleStageWidth && textureHeight >= doubleStageHeight) {
+            return 2;
+        }
+        return 1;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Towards resolving LLK/scratch-gui#1777

### Proposed Changes

Determine whether or not to scale the bitmap skin by one half based on the skin size.

### Reason for Changes

Uploading a large costume from an unpacked .sb2 gives different results than uploading the .sb2 itself.
It might also be nice to scale down a bitmap if it's larger than double the stage size... but we're a little less decided on that issue...

### Test Coverage

Existing tests pass.
