### PR TITLE
Compute max texture size directly instead of stepping by powers of two.

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -115,10 +115,7 @@ class SVGSkin extends Skin {
             }
 
             const maxDimension = Math.max(this._svgRenderer.canvas.width, this._svgRenderer.canvas.height);
-            let testScale = 2;
-            for (testScale; maxDimension * testScale <= MAX_TEXTURE_DIMENSION; testScale *= 2) {
-                this._maxTextureScale = testScale;
-            }
+            this._maxTextureScale = MAX_TEXTURE_DIMENSION / maxDimension;
 
             if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
             this.setRotationCenter.apply(this, rotationCenter);

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -68,7 +68,7 @@ class SVGSkin extends Skin {
     getTexture (scale) {
         // The texture only ever gets uniform scale. Take the larger of the two axes.
         const scaleMax = scale ? Math.max(Math.abs(scale[0]), Math.abs(scale[1])) : 100;
-        const requestedScale = Math.min(scaleMax / 100, this._maxTextureScale);
+        const requestedScale = scaleMax / 100;
         let newScale = this._textureScale;
         while ((newScale < this._maxTextureScale) && (requestedScale >= 1.5 * newScale)) {
             newScale = Math.min(this._maxTextureScale, newScale * 2);

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -71,7 +71,7 @@ class SVGSkin extends Skin {
         const requestedScale = Math.min(scaleMax / 100, this._maxTextureScale);
         let newScale = this._textureScale;
         while ((newScale < this._maxTextureScale) && (requestedScale >= 1.5 * newScale)) {
-            newScale *= 2;
+            newScale = Math.max(this._maxTextureScale, newScale * 2);
         }
         if (this._textureScale !== newScale) {
             this._textureScale = newScale;

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -71,7 +71,7 @@ class SVGSkin extends Skin {
         const requestedScale = Math.min(scaleMax / 100, this._maxTextureScale);
         let newScale = this._textureScale;
         while ((newScale < this._maxTextureScale) && (requestedScale >= 1.5 * newScale)) {
-            newScale = Math.max(this._maxTextureScale, newScale * 2);
+            newScale = Math.min(this._maxTextureScale, newScale * 2);
         }
         if (this._textureScale !== newScale) {
             this._textureScale = newScale;


### PR DESCRIPTION
~Allows more of the MAX_TEXTURE_SIZE to be used for scaling vector costumes. Tested with the projects listed when this was originally introduced (https://github.com/LLK/scratch-render/pull/232) and tested with things like the sonic engine which uses huge scaling for levels (#7471180) and @thisandagain s test project (#276930698)~

I don't think this works the way we wanted. needs help