### PR TITLE
Scale the drawable scale by the ratio of pixel size to native size.

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1237,7 +1237,11 @@ class RenderWebGL extends EventEmitter {
             // the ignoreVisibility flag is used (e.g. for stamping or touchingColor).
             if (!drawable.getVisible() && !opts.ignoreVisibility) continue;
 
-            const drawableScale = drawable.scale;
+            // Combine drawable scale with the native vs. backing pixel ratio
+            const drawableScale = [
+                drawable.scale[0] * this._gl.canvas.width / this._nativeSize[0],
+                drawable.scale[1] * this._gl.canvas.height / this._nativeSize[1]
+            ];
 
             // If the skin or texture isn't ready yet, skip it.
             if (!drawable.skin || !drawable.skin.getTexture(drawableScale)) continue;


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-render/issues/256
Fixes https://github.com/LLK/scratch-gui/issues/1374

### Proposed Changes

_Describe what this Pull Request does_

When requesting a drawable texture, combine the drawable scale with the pixel / logical size ratio (large in fullscreen mode, for example). 

### Reason for Changes

_Explain why these changes should be made_

This makes the vector sprites not blurry in fullscreen mode

![image](https://user-images.githubusercontent.com/654102/39448972-c30f4964-4c94-11e8-9255-93f87245abc2.png)

![image](https://user-images.githubusercontent.com/654102/39448976-c5f08f94-4c94-11e8-9a3c-c366716a9e7b.png)


