### PR TITLE
Fix color inversion bug on mobile

### DIFF
--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -46,7 +46,7 @@ varying vec2 v_texCoord;
 // See also: https://en.wikipedia.org/wiki/HSL_and_HSV#Formal_derivation
 
 // Smaller values can cause problems with "color" and "brightness" effects on some mobile devices
-const float epsilon = 1e-4;
+const float epsilon = 1e-3;
 
 // Convert an RGB color to Hue, Saturation, and Lightness.
 // All components of input and output are expected to be in the [0,1] range.


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-render/issues/245

### Proposed Changes

_Describe what this Pull Request does_

Looks like the original proposed fix does not work on iPad. Upped the epsilon value from https://github.com/LLK/scratch-render/pull/210 to make it work.

Tested on iPad Mini, iOS 11.2.2