### PR TITLE
Replace babel-preset-es2015 with babel-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-eslint": "^8.2.1",
     "babel-loader": "^7.1.4",
     "babel-polyfill": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "chromeless": "^1.5.1",
     "copy-webpack-plugin": "^4.5.1",
     "docdash": "^0.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const base = {
                 test: /\.js$/,
                 loader: 'babel-loader',
                 options: {
-                    presets: ['es2015']
+                    presets: [['env', {targets: {browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']}}]]
                 }
             },
             {


### PR DESCRIPTION
### Proposed Changes

Replace babel-preset-es2015 with babel-preset-env.

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1112.
