### PR TITLE
Fix typo for sb3 test files

### DIFF
--- a/test/integration/scratch-tests.js
+++ b/test/integration/scratch-tests.js
@@ -114,7 +114,7 @@ const testBubbles = () => test('bubble snapshot', async t => {
 // immediately invoked async function to let us wait for each test to finish before starting the next.
 (async () => {
     const files = fs.readdirSync(testDir())
-        .filter(uri => uri.endsWith('.sb2') || uri.endsWidth('.sb3'));
+        .filter(uri => uri.endsWith('.sb2') || uri.endsWith('.sb3'));
 
     for (const file of files) {
         await testFile(file);


### PR DESCRIPTION
### Proposed Changes

Fixes a small typo that prevents us from testing with `sb3` files

### Reason for Changes

I saw this typo while working on scratch-tests.js, it currently errors if we try to run this test with an sb3 file.
