### PR TITLE
Remove speech bubbles' reliance on svg quirks mode's _transformText

### DIFF
--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -59,11 +59,11 @@ class Silhouette {
         const height = this._height = canvas.height = bitmapData.height;
         const ctx = canvas.getContext('2d');
 
-        ctx.clearRect(0, 0, width, height);
-        ctx.drawImage(bitmapData, 0, 0, width, height);
         if (!(width && height)) {
             return;
         }
+        ctx.clearRect(0, 0, width, height);
+        ctx.drawImage(bitmapData, 0, 0, width, height);
         const imageData = ctx.getImageData(0, 0, width, height);
 
         this._data = new Uint8ClampedArray(imageData.data.length / 4);

--- a/src/util/svg-text-bubble.js
+++ b/src/util/svg-text-bubble.js
@@ -3,6 +3,7 @@ const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 
 const MAX_LINE_LENGTH = 170;
 const MIN_WIDTH = 50;
+const STROKE_WIDTH = 4;
 
 class SVGTextBubble {
     constructor () {
@@ -57,7 +58,7 @@ class SVGTextBubble {
                 <path
                   d="${pathString}"
                   stroke="rgba(0, 0, 0, 0.15)"
-                  stroke-width="4"
+                  stroke-width="${STROKE_WIDTH}"
                   fill="rgba(0, 0, 0, 0.15)"
                   stroke-line-join="round"
               />
@@ -113,7 +114,7 @@ class SVGTextBubble {
                     rx="${rx}" ry="${ry}"
                     fill="rgba(0, 0, 0, 0.15)"
                     stroke="rgba(0, 0, 0, 0.15)"
-                    stroke-width="4"
+                    stroke-width="${STROKE_WIDTH}"
                 />
                 <ellipse
                     cx="${cx}" cy="${cy}"
@@ -137,7 +138,8 @@ class SVGTextBubble {
 
         return `
              <g>
-                <path d="${pathString}" stroke="rgba(0, 0, 0, 0.15)" stroke-width="4" fill="rgba(0, 0, 0, 0.15)" />
+                <path d="${pathString}" stroke="rgba(0, 0, 0, 0.15)" stroke-width="${STROKE_WIDTH}"
+                    fill="rgba(0, 0, 0, 0.15)" />
                 <path d="${pathString}" stroke="none" fill="white" />
                 ${ellipses.join('\n')}
             </g>`;
@@ -152,13 +154,16 @@ class SVGTextBubble {
         return this._textSizeCache[svgString];
     }
 
-    _wrapSvgFragment (fragment) {
-        // @todo generate view box
-        return `
-          <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-              ${fragment}
-          </svg>
-        `;
+    _wrapSvgFragment (fragment, width, height) {
+        let svgString = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1"`;
+        if (width && height) {
+            svgString = `${svgString} viewBox="
+                ${-STROKE_WIDTH / 2} ${-STROKE_WIDTH / 2} ${width + STROKE_WIDTH} ${height + STROKE_WIDTH + 12}">`;
+        } else {
+            svgString = `${svgString}>`;
+        }
+        svgString = `${svgString} ${fragment} </svg>`;
+        return svgString;
     }
 
     buildString (type, text, pointsLeft) {
@@ -181,7 +186,7 @@ class SVGTextBubble {
             fragment += this._thinkBubble(fullWidth, fullHeight, radius, this.pointsLeft);
         }
         fragment += `<g transform="translate(${padding - x}, ${padding - y})">${this._textFragment}</g>`;
-        return this._wrapSvgFragment(fragment);
+        return this._wrapSvgFragment(fragment, fullWidth, fullHeight);
     }
 }
 


### PR DESCRIPTION
### Resolves
Progress toward fixing https://github.com/LLK/scratch-paint/issues/436

### Proposed Changes
Quirks mode (_transformText and _transformMeasurements in scratch-svg-renderer) deals with fixing really weird stuff scratch 2 did to exported SVGs and should only be applied when converting from scratch 2 to scratch 3 projects. In scratch 3 we want to trust how SVGs are formatted.

Speech bubbles currently rely on quirks mode, so a first step is to remove speech bubbles' dependency on quirks mode. This includes having them be responsible for their own style, instead of expecting quirks mode to enforce a style, and exporting text with tspans instead of \n linebreaks.
