### PR TITLE
Align the bounding box to the center of the pixel instead of top left

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -536,13 +536,15 @@ class Drawable {
     _getTransformedHullPoints () {
         const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
         const skinSize = this.skin.size;
+        const halfXPixel = 1 / skinSize[0] / 2;
+        const halfYPixel = 1 / skinSize[1] / 2;
         const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
         const transformedHullPoints = [];
         for (let i = 0; i < this._convexHullPoints.length; i++) {
             const point = this._convexHullPoints[i];
             const glPoint = twgl.v3.create(
-                0.5 + (-point[0] / skinSize[0]),
-                (point[1] / skinSize[1]) - 0.5,
+                0.5 + (-point[0] / skinSize[0]) - halfXPixel,
+                (point[1] / skinSize[1]) - 0.5 + halfYPixel,
                 0
             );
             twgl.m4.transformPoint(tm, glPoint, glPoint);


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/1536

### Proposed Changes

Subtract half a pixel from X and Y for each bounding box hull point.

### Reason for Changes

Previously point values were aligned with top left of the pixel, which would mean that if an image was 128 wide, X values could only range between 0 - 127. This made every bounding box up and to the left by half a pixel, and this difference would get multiplied by the sprite size. 

This bounding box offset is why the circles in [this test project](https://llk.github.io/scratch-gui/develop/#207038919) were pushed down and to the right. If you take a look at the first circle, it gets its size multiplied by 11, which led to a 5.5 pixel offset for the X and Y coordinate values. With this change, we add some math to subtract or add half a pixel to the X and Y point values. This aligns the bounding box with the center of the pixel, which prevents this shift in coordinates. 
