### PR TITLE
Add "query playground"

### DIFF
--- a/src/playground/.eslintrc.js
+++ b/src/playground/.eslintrc.js
@@ -3,5 +3,8 @@ module.exports = {
     extends: ['scratch'],
     env: {
         browser: true
+    },
+    rules: {
+        'no-console': 'off'
     }
 };

--- a/src/playground/.eslintrc.js
+++ b/src/playground/.eslintrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-    root: true,
     extends: ['scratch'],
     env: {
         browser: true

--- a/src/playground/getMousePosition.js
+++ b/src/playground/getMousePosition.js
@@ -1,0 +1,37 @@
+// Adapted from code by Simon Sarris: http://stackoverflow.com/a/10450761
+const getMousePos = function (event, element) {
+    const stylePaddingLeft = parseInt(document.defaultView.getComputedStyle(element, null).paddingLeft, 10) || 0;
+    const stylePaddingTop = parseInt(document.defaultView.getComputedStyle(element, null).paddingTop, 10) || 0;
+    const styleBorderLeft = parseInt(document.defaultView.getComputedStyle(element, null).borderLeftWidth, 10) || 0;
+    const styleBorderTop = parseInt(document.defaultView.getComputedStyle(element, null).borderTopWidth, 10) || 0;
+
+    // Some pages have fixed-position bars at the top or left of the page
+    // They will mess up mouse coordinates and this fixes that
+    const html = document.body.parentNode;
+    const htmlTop = html.offsetTop;
+    const htmlLeft = html.offsetLeft;
+
+    // Compute the total offset. It's possible to cache this if you want
+    let offsetX = 0;
+    let offsetY = 0;
+    if (typeof element.offsetParent !== 'undefined') {
+        do {
+            offsetX += element.offsetLeft;
+            offsetY += element.offsetTop;
+        } while ((element = element.offsetParent));
+    }
+
+    // Add padding and border style widths to offset
+    // Also add the <html> offsets in case there's a position:fixed bar
+    // This part is not strictly necessary, it depends on your styling
+    offsetX += stylePaddingLeft + styleBorderLeft + htmlLeft;
+    offsetY += stylePaddingTop + styleBorderTop + htmlTop;
+
+    // We return a simple javascript object with x and y defined
+    return {
+        x: event.pageX - offsetX,
+        y: event.pageY - offsetY
+    };
+};
+
+module.exports = getMousePos;

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -12,7 +12,7 @@
 <canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
 <p>
     <label for="fudgeproperty">Property to tweak:</label>
-    <select id="fudgeproperty" onchange="onFudgePropertyChanged(this.value)">
+    <select id="fudgeproperty">
         <option value="posx">Position X</option>
         <option value="posy">Position Y</option>
         <option value="direction">Direction</option>
@@ -27,149 +27,12 @@
         <option value="ghost">Ghost</option>
     </select>
     <label for="fudge">Property Value:</label>
-    <input type="range" id="fudge" style="width:50%" value="90" min="-90" max="270" step="any" oninput="onFudgeChanged(this.value)" onchange="onFudgeChanged(this.value)">
+    <input type="range" id="fudge" style="width:50%" value="90" min="-90" max="270" step="any">
 </p>
 <p>
-    <label for="fudgeMin">Min:</label><input id="fudgeMin" type="number" onchange="onFudgeMinChanged(this.value)">
-    <label for="fudgeMax">Max:</label><input id="fudgeMax" type="number" onchange="onFudgeMaxChanged(this.value)">
+    <label for="fudgeMin">Min:</label><input id="fudgeMin" type="number">
+    <label for="fudgeMax">Max:</label><input id="fudgeMax" type="number">
 </p>
-<script src="scratch-render.js"></script>
-<script>
-    var canvas = document.getElementById('scratch-stage');
-    var fudge = 90;
-    var renderer = new ScratchRender(canvas);
-    renderer.setLayerGroupOrdering(['group1']);
-
-    var drawableID = renderer.createDrawable('group1');
-    renderer.updateDrawableProperties(drawableID, {
-        position: [0, 0],
-        scale: [100, 100],
-        direction: 90
-    });
-
-    var drawableID2 = renderer.createDrawable('group1');
-    var wantBitmapSkin = false;
-
-    // Bitmap (squirrel)
-    var image = new Image();
-    image.onload = function () {
-        var bitmapSkinId = renderer.createBitmapSkin(image);
-        if (wantBitmapSkin) {
-            renderer.updateDrawableProperties(drawableID2, {
-                skinId: bitmapSkinId
-            });
-        }
-    };
-    image.crossOrigin = 'anonymous';
-    image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/';
-
-    // SVG (cat 1-a)
-    var xhr = new XMLHttpRequest();
-    xhr.addEventListener("load", function () {
-        var skinId = renderer.createSVGSkin(xhr.responseText);
-        if (!wantBitmapSkin) {
-            renderer.updateDrawableProperties(drawableID2, {
-                skinId: skinId
-            });
-        }
-    });
-    xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/f88bf1935daea28f8ca098462a31dbb0.svg/get/');
-    xhr.send();
-
-    var posX = 0;
-    var posY = 0;
-    var scaleX = 100;
-    var scaleY = 100;
-    var fudgeProperty = 'posx';
-    function onFudgePropertyChanged(newValue) {
-        fudgeProperty = newValue;
-    }
-    var fudgeInput = document.getElementById('fudge');
-    function onFudgeMinChanged(newValue) {
-        fudgeInput.min = newValue;
-    }
-    function onFudgeMaxChanged(newValue) {
-        fudgeInput.max = newValue;
-    }
-    function onFudgeChanged(newValue) {
-        fudge = newValue;
-        var props = {};
-        switch (fudgeProperty) {
-            case 'posx': props.position = [fudge, posY]; posX = fudge; break;
-            case 'posy': props.position = [posX, fudge]; posY = fudge; break;
-            case 'direction': props.direction = fudge; break;
-            case 'scalex': props.scale = [fudge, scaleY]; scaleX = fudge; break;
-            case 'scaley': props.scale = [scaleX, fudge]; scaleY = fudge; break;
-            case 'color': props.color = fudge; break;
-            case 'whirl': props.whirl = fudge; break;
-            case 'fisheye': props.fisheye = fudge; break;
-            case 'pixelate': props.pixelate = fudge; break;
-            case 'mosaic': props.mosaic = fudge; break;
-            case 'brightness': props.brightness = fudge; break;
-            case 'ghost': props.ghost = fudge; break;
-        }
-        renderer.updateDrawableProperties(drawableID2, props);
-    }
-
-    // Adapted from code by Simon Sarris: http://stackoverflow.com/a/10450761
-    function getMousePos(event, element) {
-        var stylePaddingLeft = parseInt(document.defaultView.getComputedStyle(element, null)['paddingLeft'], 10)     || 0;
-        var stylePaddingTop  = parseInt(document.defaultView.getComputedStyle(element, null)['paddingTop'], 10)      || 0;
-        var styleBorderLeft  = parseInt(document.defaultView.getComputedStyle(element, null)['borderLeftWidth'], 10) || 0;
-        var styleBorderTop   = parseInt(document.defaultView.getComputedStyle(element, null)['borderTopWidth'], 10)  || 0;
-
-        // Some pages have fixed-position bars at the top or left of the page
-        // They will mess up mouse coordinates and this fixes that
-        var html = document.body.parentNode;
-        var htmlTop = html.offsetTop;
-        var htmlLeft = html.offsetLeft;
-
-        // Compute the total offset. It's possible to cache this if you want
-        var offsetX = 0, offsetY = 0;
-        if (element.offsetParent !== undefined) {
-            do {
-                offsetX += element.offsetLeft;
-                offsetY += element.offsetTop;
-            } while ((element = element.offsetParent));
-        }
-
-        // Add padding and border style widths to offset
-        // Also add the <html> offsets in case there's a position:fixed bar
-        // This part is not strictly necessary, it depends on your styling
-        offsetX += stylePaddingLeft + styleBorderLeft + htmlLeft;
-        offsetY += stylePaddingTop + styleBorderTop + htmlTop;
-
-        // We return a simple javascript object with x and y defined
-        return {
-            x: event.pageX - offsetX,
-            y: event.pageY - offsetY
-        };
-    }
-
-    canvas.onmousemove = function(event) {
-        var mousePos = getMousePos(event, canvas);
-        renderer.extractColor(mousePos.x, mousePos.y, 30);
-    };
-
-    canvas.onclick = function(event) {
-        var mousePos = getMousePos(event, canvas);
-        var pickID = renderer.pick(mousePos.x, mousePos.y);
-        console.log('You clicked on ' + (pickID < 0 ? 'nothing' : 'ID# ' + pickID));
-        if (pickID >= 0) {
-            console.dir(renderer.extractDrawable(pickID, mousePos.x, mousePos.y));
-        }
-    };
-
-    function drawStep() {
-        renderer.draw();
-        // renderer.getBounds(drawableID2);
-        // renderer.isTouchingColor(drawableID2, [255,255,255]);
-        requestAnimationFrame(drawStep);
-    }
-    drawStep();
-
-    var debugCanvas = /** @type {canvas} */ document.getElementById('debug-canvas');
-    renderer.setDebugCanvas(debugCanvas);
-</script>
+<script src="playground.js"></script>
 </body>
 </html>

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -1,0 +1,141 @@
+const ScratchRender = require('../RenderWebGL');
+const getMousePosition = require('./getMousePosition');
+
+var canvas = document.getElementById('scratch-stage');
+var fudge = 90;
+var renderer = new ScratchRender(canvas);
+renderer.setLayerGroupOrdering(['group1']);
+
+var drawableID = renderer.createDrawable('group1');
+renderer.updateDrawableProperties(drawableID, {
+    position: [0, 0],
+    scale: [100, 100],
+    direction: 90
+});
+
+var drawableID2 = renderer.createDrawable('group1');
+var wantBitmapSkin = false;
+
+// Bitmap (squirrel)
+var image = new Image();
+image.addEventListener('load', () => {
+    var bitmapSkinId = renderer.createBitmapSkin(image);
+    if (wantBitmapSkin) {
+        renderer.updateDrawableProperties(drawableID2, {
+            skinId: bitmapSkinId
+        });
+    }
+});
+image.crossOrigin = 'anonymous';
+image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/';
+
+// SVG (cat 1-a)
+var xhr = new XMLHttpRequest();
+xhr.addEventListener('load', function () {
+    var skinId = renderer.createSVGSkin(xhr.responseText);
+    if (!wantBitmapSkin) {
+        renderer.updateDrawableProperties(drawableID2, {
+            skinId: skinId
+        });
+    }
+});
+xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/f88bf1935daea28f8ca098462a31dbb0.svg/get/');
+xhr.send();
+
+var posX = 0;
+var posY = 0;
+var scaleX = 100;
+var scaleY = 100;
+var fudgeProperty = 'posx';
+
+const fudgePropertyInput = document.getElementById('fudgeproperty');
+fudgePropertyInput.addEventListener('change', event => {
+    fudgeProperty = event.target.value;
+});
+
+const fudgeInput = document.getElementById('fudge');
+
+const fudgeMinInput = document.getElementById('fudgeMin');
+fudgeMinInput.addEventListener('change', event => {
+    fudgeInput.min = event.target.valueAsNumber;
+});
+
+const fudgeMaxInput = document.getElementById('fudgeMax');
+fudgeMaxInput.addEventListener('change', event => {
+    fudgeInput.max = event.target.valueAsNumber;
+});
+
+const handleFudgeChanged = function (event) {
+    fudge = event.target.valueAsNumber;
+    var props = {};
+    switch (fudgeProperty) {
+    case 'posx':
+        props.position = [fudge, posY];
+        posX = fudge;
+        break;
+    case 'posy':
+        props.position = [posX, fudge];
+        posY = fudge;
+        break;
+    case 'direction':
+        props.direction = fudge;
+        break;
+    case 'scalex':
+        props.scale = [fudge, scaleY];
+        scaleX = fudge;
+        break;
+    case 'scaley':
+        props.scale = [scaleX, fudge];
+        scaleY = fudge;
+        break;
+    case 'color':
+        props.color = fudge;
+        break;
+    case 'whirl':
+        props.whirl = fudge;
+        break;
+    case 'fisheye':
+        props.fisheye = fudge;
+        break;
+    case 'pixelate':
+        props.pixelate = fudge;
+        break;
+    case 'mosaic':
+        props.mosaic = fudge;
+        break;
+    case 'brightness':
+        props.brightness = fudge;
+        break;
+    case 'ghost':
+        props.ghost = fudge;
+        break;
+    }
+    renderer.updateDrawableProperties(drawableID2, props);
+};
+fudgeInput.addEventListener('input', handleFudgeChanged);
+fudgeInput.addEventListener('change', handleFudgeChanged);
+
+canvas.addEventListener('mousemove', event => {
+    var mousePos = getMousePosition(event, canvas);
+    renderer.extractColor(mousePos.x, mousePos.y, 30);
+});
+
+canvas.addEventListener('click', event => {
+    var mousePos = getMousePosition(event, canvas);
+    var pickID = renderer.pick(mousePos.x, mousePos.y);
+    console.log('You clicked on ' + (pickID < 0 ? 'nothing' : 'ID# ' + pickID));
+    if (pickID >= 0) {
+        console.dir(renderer.extractDrawable(pickID, mousePos.x, mousePos.y));
+    }
+});
+
+const drawStep = function () {
+    renderer.draw();
+    // renderer.getBounds(drawableID2);
+    // renderer.isTouchingColor(drawableID2, [255,255,255]);
+    requestAnimationFrame(drawStep);
+};
+drawStep();
+
+var debugCanvas = /** @type {canvas} */ document.getElementById('debug-canvas');
+renderer.setDebugCanvas(debugCanvas);

--- a/src/playground/queryPlayground.html
+++ b/src/playground/queryPlayground.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scratch WebGL Query Playground</title>
+    <style>
+        input[type=range][orient=vertical] {
+            writing-mode: bt-lr; /* IE */
+            -webkit-appearance: slider-vertical;
+            width: 1rem;
+            padding: 0 0.5rem;
+        }
+    </style>
+</head>
+<body style="background: lightsteelblue">
+    <div>
+        <fieldset>
+            <legend>Query Canvas</legend>
+            <div>Touching white? <span id="touchingWhite">maybe</span></div>
+            <div>Touching black? <span id="touchingBlack">maybe</span></div>
+            <canvas id="queryCanvas" width="480" height="360" style="border:3px dashed black"></canvas>
+        </fieldset>
+        <fieldset>
+            <legend>Render Canvas</legend>
+            <div>Cursor Position: <span id="cursorPosition">somewhere</span></div>
+            <table>
+                <tr>
+                    <td></td>
+                    <td>
+                        <input id="cursorX" type="range" step="0.25" value="0" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <input id="cursorY" type="range" orient="vertical" step="0.25" value="0" />
+                    </td>
+                    <td>
+                        <canvas id="renderCanvas" width="480" height="360" style="border:3px dashed black"></canvas>
+                    </td>
+                </tr>
+            </table>
+        </fieldset>
+    </div>
+</body>
+<script src="queryPlayground.js"></script>
+</html>

--- a/src/playground/queryPlayground.html
+++ b/src/playground/queryPlayground.html
@@ -12,6 +12,14 @@
         }
         canvas {
             border: 3px dashed black;
+
+            /* https://stackoverflow.com/a/7665647 */
+            image-rendering: optimizeSpeed; /* Older versions of FF */
+            image-rendering: -moz-crisp-edges; /* FF 6.0+ */
+            image-rendering: -webkit-optimize-contrast; /* Safari */
+            image-rendering: -o-crisp-edges; /* OS X & Windows Opera (12.02+) */
+            image-rendering: pixelated; /* Awesome future-browsers */
+            -ms-interpolation-mode: nearest-neighbor; /* IE */
         }
     </style>
 </head>

--- a/src/playground/queryPlayground.html
+++ b/src/playground/queryPlayground.html
@@ -10,15 +10,35 @@
             width: 1rem;
             padding: 0 0.5rem;
         }
+        canvas {
+            border: 3px dashed black;
+        }
     </style>
 </head>
 <body style="background: lightsteelblue">
     <div>
         <fieldset>
-            <legend>Query Canvas</legend>
-            <div>Touching white? <span id="touchingWhite">maybe</span></div>
-            <div>Touching black? <span id="touchingBlack">maybe</span></div>
-            <canvas id="queryCanvas" width="480" height="360" style="border:3px dashed black"></canvas>
+            <legend>Query Canvases</legend>
+            <table>
+                <tr>
+                    <td>
+                        <fieldset>
+                            <legend>GPU</legend>
+                            <div>Touching color A? <span id="gpuTouchingA">maybe</span></div>
+                            <div>Touching color B? <span id="gpuTouchingB">maybe</span></div>
+                            <canvas id="gpuQueryCanvas" width="480" height="360" style="height: 20rem"></canvas>
+                        </fieldset>
+                    </td>
+                    <td>
+                        <fieldset>
+                            <legend>CPU</legend>
+                            <div>Touching color A? <span id="cpuTouchingA">maybe</span></div>
+                            <div>Touching color B? <span id="cpuTouchingB">maybe</span></div>
+                            <canvas id="cpuQueryCanvas" width="480" height="360" style="height: 20rem"></canvas>
+                        </fieldset>
+                    </td>
+                </tr>
+            </table>
         </fieldset>
         <fieldset>
             <legend>Render Canvas</legend>

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -1,0 +1,50 @@
+const getMousePosition = require('./getMousePosition');
+
+const renderCanvas = document.getElementById('renderCanvas');
+const inputCursorX = document.getElementById('cursorX');
+const inputCursorY = document.getElementById('cursorY');
+const labelCursorPosition = document.getElementById('cursorPosition');
+
+const handleResizeRenderCanvas = () => {
+    const halfWidth = renderCanvas.clientWidth / 2;
+    const halfHeight = renderCanvas.clientHeight / 2;
+
+    inputCursorX.style.width = `${renderCanvas.clientWidth}px`;
+    inputCursorY.style.height = `${renderCanvas.clientHeight}px`;
+    inputCursorX.min = -halfWidth;
+    inputCursorX.max = halfWidth;
+    inputCursorY.min = -halfHeight;
+    inputCursorY.max = halfHeight;
+};
+renderCanvas.addEventListener('resize', handleResizeRenderCanvas);
+handleResizeRenderCanvas();
+
+const handleCursorPositionChanged = () => {
+    const cursorX = inputCursorX.valueAsNumber;
+    const cursorY = inputCursorY.valueAsNumber;
+    const positionHTML = `${cursorX}, ${cursorY}`;
+    labelCursorPosition.innerHTML = positionHTML;
+};
+inputCursorX.addEventListener('change', handleCursorPositionChanged);
+inputCursorY.addEventListener('change', handleCursorPositionChanged);
+inputCursorX.addEventListener('input', handleCursorPositionChanged);
+inputCursorY.addEventListener('input', handleCursorPositionChanged);
+handleCursorPositionChanged();
+
+let trackingMouse = true;
+renderCanvas.addEventListener('click', event => {
+    trackingMouse = !trackingMouse;
+    if (trackingMouse) {
+        handleMouseMove(event);
+    }
+});
+
+const handleMouseMove = event => {
+    if (trackingMouse) {
+        const mousePosition = getMousePosition(event, renderCanvas);
+        inputCursorX.value = mousePosition.x - (renderCanvas.clientWidth / 2);
+        inputCursorY.value = (renderCanvas.clientHeight / 2) - mousePosition.y;
+        handleCursorPositionChanged();
+    }
+};
+renderCanvas.addEventListener('mousemove', handleMouseMove);

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -40,8 +40,9 @@ renderCanvas.addEventListener('resize', handleResizeRenderCanvas);
 handleResizeRenderCanvas();
 
 const handleCursorPositionChanged = () => {
-    const cursorX = inputCursorX.valueAsNumber;
-    const cursorY = inputCursorY.valueAsNumber;
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const cursorX = inputCursorX.valueAsNumber / devicePixelRatio;
+    const cursorY = inputCursorY.valueAsNumber / devicePixelRatio;
     const positionHTML = `${cursorX}, ${cursorY}`;
     labelCursorPosition.innerHTML = positionHTML;
     if (drawables.cursor >= 0) {
@@ -141,13 +142,13 @@ const makeTestPatternImage = () => {
     }
     for (let x = xSplit2; x < xSplit3; ++x) {
         for (let y = ySplit; y < canvas.height; ++y) {
-            context.fillStyle = (x + y) % 2 ? patternA : patternB;
+            context.fillStyle = (x + y) % 2 ? patternB : patternA;
             context.fillRect(x, y, 1, 1);
         }
     }
     for (let x = xSplit3; x < canvas.width; x += 2) {
         for (let y = ySplit; y < canvas.height; y += 2) {
-            context.fillStyle = (x + y) % 4 ? patternA : patternB;
+            context.fillStyle = (x + y) % 4 ? patternB : patternA;
             context.fillRect(x, y, 2, 2);
         }
     }

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -155,8 +155,17 @@ const makeTestPatternImage = () => {
     return canvas;
 };
 
-const makeBitmapDrawable = function (group, image) {
+const makeTestPatternDrawable = function (group) {
+    const image = makeTestPatternImage();
     const skinId = renderer.createBitmapSkin(image, 1);
+    const drawableId = renderer.createDrawable(group);
+    renderer.updateDrawableProperties(drawableId, {skinId});
+    return drawableId;
+};
+
+const makeCursorDrawable = function (group) {
+    const image = makeCursorImage();
+    const skinId = renderer.createBitmapSkin(image, 1, [0, 0]);
     const drawableId = renderer.createDrawable(group);
     renderer.updateDrawableProperties(drawableId, {skinId});
     return drawableId;
@@ -168,14 +177,8 @@ const initRendering = () => {
         cursor: 'cursor'
     };
     renderer.setLayerGroupOrdering([layerGroup.testPattern, layerGroup.cursor]);
-
-    const images = {
-        testPattern: makeTestPatternImage(),
-        cursor: makeCursorImage()
-    };
-
-    drawables.testPattern = makeBitmapDrawable(layerGroup.testPattern, images.testPattern);
-    drawables.cursor = makeBitmapDrawable(layerGroup.cursor, images.cursor);
+    drawables.testPattern = makeTestPatternDrawable(layerGroup.testPattern);
+    drawables.cursor = makeCursorDrawable(layerGroup.cursor);
 };
 
 initRendering();

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -179,6 +179,16 @@ const initRendering = () => {
     renderer.setLayerGroupOrdering([layerGroup.testPattern, layerGroup.cursor]);
     drawables.testPattern = makeTestPatternDrawable(layerGroup.testPattern);
     drawables.cursor = makeCursorDrawable(layerGroup.cursor);
+
+    const corner00 = makeCursorDrawable(layerGroup.cursor);
+    const corner01 = makeCursorDrawable(layerGroup.cursor);
+    const corner10 = makeCursorDrawable(layerGroup.cursor);
+    const corner11 = makeCursorDrawable(layerGroup.cursor);
+
+    renderer.updateDrawableProperties(corner00, {position: [-240, -179]});
+    renderer.updateDrawableProperties(corner01, {position: [-240, 180]});
+    renderer.updateDrawableProperties(corner10, {position: [239, -179]});
+    renderer.updateDrawableProperties(corner11, {position: [239, 180]});
 };
 
 initRendering();

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -51,21 +51,21 @@ const handleCursorPositionChanged = () => {
             position: [cursorX, cursorY]
         });
 
-        renderer.setForceGPU(true);
+        renderer.setUseGpuMode(ScratchRender.UseGpuModes.ForceGPU);
         renderer.setDebugCanvas(gpuQueryCanvas);
         const isGpuTouchingA = renderer.isTouchingColor(drawables.cursor, colors.patternA);
         const isGpuTouchingB = renderer.isTouchingColor(drawables.cursor, colors.patternB);
         labelGpuTouchingA.innerHTML = isGpuTouchingA ? 'yes' : 'no';
         labelGpuTouchingB.innerHTML = isGpuTouchingB ? 'yes' : 'no';
 
-        renderer.setForceGPU(false);
+        renderer.setUseGpuMode(ScratchRender.UseGpuModes.ForceCPU);
         renderer.setDebugCanvas(cpuQueryCanvas);
         const isCpuTouchingA = renderer.isTouchingColor(drawables.cursor, colors.patternA);
         const isCpuTouchingB = renderer.isTouchingColor(drawables.cursor, colors.patternB);
         labelCpuTouchingA.innerHTML = isCpuTouchingA ? 'yes' : 'no';
         labelCpuTouchingB.innerHTML = isCpuTouchingB ? 'yes' : 'no';
 
-        renderer.clearForceGPU();
+        renderer.setUseGpuMode(ScratchRender.UseGpuModes.Automatic);
     }
 };
 inputCursorX.addEventListener('change', handleCursorPositionChanged);

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -23,6 +23,8 @@ const colors = {
     patternB: [0, 0, 255]
 };
 
+const renderer = new ScratchRender(renderCanvas);
+
 const handleResizeRenderCanvas = () => {
     const halfWidth = renderCanvas.clientWidth / 2;
     const halfHeight = renderCanvas.clientHeight / 2;
@@ -72,13 +74,6 @@ inputCursorY.addEventListener('input', handleCursorPositionChanged);
 handleCursorPositionChanged();
 
 let trackingMouse = true;
-renderCanvas.addEventListener('click', event => {
-    trackingMouse = !trackingMouse;
-    if (trackingMouse) {
-        handleMouseMove(event);
-    }
-});
-
 const handleMouseMove = event => {
     if (trackingMouse) {
         const mousePosition = getMousePosition(event, renderCanvas);
@@ -88,6 +83,13 @@ const handleMouseMove = event => {
     }
 };
 renderCanvas.addEventListener('mousemove', handleMouseMove);
+
+renderCanvas.addEventListener('click', event => {
+    trackingMouse = !trackingMouse;
+    if (trackingMouse) {
+        handleMouseMove(event);
+    }
+});
 
 const rgb2fillStyle = (rgb) => {
     return `rgb(${rgb[0]},${rgb[1]},${rgb[2]})`;
@@ -153,7 +155,7 @@ const makeTestPatternImage = () => {
     return canvas;
 };
 
-const makeBitmapDrawable = function (renderer, group, image) {
+const makeBitmapDrawable = function (group, image) {
     const skinId = renderer.createBitmapSkin(image, 1);
     const drawableId = renderer.createDrawable(group);
     renderer.updateDrawableProperties(drawableId, {skinId});
@@ -161,8 +163,6 @@ const makeBitmapDrawable = function (renderer, group, image) {
 };
 
 const initRendering = () => {
-    const renderer = new ScratchRender(renderCanvas);
-
     const layerGroup = {
         testPattern: 'testPattern',
         cursor: 'cursor'
@@ -174,11 +174,9 @@ const initRendering = () => {
         cursor: makeCursorImage()
     };
 
-    drawables.testPattern = makeBitmapDrawable(renderer, layerGroup.testPattern, images.testPattern);
-    drawables.cursor = makeBitmapDrawable(renderer, layerGroup.cursor, images.cursor);
-
-    return renderer;
+    drawables.testPattern = makeBitmapDrawable(layerGroup.testPattern, images.testPattern);
+    drawables.cursor = makeBitmapDrawable(layerGroup.cursor, images.cursor);
 };
 
-const renderer = initRendering();
+initRendering();
 renderer.draw();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = [
     Object.assign({}, base, {
         target: 'web',
         entry: {
-            playground: './src/playground/playground.js'
+            playground: './src/playground/playground.js',
+            queryPlayground: './src/playground/queryPlayground.js'
         },
         output: {
             libraryTarget: 'umd',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,10 +39,9 @@ module.exports = [
     Object.assign({}, base, {
         target: 'web',
         entry: {
-            'scratch-render': './src/index.js'
+            playground: './src/playground/playground.js'
         },
         output: {
-            library: 'ScratchRender',
             libraryTarget: 'umd',
             path: path.resolve('playground'),
             filename: '[name].js'
@@ -50,7 +49,8 @@ module.exports = [
         plugins: base.plugins.concat([
             new CopyWebpackPlugin([
                 {
-                    from: 'src/playground'
+                    context: 'src/playground',
+                    from: '*.html'
                 }
             ])
         ])


### PR DESCRIPTION
### Resolves

Progress toward diagnosing #390 and other "touching color" issues

### Proposed Changes

1. Add a flag to force the renderer to use the GPU or CPU implementation of `touching color?`.
2. Pull playground JS out of the HTML and into its own JS files.
3. Build the playground JS using Webpack instead of just copying it as-is.
4. Add a new playground, `queryPlayground.html`, to interactively test renderer queries like `touching color?`.

Current state:
![image](https://user-images.githubusercontent.com/7019101/52005673-1c8d9c80-247f-11e9-9a07-2e8be3fc0ed6.png)

### Reason for Changes

This should help figure out what's going wrong with `touching color?`, as well as making it easier to add more playgrounds in the future if necessary.