### PR TITLE
offset pen lines of width 1 and 3

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -132,9 +132,13 @@ class PenSkin extends Skin {
     drawLine (penAttributes, x0, y0, x1, y1) {
         const ctx = this._canvas.getContext('2d');
         this._setAttributes(ctx, penAttributes);
+
+        // Width 1 and 3 lines need to be offset by 0.5.
+        const diameter = penAttributes.diameter || DefaultPenAttributes.diameter;
+        const offset = (Math.max(4 - diameter, 0) % 2) / 2;
         ctx.beginPath();
-        ctx.moveTo(this._rotationCenter[0] + x0, this._rotationCenter[1] - y0);
-        ctx.lineTo(this._rotationCenter[0] + x1, this._rotationCenter[1] - y1);
+        ctx.moveTo(this._rotationCenter[0] + x0 + offset, this._rotationCenter[1] - y0 + offset);
+        ctx.lineTo(this._rotationCenter[0] + x1 + offset, this._rotationCenter[1] - y1 + offset);
         ctx.stroke();
         this._canvasDirty = true;
         this._silhouetteDirty = true;


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-vm/issues/1306

### Proposed Changes

Offset pen lines with width of 1 or 3.

### Reason for Changes

Lines with width 1 or 3 in Scratch 2 seem to be rendered in the center of their pixels leaving crisp edges for vertical and horizontal lines. Lines with odd widths larger than 3 have aliased lines like the lines in Scratch 3 already are.

### Test Coverage

The images below are differences of Scratch 2 and Scratch 3 rendering https://llk.github.io/scratch-gui/develop/#236563663. The second image shows the difference with this change.

<img width="486" alt="screen shot 2018-07-16 at 3 22 34 pm" src="https://user-images.githubusercontent.com/833298/42785413-634580ac-8920-11e8-80f4-69e4c37c87ee.png">

<img width="487" alt="screen shot 2018-07-17 at 1 09 37 pm" src="https://user-images.githubusercontent.com/833298/42833669-bbef16e4-89c2-11e8-8ec0-940a8aa05c37.png">

![2018-07-16 17 41 42](https://user-images.githubusercontent.com/833298/42785430-76ff5ad2-8920-11e8-80d1-cfd27d7de6e3.gif)

![2018-07-16 17 42 38](https://user-images.githubusercontent.com/833298/42785431-77130a28-8920-11e8-9e38-7a7dbf4671d1.gif)
