### PR TITLE
Remove duplicate xml escaping

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/*
 node_modules/*
 playground/*
+tap-snapshots/*

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.8.0",
     "webpack-cli": "^2.0.15",
-    "webpack-dev-server": "^3.1.4",
-    "xml-escape": "1.1.0"
+    "webpack-dev-server": "^3.1.4"
   }
 }

--- a/src/util/svg-text-bubble.js
+++ b/src/util/svg-text-bubble.js
@@ -169,12 +169,16 @@ class SVGTextBubble {
         return svgString;
     }
 
+    _buildTextFragment (text) {
+        const textNode = this.svgTextWrapper.wrapText(MAX_LINE_LENGTH, text);
+        const serializer = new XMLSerializer();
+        return serializer.serializeToString(textNode);
+    }
+
     buildString (type, text, pointsLeft) {
         this.type = type;
         this.pointsLeft = pointsLeft;
-        const textNode = this.svgTextWrapper.wrapText(MAX_LINE_LENGTH, text);
-        const serializer = new XMLSerializer();
-        this._textFragment = serializer.serializeToString(textNode);
+        this._textFragment = this._buildTextFragment(text);
 
         let fragment = '';
 

--- a/src/util/svg-text-wrapper.js
+++ b/src/util/svg-text-wrapper.js
@@ -1,5 +1,4 @@
 const TextWrapper = require('./text-wrapper');
-const xmlescape = require('xml-escape');
 
 /**
  * Measure text by using a hidden SVG attached to the DOM.
@@ -118,7 +117,7 @@ class SVGTextWrapper extends TextWrapper {
             const tspanNode = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
             tspanNode.setAttribute('x', '0');
             tspanNode.setAttribute('dy', '1.2em');
-            tspanNode.textContent = xmlescape(line);
+            tspanNode.textContent = line;
             textElement.appendChild(tspanNode);
         }
         return textElement;

--- a/tap-snapshots/test-integration-scratch-tests.js-TAP.test.js
+++ b/tap-snapshots/test-integration-scratch-tests.js-TAP.test.js
@@ -1,0 +1,10 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/integration/scratch-tests.js TAP bubble snapshot > bubble-text-snapshot 1`] = `
+<text xmlns="http://www.w3.org/2000/svg" alignment-baseline="text-before-edge" font-size="14" fill="#575E75" font-family="Helvetica"><tspan x="0" dy="1.2em">&lt;e*&amp;%$&amp;^$&gt;&lt;/!abc'&gt;</tspan></text>
+`

--- a/test/integration/scratch-tests.js
+++ b/test/integration/scratch-tests.js
@@ -1,4 +1,4 @@
-/* global vm, Promise */
+/* global vm, render, Promise */
 const {Chromeless} = require('chromeless');
 const test = require('tap').test;
 const path = require('path');
@@ -101,6 +101,16 @@ const testFile = file => test(file, async t => {
     }
 });
 
+const testBubbles = () => test('bubble snapshot', async t => {
+    const bubbleSvg = await chromeless.goto(`file://${indexHTML}`)
+        .evaluate(() => {
+            const testString = '<e*&%$&^$></!abc\'>';
+            return render._svgTextBubble._buildTextFragment(testString);
+        });
+    t.matchSnapshot(bubbleSvg, 'bubble-text-snapshot');
+    t.end();
+});
+
 // immediately invoked async function to let us wait for each test to finish before starting the next.
 (async () => {
     const files = fs.readdirSync(testDir())
@@ -109,6 +119,8 @@ const testFile = file => test(file, async t => {
     for (const file of files) {
         await testFile(file);
     }
+
+    await testBubbles();
 
     // close the browser window we used
     await chromeless.end();


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2148

### Proposed Changes

_Describe what this Pull Request does_

We used to write the user string directly into the svg string, but now we are setting the `.textContent` of an actual dom node, which does the escaping for us.

### Test Coverage

_Please show how you have added tests to cover your changes_

I added an additional test to the integration tester that does a snapshot test on the svg strings from the bubble creator. This is just to catch any unintended changes to that code, like this one. It had to be in the integration test because it requires the real svg dom to run. Luckily tap has a built in snapshot tester, which is useful. Sadly couldn't change the snapshot path to nest it under the `test` dir the way I'd like :(

But on the plus side yay tests!

BTW I ran the snapshot test without the fix, and the output was pretty readable, showed a diff with the snapshot the revealed the first character, a `<`, was supposed to be `&lt;`, but was actually becomping `&amp;lt;`