### PR TITLE
Publish only src, dist, TRADEMARK, README.md, package.json, and LICENSE to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Development files
+.eslintrc.js
+/.editorconfig
+/.eslintignore
+/.gitattributes
+/.github
+/.jsdoc.json
+/.travis.yml
+/test
+/webpack.config.js
+
+# Build created files
+/playground
+
+# Exclude already built packages from testing with npm pack
+/scratch-render-*.{tar,tgz}


### PR DESCRIPTION
### Proposed Changes

- Publish only `src`, `dist`, `TRADEMARK`, `README.md`, `package.json`, and `LICENSE` to npm

### Reason for Changes

Other packages that depend on scratch-render need to download it and locally install a copy to require into. As scratch-render is, it's publishing `playground` and `test`. These folders are not used by scratch-render dependents. They take up a relatively large amount of space in the download file and once extracted on disk. Importantly this extra space means that CI servers along with the developers working on another scratch-* package need to spend more time downloading and for CI, more time storing and retrieving the node_modules cache to perform CI work quicker.

Specifying the files published with this change, reduces the download from **7.6MB** to **3.2MB**, and space used once extracted from **19MB** to **11MB**. Most of the savings is from omitting `playground`.

-----

`README.md`, `package.json` and `LICENSE` are automatically included in the files published to npm whether they are stated in `package.json` or not. I can add those if the explicit nature of stating them that way would be preferred.

-----

If you want to check locally what files will be published, one way to do so is to make the package npm will publish with the `npm pack` command. It'll make a gzip'd tar file with the content that would be published. You can then use a tool to see the contents (like `tar -tf scratch-render-0.1.0.tgz` on a command line) or extract the contents and look at the extracted directory.
