### PR TITLE
Layer ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdoc": "^3.5.5",
     "json": "^9.0.4",
     "linebreak": "0.3.0",
+    "minilog": "3.1.0",
     "raw-loader": "^0.5.1",
     "scratch-storage": "^0.4.0",
     "scratch-svg-renderer": "0.1.0-prerelease.20180514170126",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "raw-loader": "^0.5.1",
     "scratch-storage": "^0.4.0",
     "scratch-svg-renderer": "0.1.0-prerelease.20180514170126",
-    "scratch-vm": "0.1.0-prerelease.1525975472",
+    "scratch-vm": "0.1.0-prerelease.1527254075",
     "tap": "^11.0.0",
     "travis-after-all": "^1.4.4",
     "twgl.js": "4.4.0",

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -128,9 +128,9 @@ class RenderWebGL extends EventEmitter {
 
         /**
          * @typedef LayerGroup
-         * @property {boolean} explicitOrdering Whether or not this group uses explicit ordering
-         * @property {Array} drawables List of drawables (either objects with drawableID and ordering
-         * OR just a drawableID if the ordering for this group is implicit)
+         * @property {int} groupIndex The relative position of this layer group in the group ordering
+         * @property {int} drawListOffset The absolute position of this layer group in the draw list
+         * This number gets updated as drawables get added to or deleted from the draw list.
          */
 
         // Map of group name to layer group
@@ -398,7 +398,7 @@ class RenderWebGL extends EventEmitter {
     /**
      * Set the layer group ordering for the renderer.
      * @param {Array<string>} groupOrdering The ordered array of layer group
-     * descriptors
+     * names
      */
     setLayerGroupOrdering (groupOrdering) {
         this._groupOrdering = groupOrdering;
@@ -431,6 +431,8 @@ class RenderWebGL extends EventEmitter {
         }
     }
 
+    // Given a layer group, return the index where it ends (non-inclusive),
+    // e.g. the returned index does not have a drawable from this layer group in it)
     _endIndexForKnownLayerGroup (layerGroup) {
         const groupIndex = layerGroup.groupIndex;
         if (groupIndex === this._groupOrdering.length - 1) {
@@ -442,9 +444,7 @@ class RenderWebGL extends EventEmitter {
     /**
      * Destroy a Drawable, removing it from the scene.
      * @param {int} drawableID The ID of the Drawable to remove.
-     * @param {string} group Optional group name that the drawable belongs to
-     * If the drawable was created in a specific group, it should be destroyed in the
-     * same group.
+     * @param {string} group Group name that the drawable belongs to
      */
     destroyDrawable (drawableID, group) {
         if (!group || !this._layerGroups.hasOwnProperty(group)) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -121,10 +121,9 @@ class RenderWebGL extends EventEmitter {
         /** @type {Array<int>} */
         this._drawList = [];
 
-        /** @type {Array<String>}
-         * A list of layer group names in the order they should appear
-         * from furthest back to furthest in front.
-         */
+        // A list of layer group names in the order they should appear
+        // from furthest back to furthest in front.
+        /** @type {Array<String>} */
         this._groupOrdering = [];
 
         /**
@@ -134,17 +133,15 @@ class RenderWebGL extends EventEmitter {
          * OR just a drawableID if the ordering for this group is implicit)
          */
 
-        /** @type {Object.<string, LayerGroup>}
-         * Map of group name to layer group
-         */
+        // Map of group name to layer group
+        /** @type {Object.<string, LayerGroup>} */
         this._layerGroups = {};
 
-        /** @type {Object<string, DrawableOrderingDesc>}
-         * Group to be used for a new drawable
-         * if a group is not provided during creation.
-         * This is null to start with but will get populated
-         * if createDrawable is called without a group
-         */
+        // Group to be used for a new drawable
+        // if a group is not provided during creation.
+        // This is null to start with but will get populated
+        // if createDrawable is called without a group
+        /** @type {Object<string, DrawableOrderingDesc>} */
         this._unspecifiedLayerGroup = null;
 
         /** @type {int} */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -618,12 +618,10 @@ class RenderWebGL extends EventEmitter {
         if (groupIndex === this._groupOrdering.length - 1) {
             if (this._unspecifiedLayerGroup) {
                 return this._unspecifiedLayerGroup.drawListOffset;
-            } else {
-                return this._drawList.length;
             }
-        } else {
-            return this._layerGroups[this._groupOrdering[groupIndex + 1]].drawListOffset;
+            return this._drawList.length;
         }
+        return this._layerGroups[this._groupOrdering[groupIndex + 1]].drawListOffset;
     }
 
     /**
@@ -721,7 +719,8 @@ class RenderWebGL extends EventEmitter {
 
         // At this point, we know that if a layer group was provided,
         // then it is implicitly ordered.
-        let startIndex, endIndex;
+        let startIndex;
+        let endIndex;
         if (usingLayerGroup) {
             const currentLayerGroup = this._layerGroups[optGroup];
 

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -38,15 +38,16 @@
     var canvas = document.getElementById('scratch-stage');
     var fudge = 90;
     var renderer = new ScratchRender(canvas);
+    renderer.setLayerGroupOrdering(['group1']);
 
-    var drawableID = renderer.createDrawable();
+    var drawableID = renderer.createDrawable('group1');
     renderer.updateDrawableProperties(drawableID, {
         position: [0, 0],
         scale: [100, 100],
         direction: 90
     });
 
-    var drawableID2 = renderer.createDrawable();
+    var drawableID2 = renderer.createDrawable('group1');
     var wantBitmapSkin = false;
 
     // Bitmap (squirrel)

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -1,0 +1,4 @@
+const minilog = require('minilog');
+minilog.enable();
+
+module.exports = minilog('scratch-render');


### PR DESCRIPTION
### Resolves

LLK/scratch-vm#1066

### Proposed Changes

Create layer groups to organize the many different kinds of layers and ordering needs for those layers on the stage.

Layer groups can be either explicitly or implicitly ordered. Explicitly ordered layer groups are strictly ordered based on a provided ordering preference. Layer groups that are explicitly ordered cannot have the items within their group re-ordered (e.g. via setDrawableOrder). Layer groups that are implicitly ordered are initially ordered based on what order the drawables are created (each new one getting added in front of the previous ones in that group). Items in implicitly ordered groups (e.g. sprites) can get re-ordered via setDrawableOrder.

Layer groups are themselves ordered. An initial set of layer groups (and their ordering) is determined via the new `setLayerGroupOrdering` function. If a drawable is created in a group that is not already known, the group gets created and put in front of all known groups. The ordering type (explicit vs. implicit) of the not previously known is determined based on whether an explicit ordering preference is provided for the drawable being provided (e.g. if explicit ordering is provided, create the new group as an explicitly ordered group, otherwise the new group is an implicitly ordered group).

`createDrawable`, `destroyDrawable` and `setDrawableOrder` each take information about what group the drawable belongs to. If a group is not provided, it will be added to a special internal 'unspecified layer group' which has implicit ordering. Items added to this group will appear in front of all other items (including any new groups that were created as described above).

### Reason for Changes

LLK/scratch-vm#1066

### Test Coverage

Existing tests pass (as long as VM also gets updated). Tried to add new unit tests, but the tests are failing because of a dependency of scratch-svg-renderer depending on `window` and `self` (so leaving new tests as TODO #287).

#### Related PR
LLK/scratch-vm#1148 <-- should be merged before this one.