### PR TITLE
Add ability to get a snapshot of the next frame

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -178,6 +178,9 @@ class RenderWebGL extends EventEmitter {
         /** @type {function} */
         this._exitRegion = null;
 
+        /** @type {Array.<function>} */
+        this._snapshotCallbacks = [];
+
         this._svgTextBubble = new SVGTextBubble();
 
         this._createGeometry();
@@ -589,6 +592,11 @@ class RenderWebGL extends EventEmitter {
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         this._drawThese(this._drawList, ShaderManager.DRAW_MODE.default, this._projection);
+        if (this._snapshotCallbacks.length > 0) {
+            const snapshot = gl.canvas.toDataURL();
+            this._snapshotCallbacks.forEach(cb => cb(snapshot));
+            this._snapshotCallbacks = [];
+        }
     }
 
     /**
@@ -1703,6 +1711,10 @@ class RenderWebGL extends EventEmitter {
         dst[1] += blendAlpha * 255;
         dst[2] += blendAlpha * 255;
         return dst;
+    }
+
+    requestSnapshot (callback) {
+        this._snapshotCallbacks.push(callback);
     }
 }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -178,7 +178,7 @@ class RenderWebGL extends EventEmitter {
         /** @type {function} */
         this._exitRegion = null;
 
-        /** @type {Array.<function>} */
+        /** @type {Array.<snapshotCallback>} */
         this._snapshotCallbacks = [];
 
         this._svgTextBubble = new SVGTextBubble();
@@ -1713,6 +1713,14 @@ class RenderWebGL extends EventEmitter {
         return dst;
     }
 
+    /**
+     * @callback RenderWebGL#snapshotCallback
+     * @param {string} dataURI Data URI of the snapshot of the renderer
+     */
+
+    /**
+     * @param {snapshotCallback} callback Function called in the next frame with the snapshot data
+     */
     requestSnapshot (callback) {
         this._snapshotCallbacks.push(callback);
     }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Gives a means to resolving LLK/scratch-gui#3166

### Proposed Changes

_Describe what this Pull Request does_
Adds a method for registering callbacks that receive the renderer contents as a data URI on the next frame.

### Reason for Changes

_Explain why these changes should be made_
See LLK/scratch-gui#3166!

### Test Coverage

_Please show how you have added tests to cover your changes_
:| It works in my testing on the GUI!
