### PR TITLE
Add API for getting the drawable order of a given drawable.

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -475,6 +475,16 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
+     * Returns the position of the given drawableID in the draw list. This is
+     * the absolute position irrespective of layer group.
+     * @param {number} drawableID The drawable ID to find.
+     * @return {number} The postion of the given drawable ID.
+     */
+    getDrawableOrder (drawableID) {
+        return this._drawList.indexOf(drawableID);
+    }
+
+    /**
      * Set a drawable's order in the drawable list (effectively, z/layer).
      * Can be used to move drawables to absolute positions in the list,
      * or relative to their current positions.


### PR DESCRIPTION
### Resolves

Work towards saving/loading sprite layer ordering in .sb3 files.

### Proposed Changes

Adds a top level API for accessing a drawable's layer ordering within the full draw list. This does not take into account layer groups because it will be used across the background layer group as well as the sprite layer group.

### Reason for Changes

This is necessary for getting the sprite layer ordering information to the VM so that it can be saved/loaded.

### Related PRs
LLK/scratch-vm#TBD