### PR TITLE
Pass in factor of 2 instead of having magic 2s

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -302,21 +302,18 @@ class RenderWebGL extends EventEmitter {
      * Update an existing bitmap skin, or create a bitmap skin if the previous skin was not bitmap.
      * @param {!int} skinId the ID for the skin to change.
      * @param {!string} imgData - new bitmap to use.
+     * @param {!number} bitmapResolution - the resolution scale for a bitmap costume.
      * @param {?Array<number>} rotationCenter Optional: rotation center of the skin. If not supplied, the center of the
      * skin will be used
      */
-    updateBitmapSkin (skinId, imgData, rotationCenter) {
-        // Divide rotation center by 2 and set bitmap resolution = 2 because all images coming from paint editor
-        // are double resolution
-        const updatedRotationCenter = rotationCenter ?
-            [Math.floor(rotationCenter[0] / 2), Math.floor(rotationCenter[1] / 2)] : null;
+    updateBitmapSkin (skinId, imgData, bitmapResolution, rotationCenter) {
         if (this._allSkins[skinId] instanceof BitmapSkin) {
-            this._allSkins[skinId].setBitmap(imgData, 2, updatedRotationCenter);
+            this._allSkins[skinId].setBitmap(imgData, bitmapResolution, rotationCenter);
             return;
         }
 
         const newSkin = new BitmapSkin(skinId, this);
-        newSkin.setBitmap(imgData, 2, updatedRotationCenter);
+        newSkin.setBitmap(imgData, bitmapResolution, rotationCenter);
         this._reskin(skinId, newSkin);
     }
 


### PR DESCRIPTION
We decided that it should not be the renderer's responsibility to know a detail about how the paint editor works, and have the bitmap resolution passed in instead