### PR TITLE
Fix bug when bounds would be infinite and cause never ending loop

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -968,7 +968,12 @@ class RenderWebGL extends EventEmitter {
         if (candidateIDs.length === 0) {
             return false;
         }
+
         const bounds = this.clientSpaceToScratchBounds(centerX, centerY, touchWidth, touchHeight);
+        if (bounds.left === -Infinity || bounds.bottom === -Infinity) {
+            return false;
+        }
+
         const hits = [];
         const worldPos = twgl.v3.create(0, 0, 0);
         // Iterate over the scratch pixels and check if any candidate can be


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/344

### Proposed Changes

This will add a check when picking an object at a certain point to return early when the bounds are unset for any reason.

### Reason for Changes

Sometimes the `scratch-gui` tab would hang completely when using the `scratch-paint` vector editor.
I tracked this back to the `pick` method in this project.

This is not really easy to reproduce but seems to fix the issue and should be a reasonable improvement in the code.

### Test Coverage

None. This is really hard to reproduce in a test.