### PR TITLE
Update scratch-vm and svg-renderer dependency and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gh-pages": "^1.0.0",
     "jsdoc": "^3.5.5",
     "json": "^9.0.4",
-    "scratch-vm": "0.1.0-prerelease.1527254075",
+    "scratch-vm": "0.2.0-prerelease.20180724192502",
     "tap": "^11.0.0",
     "travis-after-all": "^1.4.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
@@ -53,7 +53,7 @@
     "minilog": "3.1.0",
     "raw-loader": "^0.5.1",
     "scratch-storage": "^0.4.0",
-    "scratch-svg-renderer": "0.2.0-prerelease.20180613184320",
+    "scratch-svg-renderer": "0.2.0-prerelease.20180712223402",
     "twgl.js": "4.4.0"
   }
 }

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -1,6 +1,7 @@
 <body>
     <script src="../../node_modules/scratch-vm/dist/web/scratch-vm.js"></script>
     <script src="../../node_modules/scratch-storage/dist/web/scratch-storage.js"></script>
+    <script src="../../node_modules/scratch-svg-renderer/dist/web/scratch-svg-renderer.js"></script>
     <!-- note: this uses the BUILT version of scratch-render!  make sure to npm run build -->
     <script src="../../dist/web/scratch-render.js"></script>
 
@@ -17,6 +18,8 @@
 
         vm.attachStorage(storage);
         vm.attachRenderer(render);
+        vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
+        vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
         document.getElementById('file').addEventListener('click', e => {
             document.body.removeChild(document.getElementById('loaded'));


### PR DESCRIPTION
There was an issue where greenkeeper was not able to update the VM dependency because the svg renderer needed to be updated also, and the new API for connecting vector/bitmap adapters needed to be implemented.

/cc @fsih @cwillisf @kchadha I'm not sure who knows this stuff best, but I was assigned https://github.com/LLK/scratch-render/pull/316 so here it is!

Closes https://github.com/LLK/scratch-render/pull/316