### PR TITLE
Round drawable position

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -190,8 +190,8 @@ class Drawable {
         if ('position' in properties && (
             this._position[0] !== properties.position[0] ||
             this._position[1] !== properties.position[1])) {
-            this._position[0] = properties.position[0];
-            this._position[1] = properties.position[1];
+            this._position[0] = Math.round(properties.position[0]);
+            this._position[1] = Math.round(properties.position[1]);
             dirty = true;
         }
         if ('direction' in properties && this._direction !== properties.direction) {


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-vm/pull/1453

### Proposed Changes

Round the sprite position received from the VM.

### Reason for Changes

Scratch 2 rendered sprite position is at whole numbers, while its vm position may be rational numbers.

Reviewing https://github.com/LLK/scratch-flash/blob/develop/src/scratch/ScratchSprite.as#L180-L186 again I see the error I made in https://github.com/LLK/scratch-vm/pull/1453. `x` and `y` in `ScratchSprite.as` are the rendering position. `scratchX` and `scratchY` are the vm position. `x` and `y` are defined by the `Sprite` class that `ScratchSprite` inherits from its parent `ScratchObj`.

### Test Coverage

I haven't identified a project this improves yet. In theory it should fix projects with sprites with a 1-pixel blur because it is rendered with a rational position instead of a whole number position. It should also fix some high-precision issues with touching object and color. It may be one cause for these problems and not fix all instances of these issues.
