### PR TITLE
Always use nearest for raster textures

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -426,14 +426,14 @@ class Drawable {
      * Should the drawable use NEAREST NEIGHBOR or LINEAR INTERPOLATION mode
      */
     get useNearest () {
-        // We can't use nearest neighbor unless we are a multiple of 90 rotation
-        if (this._direction % 90 !== 0) {
-            return false;
-        }
-
         // Raster skins (bitmaps) should always prefer nearest neighbor
         if (this.skin.isRaster) {
             return true;
+        }
+
+        // We can't use nearest neighbor unless we are a multiple of 90 rotation
+        if (this._direction % 90 !== 0) {
+            return false;
         }
 
         // If the scale of the skin is very close to 100 (0.99999 variance is okay I guess)


### PR DESCRIPTION
### Resolves
Fixes blurring of rotated bitmaps
Before
![image](https://user-images.githubusercontent.com/2855464/50650850-a7967800-0f4f-11e9-863d-330969d8e5dd.png)
After
![image](https://user-images.githubusercontent.com/2855464/50650782-7453e900-0f4f-11e9-9d21-087b7f816f6a.png)

### Proposed Changes
Use nearest neighbor for rasters

### Reason for Changes
Keep pixels pixelated

### Test Coverage

_Please show how you have added tests to cover your changes_
