### PR TITLE
Implement updateSilhouette to allow updates to happen when needed

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -101,7 +101,6 @@ class SVGSkin extends Skin {
             if (this._texture) {
                 gl.bindTexture(gl.TEXTURE_2D, this._texture);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
-                this._silhouette.update(this._svgRenderer.canvas);
             } else {
                 // TODO: mipmaps?
                 const textureOptions = {
@@ -111,8 +110,8 @@ class SVGSkin extends Skin {
                 };
 
                 this._texture = twgl.createTexture(gl, textureOptions);
-                this._silhouette.update(this._svgRenderer.canvas);
             }
+            this._silhouetteDirty = true;
 
             const maxDimension = Math.max(this._svgRenderer.canvas.width, this._svgRenderer.canvas.height);
             let testScale = 2;
@@ -126,6 +125,12 @@ class SVGSkin extends Skin {
         });
     }
 
+    updateSilhouette () {
+        if (this._silhouetteDirty) {
+            this._silhouette.update(this._svgRenderer.canvas);
+            this._silhouetteDirty = false;
+        }
+    }
 }
 
 module.exports = SVGSkin;


### PR DESCRIPTION
Instead of updating the silhouette on svg load, allow it to happen later when it is needed, improving load performance.

/cc @cwillisf 