### PR TITLE
fix travis.yml to quote github author name for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
       - VPKG=$($(npm bin)/json -f package.json version)
       - export VERSION=${VPKG}-prerelease.$(date +%Y%m%d%H%M%S)
       - npm --no-git-tag-version version $VERSION
-      - git config --global user.email $(git log --pretty=format:"%ae" -n1)
-      - git config --global user.name $(git log --pretty=format:"%an" -n1)
+      - git config --global user.email "$(git log --pretty=format:'%ae' -n1)"
+      - git config --global user.name "$(git log --pretty=format:'%an' -n1)"
       deploy:
         provider: npm
         skip_cleanup: true


### PR DESCRIPTION
This will stop deploy scripts from failing for people with more than one name, or fancy stuff in their names