### PR TITLE
Fix uncaught error `cannot find property updateSilhouette of null`

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -931,7 +931,11 @@ class RenderWebGL extends EventEmitter {
         const worldPos = twgl.v3.create();
 
         drawable.updateMatrix();
-        drawable.skin.updateSilhouette();
+        if (drawable.skin) {
+            drawable.skin.updateSilhouette();
+        } else {
+            log.warn(`Could not find skin for drawable with id: ${drawableID}`);
+        }
 
         for (worldPos[1] = bounds.bottom; worldPos[1] <= bounds.top; worldPos[1]++) {
             for (worldPos[0] = bounds.left; worldPos[0] <= bounds.right; worldPos[0]++) {
@@ -963,7 +967,11 @@ class RenderWebGL extends EventEmitter {
             // default pick list ignores visible and ghosted sprites.
             if (drawable.getVisible() && drawable.getUniforms().u_ghost !== 0) {
                 drawable.updateMatrix();
-                drawable.skin.updateSilhouette();
+                if (drawable.skin) {
+                    drawable.skin.updateSilhouette();
+                } else {
+                    log.warn(`Could not find skin for drawable with id: ${id}`);
+                }
                 return true;
             }
             return false;


### PR DESCRIPTION
### Proposed Changes

Sentry has been reporting many instances of the following error:
`cannot find property updateSilhouette of null`. Tracing the code snippet reported in the sentry event, I believe this particular issue is coming from the call to updateSilhouette inside of the `pick` function.

Unfortunately, I was not able to reproduce the error myself locally (I tried reproing at least 3 different sentry events). I added falsey checks for both of the places in RenderWebGL where we are calling updateSilhouette without first checking that drawable.skin actually exists. In the other two places the function is being called, we check for the existence of drawable.skin before getting to the line where that function is called.

### Reason for Changes

Lots of errors being reported.

### Test Coverage

I wasn't able to reproduce the actual error condition...

cc/ @thisandagain, @picklesrus 