### PR TITLE
getSkinRotationCenter API and support for new scratch-svg-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "json": "^9.0.4",
     "linebreak": "0.3.0",
     "raw-loader": "^0.5.1",
-    "scratch-svg-renderer": "0.1.0-prerelease.20180329174139",
+    "scratch-svg-renderer": "0.1.0-prerelease.20180423193917",
     "tap": "^11.0.0",
     "travis-after-all": "^1.4.4",
     "twgl.js": "4.4.0",

--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -90,7 +90,7 @@ class BitmapSkin extends Skin {
         }
 
         // Do these last in case any of the above throws an exception
-        this._costumeResolution = costumeResolution || 1;
+        this._costumeResolution = costumeResolution || 2;
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
 
         if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -494,6 +494,16 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
+     * Get the rotation center of a skin by ID.
+     * @param {int} skinID The ID of the Skin
+     * @return {Array<number>} The rotationCenterX and rotationCenterY
+     */
+    getSkinRotationCenter (skinID) {
+        const skin = this._allSkins[skinID];
+        return skin.calculateRotationCenter();
+    }
+
+    /**
      * Check if a particular Drawable is touching a particular color.
      * Unlike touching drawable, touching color tests invisible sprites.
      * @param {int} drawableID The ID of the Drawable to check.

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -2,7 +2,7 @@ const twgl = require('twgl.js');
 
 const Silhouette = require('./Silhouette');
 const Skin = require('./Skin');
-const SvgRenderer = require('scratch-svg-renderer');
+const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 
 const MAX_TEXTURE_DIMENSION = 2048;
 

--- a/src/util/svg-text-bubble.js
+++ b/src/util/svg-text-bubble.js
@@ -1,5 +1,5 @@
 const SVGTextWrapper = require('./svg-text-wrapper');
-const SvgRenderer = require('scratch-svg-renderer');
+const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 const xmlescape = require('xml-escape');
 
 const MAX_LINE_LENGTH = 170;


### PR DESCRIPTION
### Resolves

Towards resolving LLK/scratch-gui#1777

### Proposed Changes

Provides a top level api for calculating a given skin's rotation center.

### Reason for Changes

In support of LLK/scratch-gui#1836 and LLK/scratch-vm#1075. Uploaded files don't have rotation centers associated with them, so they should be set correctly (when loading a costume in the VM), so that the paint editor can also access them.

### Test Coverage

Existing tests pass.