### PR TITLE
Update silhouette after getting texture at a new scale

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -80,6 +80,7 @@ class SVGSkin extends Skin {
                     const gl = this._renderer.gl;
                     gl.bindTexture(gl.TEXTURE_2D, this._texture);
                     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._svgRenderer.canvas);
+                    this._silhouette.update(this._svgRenderer.canvas);
                 }
             });
         }


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/390

### Proposed Changes

Update the silhouette after redrawing a texture at a different scale

### Reason for Changes
Use a silhouette rendered the same size as what's on stage

### Test Coverage
Tested project 277169481
