### PR TITLE
Framebuffer PenSkin

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "raw-loader": "^0.5.1",
     "scratch-storage": "^0.4.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20180712223402",
-    "twgl.js": "4.4.0"
+    "twgl.js": "4.4.0",
+    "url-loader": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "raw-loader": "^0.5.1",
     "scratch-storage": "^0.4.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20180712223402",
-    "twgl.js": "4.4.0",
-    "url-loader": "^1.0.1"
+    "twgl.js": "4.4.0"
   }
 }

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -371,12 +371,12 @@ class PenSkin extends Skin {
         // The line needs a bit of aliasing to look smooth. Add a small offset
         // and a small size boost to scaling to give a section to alias.
         const translationVector = __modelTranslationVector;
-        translationVector[0] = avgX - alias / 2;
-        translationVector[1] = avgY + alias / 4;
+        translationVector[0] = avgX - (alias / 2);
+        translationVector[1] = avgY + (alias / 4);
 
         const scalingVector = __modelScalingVector;
         scalingVector[0] = diameter + alias;
-        scalingVector[1] = length + diameter - alias / 2;
+        scalingVector[1] = length + diameter - (alias / 2);
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -118,12 +118,6 @@ class PenSkin extends Skin {
             exit: () => this._exitDrawToBuffer()
         };
 
-        /** @type {object} */
-        this._silhouetteDrawRegionId = {
-            enter: () => this._enterUpdateSilhouette(),
-            exit: () => this._exitUpdateSilhouette()
-        };
-
         /** @type {twgl.BufferInfo} */
         this._lineBufferInfo = null;
 
@@ -628,30 +622,6 @@ class PenSkin extends Skin {
     }
 
     /**
-     * Prepare to draw the framebuffer in _silhouetteDrawRegionId region.
-     */
-    _enterUpdateSilhouette () {
-        const gl = this._renderer.gl;
-
-        twgl.bindFramebufferInfo(gl, this._silhouetteBuffer);
-
-        gl.disable(gl.BLEND);
-
-        this._drawRectangleRegionEnter(this._noEffectShader, this._bounds);
-    }
-
-    /**
-     * Return to a base state from _silhouetteDrawRegionId.
-     */
-    _exitUpdateSilhouette () {
-        const gl = this._renderer.gl;
-
-        gl.enable(gl.BLEND);
-
-        twgl.bindFramebufferInfo(gl, null);
-    }
-
-    /**
      * If there have been pen operations that have dirtied the canvas, update
      * now before someone wants to use our silhouette.
      */
@@ -668,12 +638,7 @@ class PenSkin extends Skin {
             const texture = this._exportTexture;
             const currentShader = this._noEffectShader;
 
-            this._renderer.enterDrawRegion(this._silhouetteDrawRegionId);
-
-            gl.clearColor(0, 0, 0, 0);
-            gl.clear(gl.COLOR_BUFFER_BIT);
-
-            this._drawRectangle(currentShader, texture, bounds);
+            this._renderer.enterDrawRegion(this._toBufferDrawRegionId);
 
             // Sample the framebuffer's pixels into the silhouette instance
             const skinPixels = new Uint8Array(Math.floor(this._canvas.width * this._canvas.height * 4));

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -636,8 +636,6 @@ class PenSkin extends Skin {
             const gl = this._renderer.gl;
 
             const bounds = this._bounds;
-            const texture = this._exportTexture;
-            const currentShader = this._noEffectShader;
 
             this._renderer.enterDrawRegion(this._toBufferDrawRegionId);
 

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -279,13 +279,13 @@ class PenSkin extends Skin {
                     0, 0.5,
                     0, 0,
 
-                    0.5, 0.5,
-                    0.5, 0.5,
-                    0.5, 0.5,
+                    0.5, 0,
+                    0.5, 1,
+                    0.5, 0,
 
-                    0.5, 0.5,
-                    0.5, 0.5,
-                    0.5, 0.5,
+                    0.5, 0,
+                    0.5, 1,
+                    0.5, 1,
 
                     1, 0,
                     0, 0,
@@ -364,13 +364,15 @@ class PenSkin extends Skin {
         const avgY = (y0 + y1) / 2;
         const theta = Math.atan2(y0 - y1, x0 - x1);
 
+        // The line needs a bit of aliasing to look smooth. Add a small offset
+        // and a small size boost to scaling to give a section to alias.
         const translationVector = __modelTranslationVector;
-        translationVector[0] = avgX;
-        translationVector[1] = avgY;
+        translationVector[0] = avgX - 1;
+        translationVector[1] = avgY - 1;
 
         const scalingVector = __modelScalingVector;
-        scalingVector[0] = diameter;
-        scalingVector[1] = length + diameter;
+        scalingVector[0] = diameter + 2;
+        scalingVector[1] = length + diameter + 2;
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -69,6 +69,9 @@ class PenSkin extends Skin {
         this._silhouetteBuffer = null;
 
         /** @type {boolean} */
+        this._canvasDirty = false;
+
+        /** @type {boolean} */
         this._silhouetteDirty = false;
 
         /** @type {object} */

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -315,7 +315,10 @@ class PenSkin extends Skin {
 
         // Needs a blend function that blends a destination that starts with
         // no alpha.
-        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        gl.blendFuncSeparate(
+            gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA,
+            gl.ONE, gl.ONE_MINUS_SRC_ALPHA
+        );
 
         gl.viewport(0, 0, bounds.width, bounds.height);
 
@@ -368,12 +371,12 @@ class PenSkin extends Skin {
         // The line needs a bit of aliasing to look smooth. Add a small offset
         // and a small size boost to scaling to give a section to alias.
         const translationVector = __modelTranslationVector;
-        translationVector[0] = avgX - alias;
-        translationVector[1] = avgY - alias;
+        translationVector[0] = avgX - alias / 2;
+        translationVector[1] = avgY + alias / 4;
 
         const scalingVector = __modelScalingVector;
         scalingVector[0] = diameter + alias;
-        scalingVector[1] = length + diameter + alias;
+        scalingVector[1] = length + diameter - alias / 2;
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -123,8 +123,9 @@ class PenSkin extends Skin {
 
         const NO_EFFECTS = 0;
         /** @type {twgl.ProgramInfo} */
-        this._noEffectShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.default, NO_EFFECTS);
+        this._stampShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.stamp, NO_EFFECTS);
 
+        /** @type {twgl.ProgramInfo} */
         this._lineShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.lineSample, NO_EFFECTS);
 
         this._createLineGeometry();
@@ -181,7 +182,7 @@ class PenSkin extends Skin {
         const gl = this._renderer.gl;
         twgl.bindFramebufferInfo(gl, this._framebuffer);
 
-        gl.clearColor(0, 0, 0, 0);
+        gl.clearColor(1, 1, 1, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         const ctx = this._canvas.getContext('2d');
@@ -314,7 +315,7 @@ class PenSkin extends Skin {
 
         // Needs a blend function that blends a destination that starts with
         // no alpha.
-        gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.SRC_ALPHA, gl.ONE);
+        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
         gl.viewport(0, 0, bounds.width, bounds.height);
 
@@ -480,9 +481,9 @@ class PenSkin extends Skin {
 
         twgl.bindFramebufferInfo(gl, this._framebuffer);
 
-        gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.SRC_ALPHA, gl.ONE);
+        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
-        this._drawRectangleRegionEnter(this._noEffectShader, this._bounds);
+        this._drawRectangleRegionEnter(this._stampShader, this._bounds);
     }
 
     /**
@@ -521,7 +522,7 @@ class PenSkin extends Skin {
             this._canvasDirty = false;
         }
 
-        const currentShader = this._noEffectShader;
+        const currentShader = this._stampShader;
         const bounds = this._bounds;
 
         this._renderer.enterDrawRegion(this._toBufferDrawRegionId);
@@ -594,7 +595,7 @@ class PenSkin extends Skin {
             this._silhouetteBuffer = twgl.createFramebufferInfo(gl, [{format: gl.RGBA}], width, height);
         }
 
-        gl.clearColor(0, 0, 0, 0);
+        gl.clearColor(1, 1, 1, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         this._silhouetteDirty = true;

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -363,16 +363,17 @@ class PenSkin extends Skin {
         const avgX = (x0 + x1) / 2;
         const avgY = (y0 + y1) / 2;
         const theta = Math.atan2(y0 - y1, x0 - x1);
+        const alias = x0 === x1 || y0 === y1 ? 0 : 1;
 
         // The line needs a bit of aliasing to look smooth. Add a small offset
         // and a small size boost to scaling to give a section to alias.
         const translationVector = __modelTranslationVector;
-        translationVector[0] = avgX - 1;
-        translationVector[1] = avgY - 1;
+        translationVector[0] = avgX - alias;
+        translationVector[1] = avgY - alias;
 
         const scalingVector = __modelScalingVector;
-        scalingVector[0] = diameter + 2;
-        scalingVector[1] = length + diameter + 2;
+        scalingVector[0] = diameter + alias;
+        scalingVector[1] = length + diameter + alias;
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));
@@ -380,6 +381,7 @@ class PenSkin extends Skin {
         const uniforms = {
             u_positionScalar: yScalar,
             u_capScale: diameter,
+            u_aliasAmount: alias,
             u_modelMatrix: twgl.m4.multiply(
                 twgl.m4.multiply(
                     twgl.m4.translation(translationVector, __modelTranslationMatrix),

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -309,7 +309,7 @@ class PenSkin extends Skin {
     /**
      * Prepare to draw lines in the _lineOnBufferDrawRegionId region.
      */
-    _enterDrawLineOnBuffer() {
+    _enterDrawLineOnBuffer () {
         const gl = this._renderer.gl;
 
         const bounds = this._bounds;
@@ -340,7 +340,7 @@ class PenSkin extends Skin {
     /**
      * Return to a base state from _lineOnBufferDrawRegionId.
      */
-    _exitDrawLineOnBuffer() {
+    _exitDrawLineOnBuffer () {
         const gl = this._renderer.gl;
 
         gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
@@ -359,7 +359,6 @@ class PenSkin extends Skin {
     _drawLineOnBuffer (penAttributes, x0, y0, x1, y1) {
         const gl = this._renderer.gl;
 
-        const bounds = this._bounds;
         const currentShader = this._lineShader;
 
         this._renderer.enterDrawRegion(this._lineOnBufferDrawRegionId);
@@ -423,11 +422,9 @@ class PenSkin extends Skin {
      *
      * Multiple calls with the same regionId skip the callback reducing the
      * amount of GL state changes.
-     * @param {any} regionId - id of the draw region
      * @param {twgl.ProgramInfo} currentShader - program info to draw rectangle
      *   with
      * @param {Rectangle} bounds - viewport bounds to draw in
-     * @param {function} enter - secondary call to make when entering the draw
      *   region
      */
     _drawRectangleRegionEnter (currentShader, bounds) {
@@ -484,7 +481,7 @@ class PenSkin extends Skin {
     /**
      * Prepare to draw a rectangle in the _toBufferDrawRegionId region.
      */
-    _enterDrawToBuffer() {
+    _enterDrawToBuffer () {
         const gl = this._renderer.gl;
 
         twgl.bindFramebufferInfo(gl, this._framebuffer);
@@ -497,7 +494,7 @@ class PenSkin extends Skin {
     /**
      * Return to a base state from _toBufferDrawRegionId.
      */
-    _exitDrawToBuffer() {
+    _exitDrawToBuffer () {
         const gl = this._renderer.gl;
 
         gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
@@ -633,7 +630,7 @@ class PenSkin extends Skin {
     /**
      * Prepare to draw the framebuffer in _silhouetteDrawRegionId region.
      */
-    _enterUpdateSilhouette() {
+    _enterUpdateSilhouette () {
         const gl = this._renderer.gl;
 
         twgl.bindFramebufferInfo(gl, this._silhouetteBuffer);
@@ -646,7 +643,7 @@ class PenSkin extends Skin {
     /**
      * Return to a base state from _silhouetteDrawRegionId.
      */
-    _exitUpdateSilhouette() {
+    _exitUpdateSilhouette () {
         const gl = this._renderer.gl;
 
         gl.enable(gl.BLEND);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1342,19 +1342,21 @@ class RenderWebGL extends EventEmitter {
             gl.enable(gl.BLEND);
         }
 
-        const stampPixels = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
-        gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, stampPixels);
+        // const stampPixels = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
+        // gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, stampPixels);
+        //
+        // const stampCanvas = this._tempCanvas;
+        // stampCanvas.width = bounds.width;
+        // stampCanvas.height = bounds.height;
+        //
+        // const stampContext = stampCanvas.getContext('2d');
+        // const stampImageData = stampContext.createImageData(bounds.width, bounds.height);
+        // stampImageData.data.set(stampPixels);
+        // stampContext.putImageData(stampImageData, 0, 0);
+        //
+        // skin.drawStamp(stampCanvas, bounds.left, bounds.top);
 
-        const stampCanvas = this._tempCanvas;
-        stampCanvas.width = bounds.width;
-        stampCanvas.height = bounds.height;
-
-        const stampContext = stampCanvas.getContext('2d');
-        const stampImageData = stampContext.createImageData(bounds.width, bounds.height);
-        stampImageData.data.set(stampPixels);
-        stampContext.putImageData(stampImageData, 0, 0);
-
-        skin.drawStamp(stampCanvas, bounds.left, bounds.top);
+        skin._drawToBuffer(this._queryBufferInfo.attachments[0], bounds.left, bounds.top);
     }
 
     /* ******

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1439,6 +1439,7 @@ class RenderWebGL extends EventEmitter {
      *
      * @param {any} regionId - id of the region to enter
      * @param {function} enter - handle to call when first entering a region
+     * @param {function} exit - handle to call when leaving a region
      */
     enterDrawRegion (regionId, enter = regionId.enter, exit = regionId.exit) {
         if (this._regionId !== regionId) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1516,9 +1516,9 @@ class RenderWebGL extends EventEmitter {
             twgl.setUniforms(currentShader, uniforms);
 
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
-
-            this._regionId = null;
         }
+
+        this._regionId = null;
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1455,15 +1455,14 @@ class RenderWebGL extends EventEmitter {
             let effectBits = drawable.getEnabledEffects();
             effectBits &= opts.hasOwnProperty('effectMask') ? opts.effectMask : effectBits;
             const newShader = this._shaderManager.getShader(drawMode, effectBits);
-            if (currentShader !== newShader) {
-                currentShader = newShader;
-                gl.useProgram(currentShader.program);
-                twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
-                Object.assign(uniforms, {
-                    u_projectionMatrix: projection,
-                    u_fudge: window.fudge || 0
-                });
-            }
+
+            currentShader = newShader;
+            gl.useProgram(currentShader.program);
+            twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
+            Object.assign(uniforms, {
+                u_projectionMatrix: projection,
+                u_fudge: window.fudge || 0
+            });
 
             Object.assign(uniforms,
                 drawable.skin.getUniforms(drawableScale),

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1342,20 +1342,6 @@ class RenderWebGL extends EventEmitter {
             gl.enable(gl.BLEND);
         }
 
-        // const stampPixels = new Uint8Array(Math.floor(bounds.width * bounds.height * 4));
-        // gl.readPixels(0, 0, bounds.width, bounds.height, gl.RGBA, gl.UNSIGNED_BYTE, stampPixels);
-        //
-        // const stampCanvas = this._tempCanvas;
-        // stampCanvas.width = bounds.width;
-        // stampCanvas.height = bounds.height;
-        //
-        // const stampContext = stampCanvas.getContext('2d');
-        // const stampImageData = stampContext.createImageData(bounds.width, bounds.height);
-        // stampImageData.data.set(stampPixels);
-        // stampContext.putImageData(stampImageData, 0, 0);
-        //
-        // skin.drawStamp(stampCanvas, bounds.left, bounds.top);
-
         skin._drawToBuffer(this._queryBufferInfo.attachments[0], bounds.left, bounds.top);
     }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -576,6 +576,8 @@ class RenderWebGL extends EventEmitter {
      * Draw all current drawables and present the frame on the canvas.
      */
     draw () {
+        this._doExitDrawRegion();
+
         const gl = this._gl;
 
         twgl.bindFramebufferInfo(gl, null);
@@ -732,6 +734,8 @@ class RenderWebGL extends EventEmitter {
     }
 
     _isTouchingColorGpuStart (drawableID, candidateIDs, bounds, color3b, mask3b) {
+        this._doExitDrawRegion();
+
         const gl = this._gl;
         twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
 
@@ -1000,6 +1004,8 @@ class RenderWebGL extends EventEmitter {
      * @return {?DrawableExtraction} Data about the picked drawable
      */
     extractDrawable (drawableID, x, y) {
+        this._doExitDrawRegion();
+
         const drawable = this._allDrawables[drawableID];
         if (!drawable) return null;
 
@@ -1080,6 +1086,8 @@ class RenderWebGL extends EventEmitter {
      * @return {?ColorExtraction} Data about the picked color
      */
     extractColor (x, y, radius) {
+        this._doExitDrawRegion();
+
         const scratchX = Math.round(this._nativeSize[0] * ((x / this._gl.canvas.clientWidth) - 0.5));
         const scratchY = Math.round(-this._nativeSize[1] * ((y / this._gl.canvas.clientHeight) - 0.5));
 
@@ -1316,6 +1324,8 @@ class RenderWebGL extends EventEmitter {
      * @param {int} stampID - the unique ID of the Drawable to use as the stamp.
      */
     penStamp (penSkinID, stampID) {
+        this._doExitDrawRegion();
+
         const stampDrawable = this._allDrawables[stampID];
         if (!stampDrawable) {
             return;
@@ -1415,10 +1425,7 @@ class RenderWebGL extends EventEmitter {
 
     enterDrawRegion (regionId, enter) {
         if (this._regionId !== regionId) {
-            if (this._exitRegion !== null) {
-                this._exitRegion();
-            }
-            this._exitRegion = null;
+            this._doExitDrawRegion();
             this._regionId = regionId;
             enter();
         }
@@ -1426,6 +1433,13 @@ class RenderWebGL extends EventEmitter {
 
     exitDrawRegion (exit) {
         this._exitRegion = exit;
+    }
+
+    _doExitDrawRegion() {
+        if (this._exitRegion !== null) {
+            this._exitRegion();
+        }
+        this._exitRegion = null;
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1353,7 +1353,7 @@ class RenderWebGL extends EventEmitter {
 
         try {
             gl.disable(gl.BLEND);
-            this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection, {ignoreVisibility: true});
+            this._drawThese([stampID], ShaderManager.DRAW_MODE.stamp, projection, {ignoreVisibility: true});
         } finally {
             gl.enable(gl.BLEND);
         }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1440,20 +1440,13 @@ class RenderWebGL extends EventEmitter {
      * @param {any} regionId - id of the region to enter
      * @param {function} enter - handle to call when first entering a region
      */
-    enterDrawRegion (regionId, enter) {
+    enterDrawRegion (regionId, enter = regionId.enter, exit = regionId.exit) {
         if (this._regionId !== regionId) {
             this._doExitDrawRegion();
             this._regionId = regionId;
             enter();
+            this._exitRegion = exit;
         }
-    }
-
-    /**
-     * Register a exit handle when a new region will be entered.
-     * @param {function} exit - handle to call when about to enter a new region
-     */
-    exitDrawRegion (exit) {
-        this._exitRegion = exit;
     }
 
     /**

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -171,7 +171,12 @@ ShaderManager.DRAW_MODE = {
     /**
      * Sample a "texture" to draw a line with caps.
      */
-    lineSample: 'lineSample'
+    lineSample: 'lineSample',
+
+    /**
+     * Draw normally except for pre-multiplied alpha
+     */
+    stamp: 'stamp'
 };
 
 module.exports = ShaderManager;

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -166,7 +166,12 @@ ShaderManager.DRAW_MODE = {
     /**
      * Draw only the parts of the drawable which match a particular color.
      */
-    colorMask: 'colorMask'
+    colorMask: 'colorMask',
+
+    /**
+     * Draw a line.
+     */
+    line: 'line'
 };
 
 module.exports = ShaderManager;

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -169,12 +169,7 @@ ShaderManager.DRAW_MODE = {
     colorMask: 'colorMask',
 
     /**
-     * Draw a line.
-     */
-    line: 'line',
-
-    /**
-     * Sample a texture to draw a line with caps.
+     * Sample a "texture" to draw a line with caps.
      */
     lineSample: 'lineSample'
 };

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -171,7 +171,12 @@ ShaderManager.DRAW_MODE = {
     /**
      * Draw a line.
      */
-    line: 'line'
+    line: 'line',
+
+    /**
+     * Sample a texture to draw a line with caps.
+     */
+    lineSample: 'lineSample'
 };
 
 module.exports = ShaderManager;

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 uniform float u_fudge;
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -47,6 +47,11 @@ uniform float u_lineWidth;
 varying vec2 v_position;
 #endif // DRAW_MODE_line
 
+#ifdef DRAW_MODE_lineSample
+uniform vec4 u_lineColor;
+uniform float u_capScale;
+#endif // DRAW_MODE_lineSample
+
 uniform sampler2D u_skin;
 
 varying vec2 v_texCoord;
@@ -160,6 +165,15 @@ void main()
 	#endif // ENABLE_fisheye
 
 	gl_FragColor = texture2D(u_skin, texcoord0);
+
+	#ifdef DRAW_MODE_lineSample
+	{
+		gl_FragColor = u_lineColor;
+		gl_FragColor.a *= texture2D(u_skin, texcoord0).a;
+		gl_FragColor.a *= clamp(u_capScale + 1.0 - 2.0 * u_capScale * distance(texcoord0, vec2(0.5, 0.5)), 0.0, 1.0);
+		// gl_FragColor.a *= texcoord0.y;
+	}
+	#endif
 
 	#else // DRAW_MODE_line
 	{

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -1,4 +1,8 @@
+#ifndef DRAW_MODE_line
 precision mediump float;
+#else // DRAW_MODE_line
+precision highp float;
+#endif // DRAW_MODE_line
 
 uniform float u_fudge;
 
@@ -167,7 +171,7 @@ void main()
 		vec2 s3 = s0 * c + v_lineB;
 		// vec2 s3A = s3 - v_lineA;
 		// vec2 s3B = s3 - v_lineB;
-		// float l = max(dot(s0, s0) - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0);
+		// float l = min(max(dot(s0, s0) - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0), 1.0);
 
 		// float halfWidthSq = u_lineWidth * u_lineWidth / 2.0 / 2.0;
 		// vec2 vs3 = v - s3;
@@ -183,6 +187,7 @@ void main()
 		float r = max(halfWidth + 0.5 - min(distance(v, v_lineA), distance(v, v_lineB)), 0.0);
 
 		gl_FragColor.a *= min(max(l * w, r), 1.0);
+		/// gl_FragColor.a *= w;
 	}
 	#endif // DRAW_MODE_line
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -1,8 +1,4 @@
-#ifndef DRAW_MODE_line
 precision mediump float;
-#else // DRAW_MODE_line
-precision highp float;
-#endif // DRAW_MODE_line
 
 uniform float u_fudge;
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -207,6 +207,17 @@ void main()
 
 	#else // DRAW_MODE_lineSample
 	gl_FragColor = u_lineColor;
-	gl_FragColor.a *= clamp(u_capScale - u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5)), 0.0, 1.0);
+	gl_FragColor.a *= clamp(
+		// Scale the capScale a little to have an aliased region.
+		u_capScale + 2.0 -
+			u_capScale * 2.0 * distance(
+				// Scale and offset the texture coordinate so it has a little
+				// rim where the line is aliased.
+				v_texCoord * (u_capScale + 2.0) / u_capScale - 1.0 / u_capScale,
+				vec2(0.5, 0.5)
+			),
+		0.0,
+		1.0
+	);
 	#endif // DRAW_MODE_lineSample
 }

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -38,6 +38,7 @@ uniform float u_ghost;
 #ifdef DRAW_MODE_lineSample
 uniform vec4 u_lineColor;
 uniform float u_capScale;
+uniform float u_aliasAmount;
 #endif // DRAW_MODE_lineSample
 
 uniform sampler2D u_skin;
@@ -209,13 +210,9 @@ void main()
 	gl_FragColor = u_lineColor;
 	gl_FragColor.a *= clamp(
 		// Scale the capScale a little to have an aliased region.
-		u_capScale + 2.0 -
-			u_capScale * 2.0 * distance(
-				// Scale and offset the texture coordinate so it has a little
-				// rim where the line is aliased.
-				v_texCoord * (u_capScale + 2.0) / u_capScale - 1.0 / u_capScale,
-				vec2(0.5, 0.5)
-			),
+		(u_capScale + u_aliasAmount -
+			u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5))
+		) / (u_aliasAmount + 1.0),
 		0.0,
 		1.0
 	);

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -35,6 +35,14 @@ uniform float u_mosaic;
 uniform float u_ghost;
 #endif // ENABLE_ghost
 
+#ifdef DRAW_MODE_line
+varying vec2 v_lineA;
+varying vec2 v_lineB;
+uniform vec4 u_lineColor;
+uniform float u_lineWidth;
+varying vec2 v_position;
+#endif // DRAW_MODE_line
+
 uniform sampler2D u_skin;
 
 varying vec2 v_texCoord;
@@ -103,6 +111,7 @@ const vec2 kCenter = vec2(0.5, 0.5);
 
 void main()
 {
+	#ifndef DRAW_MODE_line
 	vec2 texcoord0 = v_texCoord;
 
 	#ifdef ENABLE_mosaic
@@ -148,6 +157,34 @@ void main()
 
 	gl_FragColor = texture2D(u_skin, texcoord0);
 
+	#else // DRAW_MODE_line
+	{
+		gl_FragColor = u_lineColor;
+
+		vec2 v = v_position;
+		vec2 s0 = (v_lineA - v_lineB);
+		float c = dot(v - v_lineB, s0) / dot(s0, s0);
+		vec2 s3 = s0 * c + v_lineB;
+		// vec2 s3A = s3 - v_lineA;
+		// vec2 s3B = s3 - v_lineB;
+		// float l = max(dot(s0, s0) - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0);
+
+		// float halfWidthSq = u_lineWidth * u_lineWidth / 2.0 / 2.0;
+		// vec2 vs3 = v - s3;
+		// float w = max(halfWidthSq - dot(vs3, vs3), 0.0);
+
+		// vec2 vlA = v - v_lineA;
+		// vec2 vlB = v - v_lineB;
+		// float r = max(halfWidthSq - min(dot(vlA, vlA), dot(vlB, vlB)), 0.0);
+
+		float halfWidth = u_lineWidth / 2.0;
+		float l = min(max(length(s0) + 1.0 - max(distance(s3, v_lineA), distance(s3, v_lineB)), 0.0), 1.0);
+		float w = min(max(halfWidth + 1.0 - distance(v, s3), 0.0), 1.0);
+		float r = max(halfWidth + 0.5 - min(distance(v, v_lineA), distance(v, v_lineB)), 0.0);
+
+		gl_FragColor.a *= min(max(l * w, r), 1.0);
+	}
+	#endif // DRAW_MODE_line
 
 	if (gl_FragColor.a == 0.0)
 	{

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -39,14 +39,6 @@ uniform float u_mosaic;
 uniform float u_ghost;
 #endif // ENABLE_ghost
 
-#ifdef DRAW_MODE_line
-varying vec2 v_lineA;
-varying vec2 v_lineB;
-uniform vec4 u_lineColor;
-uniform float u_lineWidth;
-varying vec2 v_position;
-#endif // DRAW_MODE_line
-
 #ifdef DRAW_MODE_lineSample
 uniform vec4 u_lineColor;
 uniform float u_capScale;
@@ -120,7 +112,6 @@ const vec2 kCenter = vec2(0.5, 0.5);
 
 void main()
 {
-	#ifndef DRAW_MODE_line
 	#ifndef DRAW_MODE_lineSample
 	vec2 texcoord0 = v_texCoord;
 
@@ -218,40 +209,9 @@ void main()
 
 	#else // DRAW_MODE_lineSample
 	gl_FragColor = u_lineColor;
-	gl_FragColor.a *= clamp(u_capScale + 1.0 - u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5)), 0.0, 1.0);
+	gl_FragColor.a *= clamp(u_capScale - u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5)), 0.0, 1.0);
 
 	// WebGL defaults to premultiplied alpha
 	gl_FragColor.rgb *= gl_FragColor.a;
 	#endif // DRAW_MODE_lineSample
-
-	#else // DRAW_MODE_line
-	gl_FragColor = u_lineColor;
-
-	vec2 v = v_position;
-	vec2 s0 = (v_lineA - v_lineB);
-	float c = dot(v - v_lineB, s0) / dot(s0, s0);
-	vec2 s3 = s0 * c + v_lineB;
-	// vec2 s3A = s3 - v_lineA;
-	// vec2 s3B = s3 - v_lineB;
-	// float l = min(max(dot(s0, s0) + 1.0 - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0), 1.0);
-    //
-	// float halfWidthSq = u_lineWidth * u_lineWidth / 2.0 / 2.0;
-	// vec2 vs3 = v - s3;
-	// float w = max(halfWidthSq + 1.0 - dot(vs3, vs3), 0.0);
-    //
-	// vec2 vlA = v - v_lineA;
-	// vec2 vlB = v - v_lineB;
-	// float r = max(halfWidthSq + 0.5 - min(dot(vlA, vlA), dot(vlB, vlB)), 0.0);
-
-	float halfWidth = u_lineWidth / 2.0;
-	float l = min(max(length(s0) + 1.0 - max(distance(s3, v_lineA), distance(s3, v_lineB)), 0.0), 1.0);
-	float w = min(max(halfWidth + 1.0 - distance(v, s3), 0.0), 1.0);
-	float r = max(halfWidth + 0.5 - min(distance(v, v_lineA), distance(v, v_lineB)), 0.0);
-
-	gl_FragColor.a *= min(max(l * w, r), 1.0);
-	/// gl_FragColor.a *= w;
-
-	// WebGL defaults to premultiplied alpha
-	gl_FragColor.rgb *= gl_FragColor.a;
-	#endif // DRAW_MODE_line
 }

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 uniform float u_fudge;
 
@@ -208,8 +208,5 @@ void main()
 	#else // DRAW_MODE_lineSample
 	gl_FragColor = u_lineColor;
 	gl_FragColor.a *= clamp(u_capScale - u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5)), 0.0, 1.0);
-
-	// WebGL defaults to premultiplied alpha
-	gl_FragColor.rgb *= gl_FragColor.a;
 	#endif // DRAW_MODE_lineSample
 }

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -171,15 +171,15 @@ void main()
 		vec2 s3 = s0 * c + v_lineB;
 		// vec2 s3A = s3 - v_lineA;
 		// vec2 s3B = s3 - v_lineB;
-		// float l = min(max(dot(s0, s0) - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0), 1.0);
-
+		// float l = min(max(dot(s0, s0) + 1.0 - max(dot(s3A, s3A), dot(s3B, s3B)), 0.0), 1.0);
+        //
 		// float halfWidthSq = u_lineWidth * u_lineWidth / 2.0 / 2.0;
 		// vec2 vs3 = v - s3;
-		// float w = max(halfWidthSq - dot(vs3, vs3), 0.0);
-
+		// float w = max(halfWidthSq + 1.0 - dot(vs3, vs3), 0.0);
+        //
 		// vec2 vlA = v - v_lineA;
 		// vec2 vlB = v - v_lineB;
-		// float r = max(halfWidthSq - min(dot(vlA, vlA), dot(vlB, vlB)), 0.0);
+		// float r = max(halfWidthSq + 0.5 - min(dot(vlA, vlA), dot(vlB, vlB)), 0.0);
 
 		float halfWidth = u_lineWidth / 2.0;
 		float l = min(max(length(s0) + 1.0 - max(distance(s3, v_lineA), distance(s3, v_lineB)), 0.0), 1.0);

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -199,7 +199,9 @@ void main()
 	#endif // DRAW_MODE_colorMask
 
 	// WebGL defaults to premultiplied alpha
+	#ifndef DRAW_MODE_stamp
 	gl_FragColor.rgb *= gl_FragColor.a;
+	#endif // DRAW_MODE_stamp
 
 	#endif // DRAW_MODE_silhouette
 

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -6,14 +6,6 @@ attribute vec2 a_texCoord;
 
 varying vec2 v_texCoord;
 
-#ifdef DRAW_MODE_line
-uniform vec3 u_lineA;
-uniform vec3 u_lineB;
-varying vec2 v_lineA;
-varying vec2 v_lineB;
-varying vec2 v_position;
-#endif // DRAW_MODE_line
-
 #ifdef DRAW_MODE_lineSample
 uniform float u_positionScalar;
 #endif
@@ -27,10 +19,4 @@ void main() {
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
 	#endif
     v_texCoord = a_texCoord;
-
-    #ifdef DRAW_MODE_line
-	v_lineA = (u_modelMatrix * vec4(u_lineA.xy, 0, 1)).xy;
-	v_lineB = (u_modelMatrix * vec4(u_lineB.xy, 0, 1)).xy;
-    v_position = (u_modelMatrix * vec4(a_position, 0, 1)).xy;
-    #endif // DRAW_MODE_line
 }

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -14,8 +14,18 @@ varying vec2 v_lineB;
 varying vec2 v_position;
 #endif // DRAW_MODE_line
 
+#ifdef DRAW_MODE_lineSample
+uniform float u_positionScalar;
+#endif
+
 void main() {
+	#ifdef DRAW_MODE_lineSample
+	vec2 position = a_position;
+	position.y = clamp(position.y * u_positionScalar, -0.5, 0.5);
+    gl_Position = u_projectionMatrix * u_modelMatrix * vec4(position, 0, 1);
+	#else
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
+	#endif
     v_texCoord = a_texCoord;
 
     #ifdef DRAW_MODE_line

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -11,12 +11,12 @@ uniform float u_positionScalar;
 #endif
 
 void main() {
-	#ifdef DRAW_MODE_lineSample
-	vec2 position = a_position;
-	position.y = clamp(position.y * u_positionScalar, -0.5, 0.5);
+    #ifdef DRAW_MODE_lineSample
+    vec2 position = a_position;
+    position.y = clamp(position.y * u_positionScalar, -0.5, 0.5);
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(position, 0, 1);
-	#else
+    #else
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
-	#endif
+    #endif
     v_texCoord = a_texCoord;
 }

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -6,7 +6,21 @@ attribute vec2 a_texCoord;
 
 varying vec2 v_texCoord;
 
+#ifdef DRAW_MODE_line
+uniform vec3 u_lineA;
+uniform vec3 u_lineB;
+varying vec2 v_lineA;
+varying vec2 v_lineB;
+varying vec2 v_position;
+#endif // DRAW_MODE_line
+
 void main() {
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
     v_texCoord = a_texCoord;
+
+    #ifdef DRAW_MODE_line
+	v_lineA = (u_modelMatrix * vec4(u_lineA.xy, 0, 1)).xy;
+	v_lineB = (u_modelMatrix * vec4(u_lineB.xy, 0, 1)).xy;
+    v_position = (u_modelMatrix * vec4(a_position, 0, 1)).xy;
+    #endif // DRAW_MODE_line
 }


### PR DESCRIPTION
### Proposed Changes

3 high level changes are made in this work.

- PenSkin: Draw stamp to Framebuffer
- PenSkin: Draw line to Framebuffer
- RenderWebGL: Draw Regions

#### PenSkin: Draw stamp to Framebuffer

The canvas stamp implementation draws the stamp to a framebuffer, reads those pixels from WebGL, stores the pixels into a canvas, draws that canvas to PenSkin's canvas, and eventually uploads the canvas to a WebGL texture. The framebuffer implementation draws the stamp to a framebuffer and then draws the framebuffer's output texture to another framebuffer. Drawing the framebuffer implementation in the larger scene uses that second framebuffer's output texture.

#### PenSkin: Draw line to Framebuffer

The canvas line implementation draws a line on the canvas. Canvas is doing all the work. The framebuffer line implementation uses a prebuilt mesh, sets up matrix and floating value uniforms, and draws the mesh on the framebuffer using a unique shader to render the line caps.

#### RenderWebGL: Draw Regions

`RenderWebGL#_drawThese` has a simple branch to reduce some of the WebGL state changes that at times duplicates existing state. Scaling this branch to work WebGL state changes made by PenSkin introduces Draw Regions. RenderWebGL provides two functions `enterDrawRegion` and `exitDrawRegion` to allow other classes to manipulate the WebGL state with a handle through `exitDrawRegion` to undo those changes when a new region is entered.

(I chose the name Draw Region. I'm happy to rename that to any other descriptor.)

### Reason for Changes

#### PenSkin: Draw stamp to Framebuffer

`gl.readPixels` must wait for the GPU and this time spent waiting wastes time. Since we already draw the stamped item to a framebuffer, we can draw that in the GPU to another destination texture through a second framebuffer. This lets us skip a series of steps needed by the stamp canvas implementation. Doing all of the drawing and work on the GPU instead of communicating between the CPU and GPU provides a large performance boost.

#### PenSkin: Draw line to Framebuffer

To render the PenSkin correctly, a line drawn before a stamp needs to be underneath. Drawing the stamps on the framebuffer means lines need to be drawn on the framebuffer. The first method that was attempted was updating a texture with canvas drawn lines and drawing the texture to the skin's framebuffer. This method while working is slightly slower than the existing draw stamps and lines to a canvas. The second method researched was drawing a bounding rectangle to the framebuffer with a unique shader that generated the line on the GPU. Building on that second method is the implementation in this PR, drawing the line's caps and body as a mesh with uniforms to deform the mesh and generate the caps based on the line's diameter. This method generally improves line drawing performance doing most of the work on the GPU.

#### RenderWebGL: Draw Regions

Scratch projects that draw lines tend to draw a lot of lines. All of the state changes needed to draw lines was too much to be performant. A mechanism so RenderWebGL could track the state in a high level way was needed so PenSkin could make state changes only when necessary. This works well with line drawing since lines are likely to be drawn as a cluster of work separate from other WebGL uses like color testing and drawing the scene.

### Numbers

I made 2 stress tests 236345336 and 236783324. One for pen stamp and one for pen line. After they finished cloning I timed how long 300 frames (with a `repeat [300]` block stack click) took with a stopwatch app. The below times are in seconds. I've included how long Scratch 2 took on the desktop platform.

|  Test | Platform | Scratch 2 | Scratch 3 Canvas | Scratch 3 Framebuffer | Canvas / Framebuffer |
|  ------ | ------ | -----: | -----: | -----: | -----: |
|  236345336 | MacBook Pro 15" 2017 Chrome | 59.09 | 73.66 | 10.48 | 702.86% |
|   | MacBook Pro 15" 2017 Safari | 59.09 | 81.52 | 10.86 | 750.64% |
|   | iPad Mini 2015 iOS 10 | n/a | 272.6 | 23.93 | 1139.15% |
|   | SMS Chromebook 2017 | n/a | 114.46 | 22.56 | 507.35% |
|  236783324 | MacBook Pro 15" 2017 Chrome | 101.76 | 30.36 | 11.72 | 259.04% |
|   | MacBook Pro 15" 2017 Safari | 101.76 | 26.63 | 15.98 | 166.64% |
|   | iPad Mini 2015 iOS 10 | n/a | 62.99 | 48.37 | 130.22% |
|   | SMS Chromebook 2017 | n/a | 105.71 | 47.95 | 220.45% |

---

Fixes #110 