### PR TITLE
Optimize isTouchingDrawables to use Silhouette

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -1,7 +1,6 @@
 const twgl = require('twgl.js');
 
 const Skin = require('./Skin');
-const Silhouette = require('./Silhouette');
 
 class BitmapSkin extends Skin {
     /**
@@ -24,8 +23,6 @@ class BitmapSkin extends Skin {
 
         /** @type {Array<int>} */
         this._textureSize = [0, 0];
-
-        this._silhouette = new Silhouette();
     }
 
     /**
@@ -117,14 +114,6 @@ class BitmapSkin extends Skin {
         return [bitmapData.width, bitmapData.height];
     }
 
-    /**
-     * Does this point touch an opaque or translucent point on this skin?
-     * @param {twgl.v3} vec A texture coordinate.
-     * @return {boolean} Did it touch?
-     */
-    isTouching (vec) {
-        return this._silhouette.isTouching(vec);
-    }
 }
 
 module.exports = BitmapSkin;

--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -26,10 +26,9 @@ class EffectTransform {
      * @param {Drawable} drawable The drawable whose effects to emulate.
      * @param {twgl.v3} vec The texture coordinate to transform.
      * @param {?twgl.v3} dst A place to store the output coordinate.
-     * @return {twgl.v3} The coordinate after being transform by effects.
+     * @return {twgl.v3} dst - The coordinate after being transform by effects.
      */
-    static transformPoint (drawable, vec, dst) {
-        dst = dst || twgl.v3.create();
+    static transformPoint (drawable, vec, dst = twgl.v3.create()) {
         twgl.v3.copy(vec, dst);
 
         const uniforms = drawable.getUniforms();

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -2,7 +2,6 @@ const twgl = require('twgl.js');
 
 const RenderConstants = require('./RenderConstants');
 const Skin = require('./Skin');
-const Silhouette = require('./Silhouette');
 
 /**
  * Attributes to use when drawing with the pen
@@ -49,9 +48,6 @@ class PenSkin extends Skin {
 
         /** @type {WebGLTexture} */
         this._texture = null;
-
-        /** @type {Silhouette} */
-        this._silhouette = new Silhouette();
 
         /** @type {boolean} */
         this._silhouetteDirty = false;
@@ -214,18 +210,16 @@ class PenSkin extends Skin {
     }
 
     /**
-     * Does this point touch an opaque or translucent point on this skin?
-     * @param {twgl.v3} vec A texture coordinate.
-     * @return {boolean} Did it touch?
+     * If there have been pen operations that have dirtied the canvas, update
+     * now before someone wants to use our silhouette.
      */
-    isTouching (vec) {
+    updateSilhouette () {
         if (this._silhouetteDirty) {
             if (this._canvasDirty) {
                 this.getTexture();
             }
             this._silhouette.update(this._canvas);
         }
-        return this._silhouette.isTouching(vec);
     }
 }
 

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -35,6 +35,7 @@ class Rectangle {
         this.right = -Infinity;
         this.top = -Infinity;
         this.bottom = Infinity;
+
         for (let i = 0; i < points.length; i++) {
             const x = points[i][0];
             const y = points[i][1];
@@ -115,6 +116,41 @@ class Rectangle {
     }
 
     /**
+     * Compute the intersection of two bounding Rectangles.
+     * Could be an impossible box if they don't intersect.
+     * @param {Rectangle} a One rectangle
+     * @param {Rectangle} b Other rectangle
+     * @param {?Rectangle} result A resulting storage rectangle  (safe to pass
+     *                            a or b if you want to overwrite one)
+     * @returns {Rectangle} resulting rectangle
+     */
+    static intersect (a, b, result = new Rectangle()) {
+        result.left = Math.max(a.left, b.left);
+        result.right = Math.min(a.right, b.right);
+        result.top = Math.min(a.top, b.top);
+        result.bottom = Math.max(a.bottom, b.bottom);
+
+        return result;
+    }
+
+    /**
+     * Compute the union of two bounding Rectangles.
+     * @param {Rectangle} a One rectangle
+     * @param {Rectangle} b Other rectangle
+     * @param {?Rectangle} result A resulting storage rectangle  (safe to pass
+     *                            a or b if you want to overwrite one)
+     * @returns {Rectangle} resulting rectangle
+     */
+    static union (a, b, result = new Rectangle()) {
+        result.left = Math.min(a.left, b.left);
+        result.right = Math.max(a.right, b.right);
+        // Scratch Space - +y is up
+        result.top = Math.max(a.top, b.top);
+        result.bottom = Math.min(a.bottom, b.bottom);
+        return result;
+    }
+
+    /**
      * Width of the Rectangle.
      * @return {number} Width of rectangle.
      */
@@ -129,6 +165,7 @@ class Rectangle {
     get height () {
         return Math.abs(this.top - this.bottom);
     }
+
 }
 
 module.exports = Rectangle;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -13,6 +13,9 @@ const SVGSkin = require('./SVGSkin');
 const SVGTextBubble = require('./util/svg-text-bubble');
 const EffectTransform = require('./EffectTransform');
 
+const __isTouchingDrawablesPoint = twgl.v3.create();
+const __candidatesBounds = new Rectangle();
+
 /**
  * @callback RenderWebGL#idFilterFunc
  * @param {int} drawableID The ID to filter.
@@ -515,14 +518,14 @@ class RenderWebGL extends EventEmitter {
         const gl = this._gl;
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
 
-        const bounds = this._touchingBounds(drawableID);
-        if (!bounds) {
+        const candidates = this._candidatesTouching(drawableID, this._drawList);
+        if (candidates.length === 0) {
             return false;
         }
-        const candidateIDs = this._filterCandidatesTouching(drawableID, this._drawList, bounds);
-        if (!candidateIDs) {
-            return false;
-        }
+
+        const bounds = this._candidatesBounds(candidates);
+
+        const candidateIDs = candidates.map(({id}) => id);
 
         // Limit size of viewport to the bounds around the target Drawable,
         // and create the projection matrix for the draw.
@@ -606,72 +609,36 @@ class RenderWebGL extends EventEmitter {
     /**
      * Check if a particular Drawable is touching any in a set of Drawables.
      * @param {int} drawableID The ID of the Drawable to check.
-     * @param {Array<int>} candidateIDs The Drawable IDs to check, otherwise all.
-     * @returns {boolean} True iff the Drawable is touching one of candidateIDs.
+     * @param {?Array<int>} candidateIDs The Drawable IDs to check, otherwise all drawables in the renderer
+     * @returns {boolean} True if the Drawable is touching one of candidateIDs.
      */
-    isTouchingDrawables (drawableID, candidateIDs) {
-        candidateIDs = candidateIDs || this._drawList;
+    isTouchingDrawables (drawableID, candidateIDs = this._drawList) {
 
-        const gl = this._gl;
-
-        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
-
-        const bounds = this._touchingBounds(drawableID);
-        if (!bounds) {
-            return false;
-        }
-        candidateIDs = this._filterCandidatesTouching(drawableID, candidateIDs, bounds);
-        if (!candidateIDs) {
+        const candidates = this._candidatesTouching(drawableID, candidateIDs);
+        if (candidates.length === 0) {
             return false;
         }
 
-        // Limit size of viewport to the bounds around the target Drawable,
-        // and create the projection matrix for the draw.
-        gl.viewport(0, 0, bounds.width, bounds.height);
-        const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
+        // Get the union of all the candidates intersections.
+        const bounds = this._candidatesBounds(candidates);
 
-        const noneColor = Drawable.color4fFromID(RenderConstants.ID_NONE);
-        gl.clearColor.apply(gl, noneColor);
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+        const drawable = this._allDrawables[drawableID];
+        const point = __isTouchingDrawablesPoint;
 
-        try {
-            gl.enable(gl.STENCIL_TEST);
-            gl.stencilFunc(gl.ALWAYS, 1, 1);
-            gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
-            gl.colorMask(false, false, false, false);
-            this._drawThese([drawableID], ShaderManager.DRAW_MODE.silhouette, projection);
-
-            gl.stencilFunc(gl.EQUAL, 1, 1);
-            gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-            gl.colorMask(true, true, true, true);
-
-            this._drawThese(candidateIDs, ShaderManager.DRAW_MODE.silhouette, projection,
-                {idFilterFunc: testID => testID !== drawableID}
-            );
-        } finally {
-            gl.colorMask(true, true, true, true);
-            gl.disable(gl.STENCIL_TEST);
-        }
-
-        const pixels = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
-        gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
-        if (this._debugCanvas) {
-            this._debugCanvas.width = bounds.width;
-            this._debugCanvas.height = bounds.height;
-            const context = this._debugCanvas.getContext('2d');
-            const imageData = context.getImageData(0, 0, bounds.width, bounds.height);
-            imageData.data.set(pixels);
-            context.putImageData(imageData, 0, 0);
-        }
-
-        for (let pixelBase = 0; pixelBase < pixels.length; pixelBase += 4) {
-            const pixelID = Drawable.color3bToID(
-                pixels[pixelBase],
-                pixels[pixelBase + 1],
-                pixels[pixelBase + 2]);
-            if (pixelID > RenderConstants.ID_NONE) {
-                return true;
+        // This is an EXTREMELY brute force collision detector, but it is
+        // still faster than asking the GPU to give us the pixels.
+        for (let x = bounds.left; x <= bounds.right; x++) {
+            // Scratch Space - +y is top
+            point[0] = x;
+            for (let y = bounds.bottom; y <= bounds.top; y++) {
+                point[1] = y;
+                if (drawable.isTouching(point)) {
+                    for (let index = 0; index < candidates.length; index++) {
+                        if (candidates[index].drawable.isTouching(point)) {
+                            return true;
+                        }
+                    }
+                }
             }
         }
 
@@ -940,26 +907,46 @@ class RenderWebGL extends EventEmitter {
      * could possibly intersect the given bounds.
      * @param {int} drawableID - ID for drawable of query.
      * @param {Array<int>} candidateIDs - Candidates for touching query.
-     * @param {Rectangle} bounds - Bounds to limit candidates to.
-     * @return {?Array<int>} Filtered candidateIDs, or null if none.
+     * @return {?Array< {id, drawable, intersection} >} Filtered candidates with useful data.
      */
-    _filterCandidatesTouching (drawableID, candidateIDs, bounds) {
-        // Filter candidates by rough bounding box intersection.
-        // Do this before _drawThese, so we can prevent any GL operations
-        // and readback by returning early.
-        candidateIDs = candidateIDs.filter(testID => {
-            if (testID === drawableID) return false;
-            // Only draw items which could possibly overlap target Drawable.
-            const candidate = this._allDrawables[testID];
-            const candidateBounds = candidate.getFastBounds();
-            return bounds.intersects(candidateBounds);
-        });
-        if (candidateIDs.length === 0) {
-            // No possible intersections based on bounding boxes.
-            return null;
+    _candidatesTouching (drawableID, candidateIDs) {
+        const bounds = this._touchingBounds(drawableID);
+        if (!bounds) {
+            return [];
         }
-        return candidateIDs;
+        return candidateIDs.reduce((result, id) => {
+            if (id !== drawableID) {
+                const drawable = this._allDrawables[id];
+                const candidateBounds = drawable.getFastBounds();
+
+                if (bounds.intersects(candidateBounds)) {
+                    result.push({
+                        id,
+                        drawable,
+                        intersection: Rectangle.intersect(bounds, candidateBounds)
+                    });
+                }
+            }
+            return result;
+        }, []);
     }
+
+    /**
+     * Helper to get the union bounds from a set of candidates returned from the above method
+     * @private
+     * @param {Array<object>} candidates info from _candidatesTouching
+     * @return {Rectangle} the outer bounding box union
+     */
+    _candidatesBounds (candidates) {
+        return candidates.reduce((memo, {intersection}) => {
+            if (!memo) {
+                return intersection;
+            }
+            // store the union of the two rectangles in our static rectangle instance
+            return Rectangle.union(memo, intersection, __candidatesBounds);
+        }, null);
+    }
+
 
     /**
      * Update the position, direction, scale, or effect properties of this Drawable.
@@ -1185,12 +1172,6 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     _drawThese (drawables, drawMode, projection, opts = {}) {
-        const near = function (a, b, relativeTolerance = 0.01) {
-            const absA = Math.abs(a);
-            const absB = Math.abs(b);
-            const error = Math.abs(a - b) / Math.max(absA, absB);
-            return error < relativeTolerance;
-        };
 
         const gl = this._gl;
         let currentShader = null;
@@ -1239,9 +1220,9 @@ class RenderWebGL extends EventEmitter {
             }
 
             if (uniforms.u_skin) {
-                const useNearest =
-                    (drawable._direction % 90 === 0) && (near(drawableScale, 100) || drawable.skin.isRaster);
-                twgl.setTextureParameters(gl, uniforms.u_skin, {minMag: useNearest ? gl.NEAREST : gl.LINEAR});
+                twgl.setTextureParameters(
+                    gl, uniforms.u_skin, {minMag: drawable.useNearest ? gl.NEAREST : gl.LINEAR}
+                );
             }
 
             twgl.setUniforms(currentShader, uniforms);
@@ -1307,7 +1288,7 @@ class RenderWebGL extends EventEmitter {
             for (; x < width; x++) {
                 _pixelPos[0] = x / width;
                 EffectTransform.transformPoint(drawable, _pixelPos, _effectPos);
-                if (drawable.skin.isTouching(_effectPos)) {
+                if (drawable.skin.isTouchingLinear(_effectPos)) {
                     Q = [x, y];
                     break;
                 }
@@ -1337,7 +1318,7 @@ class RenderWebGL extends EventEmitter {
             for (x = width - 1; x >= 0; x--) {
                 _pixelPos[0] = x / width;
                 EffectTransform.transformPoint(drawable, _pixelPos, _effectPos);
-                if (drawable.skin.isTouching(_effectPos)) {
+                if (drawable.skin.isTouchingLinear(_effectPos)) {
                     Q = [x, y];
                     break;
                 }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -1,6 +1,5 @@
 const twgl = require('twgl.js');
 
-const Silhouette = require('./Silhouette');
 const Skin = require('./Skin');
 const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 
@@ -31,8 +30,6 @@ class SVGSkin extends Skin {
 
         /** @type {Number} */
         this._maxTextureScale = 0;
-
-        this._silhouette = new Silhouette();
     }
 
     /**
@@ -129,14 +126,6 @@ class SVGSkin extends Skin {
         });
     }
 
-    /**
-     * Does this point touch an opaque or translucent point on this skin?
-     * @param {twgl.v3} vec A texture coordinate.
-     * @return {boolean} Did it touch?
-     */
-    isTouching (vec) {
-        return this._silhouette.isTouching(vec);
-    }
 }
 
 module.exports = SVGSkin;

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events');
 const twgl = require('twgl.js');
 
 const RenderConstants = require('./RenderConstants');
+const Silhouette = require('./Silhouette');
 
 /**
  * Truncate a number into what could be stored in a 32 bit floating point value.
@@ -51,6 +52,12 @@ class Skin extends EventEmitter {
              */
             u_skin: null
         };
+
+        /**
+         * A silhouette to store touching data, skins are responsible for keeping it up to date.
+         * @private
+         */
+        this._silhouette = new Silhouette();
 
         this.setMaxListeners(RenderConstants.SKIN_SHARE_SOFT_LIMIT);
     }
@@ -141,13 +148,34 @@ class Skin extends EventEmitter {
     }
 
     /**
+     * If the skin defers silhouette operations until the last possible minute,
+     * this will be called before isTouching uses the silhouette.
+     * @abstract
+     */
+    updateSilhouette () {}
+
+    /**
      * Does this point touch an opaque or translucent point on this skin?
+     * Nearest Neighbor version
      * @param {twgl.v3} vec A texture coordinate.
      * @return {boolean} Did it touch?
      */
-    isTouching () {
-        return false;
+    isTouchingNearest (vec) {
+        this.updateSilhouette();
+        return this._silhouette.isTouchingNearest(vec);
     }
+
+    /**
+     * Does this point touch an opaque or translucent point on this skin?
+     * Linear Interpolation version
+     * @param {twgl.v3} vec A texture coordinate.
+     * @return {boolean} Did it touch?
+     */
+    isTouchingLinear (vec) {
+        this.updateSilhouette();
+        return this._silhouette.isTouchingLinear(vec);
+    }
+
 }
 
 /**


### PR DESCRIPTION
This is a work in progress and has a lot of debugging stuff still going on, please feel free to comment on any of it (including the debugging, it can only help me remember to remove it later! <3)

### Proposed Changes

* Take the `isTouchingDrawables` off the GPU

### Reason for Changes

* `gl.readPixels` is the ultimate in slow

### Test Coverage

* See #265 

