### PR TITLE
Fix empty speech bubbles showing up squished

### DIFF
--- a/src/util/svg-text-bubble.js
+++ b/src/util/svg-text-bubble.js
@@ -145,11 +145,16 @@ class SVGTextBubble {
             </g>`;
     }
 
-
-    _getTextSize () {
-        const svgString = this._wrapSvgFragment(this._textFragment);
+    _getTextSize (textFragment) {
+        const svgString = this._wrapSvgFragment(textFragment);
         if (!this._textSizeCache[svgString]) {
             this._textSizeCache[svgString] = this.svgRenderer.measure(svgString);
+            if (this._textSizeCache[svgString].height === 0) {
+                // The speech bubble is empty, so use the height of a single line with content (or else it renders
+                // weirdly, see issue #302).
+                const dummyFragment = this._buildTextFragment('X');
+                this._textSizeCache[svgString] = this._getTextSize(dummyFragment);
+            }
         }
         return this._textSizeCache[svgString];
     }
@@ -183,7 +188,7 @@ class SVGTextBubble {
         let fragment = '';
 
         const radius = 16;
-        const {x, y, width, height} = this._getTextSize();
+        const {x, y, width, height} = this._getTextSize(this._textFragment);
         const padding = 10;
         const fullWidth = Math.max(MIN_WIDTH, width) + (2 * padding);
         const fullHeight = height + (2 * padding);


### PR DESCRIPTION
### Resolves

Fixes #302.

### Proposed Changes

This makes the `_getTextSize` function measure the size of a single line with content ("X") when it sees that the measured height is zero.

### Reason for Changes

To fix empty speech bubbles (e.g. saying " ") showing up squished.

### Test Coverage

Tested manually:

![The Scratch cat with an empty speech bubble, with the same dimensions as though it included a single character](https://user-images.githubusercontent.com/9948030/48630710-4d3b5b00-e993-11e8-82f4-a3092fade530.png)