### PR TITLE
add uniformName to ShaderManager EFFECT_INFO entries

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -43,8 +43,9 @@ class Drawable {
         const numEffects = ShaderManager.EFFECTS.length;
         for (let index = 0; index < numEffects; ++index) {
             const effectName = ShaderManager.EFFECTS[index];
-            const converter = ShaderManager.EFFECT_INFO[effectName].converter;
-            this._uniforms[`u_${effectName}`] = converter(0);
+            const effectInfo = ShaderManager.EFFECT_INFO[effectName];
+            const converter = effectInfo.converter;
+            this._uniforms[effectInfo.uniformName] = converter(0);
         }
 
         this._position = twgl.v3.create(0, 0);
@@ -193,7 +194,7 @@ class Drawable {
                     this._effectBits &= ~effectInfo.mask;
                 }
                 const converter = effectInfo.converter;
-                this._uniforms[`u_${effectName}`] = converter(rawValue);
+                this._uniforms[effectInfo.uniformName] = converter(rawValue);
                 if (effectInfo.shapeChanges) {
                     this.setConvexHullDirty();
                 }

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -88,30 +88,35 @@ class ShaderManager {
 ShaderManager.EFFECT_INFO = {
     /** Color effect */
     color: {
+        uniformName: 'u_color',
         mask: 1 << 0,
         converter: x => (x / 200) % 1,
         shapeChanges: false
     },
     /** Fisheye effect */
     fisheye: {
+        uniformName: 'u_fisheye',
         mask: 1 << 1,
         converter: x => Math.max(0, (x + 100) / 100),
         shapeChanges: true
     },
     /** Whirl effect */
     whirl: {
+        uniformName: 'u_whirl',
         mask: 1 << 2,
         converter: x => -x * Math.PI / 180,
         shapeChanges: true
     },
     /** Pixelate effect */
     pixelate: {
+        uniformName: 'u_pixelate',
         mask: 1 << 3,
         converter: x => Math.abs(x) / 10,
         shapeChanges: true
     },
     /** Mosaic effect */
     mosaic: {
+        uniformName: 'u_mosaic',
         mask: 1 << 4,
         converter: x => {
             x = Math.round((Math.abs(x) + 10) / 10);
@@ -122,12 +127,14 @@ ShaderManager.EFFECT_INFO = {
     },
     /** Brightness effect */
     brightness: {
+        uniformName: 'u_brightness',
         mask: 1 << 5,
         converter: x => Math.max(-100, Math.min(x, 100)) / 100,
         shapeChanges: false
     },
     /** Ghost effect */
     ghost: {
+        uniformName: 'u_ghost',
         mask: 1 << 6,
         converter: x => 1 - (Math.max(0, Math.min(x, 100)) / 100),
         shapeChanges: false


### PR DESCRIPTION
### Resolves

Cloning performance.

### Proposed Changes

Use a member of EFFECT_INFO for uniform names like `u_${effectName}`.

### Reason for Changes

The `uniformName` is a static member with interned strings instead of always needing to concatenate. This improves the performance of cloning any sprite as they always have at least the default effect set.

### Numbers

Performance numbers are the number of clones made in 30 seconds of the following test project in the benchmark suite.

|  Test | Platform | Base | uniformName | change |
|  ------ | ------ | -----: | -----: | -----: |
|  [238081748](http://llk.github.io/scratch-vm/index.html#238081748,0,30000) | MBP 15" Chrome 2017 | 628480 | 664960 | 5.80% |
|   | MBP 15" Safari 2017 | 653696 | 671872 | 2.78% |
|   | MBP 15" Firefox 2017 | 523264 | 530560 | 1.39% |
|   | SMS Chromebook 2017 | 139648 | 167424 | 19.89% |
|   | iPad Mini 2015 | 154794 | 156672 | 1.21% |
