### PR TITLE
Fix a thread status check in integration tests to allow "done" threads

### DIFF
--- a/test/integration/scratch-tests.js
+++ b/test/integration/scratch-tests.js
@@ -35,9 +35,12 @@ const testFile = file => test(file, async t => {
             return Promise.resolve()
                 .then(async () => {
                     // waiting for all threads to complete, then we return
-                    while (vm.runtime.threads.length > 0) {
+
+                    while (vm.runtime.threads.filter(thread => vm.runtime.isActiveThread(thread)).length > 0) {
                         if ((Date.now() - startTime) >= TIMEOUT) {
-                            messages.push(`fail Threads still running after ${TIMEOUT}ms`);
+                            // if we push the message after end, the failure from tap is not very useful:
+                            // "not ok test after end() was called"
+                            messages.unshift(`fail Threads still running after ${TIMEOUT}ms`);
                             break;
                         }
 

--- a/test/integration/scratch-tests.js
+++ b/test/integration/scratch-tests.js
@@ -35,8 +35,7 @@ const testFile = file => test(file, async t => {
             return Promise.resolve()
                 .then(async () => {
                     // waiting for all threads to complete, then we return
-
-                    while (vm.runtime.threads.filter(thread => vm.runtime.isActiveThread(thread)).length > 0) {
+                    while (vm.runtime.threads.some(thread => vm.runtime.isActiveThread(thread))) {
                         if ((Date.now() - startTime) >= TIMEOUT) {
                             // if we push the message after end, the failure from tap is not very useful:
                             // "not ok test after end() was called"


### PR DESCRIPTION
### Resolves

* Bug in integration test suite, threads can still be on the runtime in a "DONE" state, so check if they are still active.

### Reason for Changes

* Tests were timing out with a useless error message

### Test Coverage

* it is a test