### PR TITLE
Fix extraction of drawable to not clip bounds.

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1038,7 +1038,6 @@ class RenderWebGL extends EventEmitter {
      * @return {?DrawableExtraction} Data about the picked drawable
      */
     extractDrawable (drawableID, x, y) {
-        // console.log('here');
         this._doExitDrawRegion();
 
         const drawable = this._allDrawables[drawableID];

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1065,14 +1065,9 @@ class RenderWebGL extends EventEmitter {
         const bufferInfo = twgl.createFramebufferInfo(gl, attachments, clampedWidth, clampedHeight);
 
         // If the new bufferInfo is invalid, fall back to using the smaller _queryBufferInfo
-        console.log(bufferInfo);
-        if (gl.checkFramebufferStatus(bufferInfo.framebuffer) === 0) {
-            // twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
-            twgl.bindFramebufferInfo(gl, bufferInfo);
-            console.log(bufferInfo);
-        } else {
-            twgl.bindFramebufferInfo(gl, bufferInfo);
-            console.log(bufferInfo);
+        twgl.bindFramebufferInfo(gl, bufferInfo);
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+            twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
         }
 
         // Translate to scratch units relative to the drawable

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1038,6 +1038,7 @@ class RenderWebGL extends EventEmitter {
      * @return {?DrawableExtraction} Data about the picked drawable
      */
     extractDrawable (drawableID, x, y) {
+        // console.log('here');
         this._doExitDrawRegion();
 
         const drawable = this._allDrawables[drawableID];

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1052,7 +1052,7 @@ class RenderWebGL extends EventEmitter {
         const bounds = drawable.getFastBounds();
         bounds.snapToInt();
 
-        // Use a new bufferInfo since _queryBufferInfo is limited to 480x360
+        // Use a new bufferInfo since this._queryBufferInfo is limited to 480x360
         const attachments = [
             {format: gl.RGBA},
             {format: gl.DEPTH_STENCIL}

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1048,10 +1048,17 @@ class RenderWebGL extends EventEmitter {
         const scratchY = this._nativeSize[1] * ((y / this._gl.canvas.clientHeight) - 0.5);
 
         const gl = this._gl;
-        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
 
         const bounds = drawable.getFastBounds();
         bounds.snapToInt();
+
+        // Use a new bufferInfo since _queryBufferInfo is limited to 480x360
+        const attachments = [
+            {format: gl.RGBA},
+            {format: gl.DEPTH_STENCIL}
+        ];
+        const bufferInfo = twgl.createFramebufferInfo(gl, attachments, bounds.width, bounds.height);
+        twgl.bindFramebufferInfo(gl, bufferInfo);
 
         // Translate to scratch units relative to the drawable
         const pickX = scratchX - bounds.left;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1064,12 +1064,15 @@ class RenderWebGL extends EventEmitter {
         ];
         const bufferInfo = twgl.createFramebufferInfo(gl, attachments, clampedWidth, clampedHeight);
 
-        // If the new bufferInfo is invalid fall back to using the smaller _queryBufferInfo
+        // If the new bufferInfo is invalid, fall back to using the smaller _queryBufferInfo
+        console.log(bufferInfo);
         if (gl.checkFramebufferStatus(bufferInfo.framebuffer) === 0) {
             // twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
             twgl.bindFramebufferInfo(gl, bufferInfo);
+            console.log(bufferInfo);
         } else {
             twgl.bindFramebufferInfo(gl, bufferInfo);
+            console.log(bufferInfo);
         }
 
         // Translate to scratch units relative to the drawable


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1808

### Notes

I am new to `scratch-render` so not 100% sure if `extractDrawable` is used somewhere else where the clipping was actually intended.
