### PR TITLE
Increase maximum texture size and back it off if GL fails to render

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -81,15 +81,18 @@ class SVGSkin extends Skin {
                 gl.bindTexture(gl.TEXTURE_2D, this._texture);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
                 error = gl.getError();
+                if (error && newScale > 1) {
+                    newScale /= 2;
+                    this._textureScale = newScale;
+                    this._maxTextureScale = newScale;
+                    this._svgRenderer._draw(this._textureScale, callback);
+                }
             }
         };
-        do {
-            if (this._textureScale !== newScale) {
-                this._textureScale = newScale;
-                this._svgRenderer._draw(this._textureScale, callback);
-            }
-            newScale /= 2;
-        } while (error && newScale > 1);
+        if (this._textureScale !== newScale) {
+            this._textureScale = newScale;
+            this._svgRenderer._draw(this._textureScale, callback);
+        }
 
         return this._texture;
     }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -3,7 +3,7 @@ const twgl = require('twgl.js');
 const Skin = require('./Skin');
 const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 
-const MAX_TEXTURE_DIMENSION = 2048;
+const MAX_TEXTURE_DIMENSION = 10240;
 
 class SVGSkin extends Skin {
     /**
@@ -68,21 +68,28 @@ class SVGSkin extends Skin {
     getTexture (scale) {
         // The texture only ever gets uniform scale. Take the larger of the two axes.
         const scaleMax = scale ? Math.max(Math.abs(scale[0]), Math.abs(scale[1])) : 100;
-        const requestedScale = Math.min(scaleMax / 100, this._maxTextureScale);
+        const requestedScale = scaleMax / 100;
         let newScale = this._textureScale;
         while ((newScale < this._maxTextureScale) && (requestedScale >= 1.5 * newScale)) {
             newScale *= 2;
         }
-        if (this._textureScale !== newScale) {
-            this._textureScale = newScale;
-            this._svgRenderer._draw(this._textureScale, () => {
-                if (this._textureScale === newScale) {
-                    const gl = this._renderer.gl;
-                    gl.bindTexture(gl.TEXTURE_2D, this._texture);
-                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
-                }
-            });
-        }
+
+        let error;
+        const callback = () => {
+            if (this._textureScale === newScale) {
+                const gl = this._renderer.gl;
+                gl.bindTexture(gl.TEXTURE_2D, this._texture);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
+                error = gl.getError();
+            }
+        };
+        do {
+            if (this._textureScale !== newScale) {
+                this._textureScale = newScale;
+                this._svgRenderer._draw(this._textureScale, callback);
+            }
+            newScale /= 2;
+        } while (error && newScale > 1);
 
         return this._texture;
     }


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-gui/issues/4211

### Proposed Changes
Increase max texture size and implement back-off

### Reason for Changes
Scratch 2 2D renderer did not enforce a max texture size

### Test Coverage
Tested projects 274832716, 74711180
