### PR TITLE
Adjust CPU isTouchingColor to match GPU results

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -24,12 +24,11 @@ const __isTouchingPosition = twgl.v3.create();
  * @return {twgl.v3} [x,y] texture space float vector - transformed by effects and matrix
  */
 const getLocalPosition = (drawable, vec) => {
-    // Transfrom from world coordinates to Drawable coordinates.
+    // Transform from world coordinates to Drawable coordinates.
     const localPosition = __isTouchingPosition;
     const v0 = vec[0];
     const v1 = vec[1];
     const m = drawable._inverseMatrix;
-    // var v2 = v[2];
     const d = (v0 * m[3]) + (v1 * m[7]) + m[15];
     // The RenderWebGL quad flips the texture's X axis. So rendered bottom
     // left is 1, 0 and the top right is 0, 1. Flip the X axis so
@@ -342,7 +341,7 @@ class Drawable {
         // Drawable configures a 3D matrix for drawing in WebGL, but most values
         // will never be set because the inputs are on the X and Y position axis
         // and the Z rotation axis. Drawable can bring the work inside
-        // _calculateTransform and greatly reduce the ammount of math and array
+        // _calculateTransform and greatly reduce the amount of math and array
         // assignments needed.
 
         const scale0 = this._skinScale[0];
@@ -625,11 +624,6 @@ class Drawable {
      */
     static sampleColor4b (vec, drawable, dst) {
         const localPosition = getLocalPosition(drawable, vec);
-        if (localPosition[0] < 0 || localPosition[1] < 0 ||
-            localPosition[0] > 1 || localPosition[1] > 1) {
-            dst[3] = 0;
-            return dst;
-        }
         const textColor =
         // commenting out to only use nearest for now
         // drawable.useNearest ?

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -747,8 +747,8 @@ class RenderWebGL extends EventEmitter {
                 return this._isTouchingColorGpuFin(bounds, color3b, y);
             }
             for (let x = 0; x < bounds.width; ++x) {
-                point[1] = bounds.top - y; // bounds.top <= y < bounds.bottom ("flipped")
-                point[0] = bounds.left + x; // bounds.left <= x < bounds.right
+                point[0] = bounds.left + x; // bounds.left <= point[0] < bounds.right
+                point[1] = bounds.top - y; // bounds.bottom < point[1] <= bounds.top ("flipped")
                 // if we use a mask, check our sample color...
                 if (hasMask ?
                     maskMatches(Drawable.sampleColor4b(point, drawable, color), mask3b) :

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -747,7 +747,7 @@ class RenderWebGL extends EventEmitter {
                 return this._isTouchingColorGpuFin(bounds, color3b, y);
             }
             for (let x = 0; x < bounds.width; ++x) {
-                point[1] = bounds.top + y; // bounds.top <= y < bounds.bottom ("flipped")
+                point[1] = bounds.top - y; // bounds.top <= y < bounds.bottom ("flipped")
                 point[0] = bounds.left + x; // bounds.left <= x < bounds.right
                 // if we use a mask, check our sample color...
                 if (hasMask ?

--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -11,16 +11,16 @@
 let __SilhouetteUpdateCanvas;
 
 /**
- * Internal helper function (in hopes that compiler can inline).  Get a pixel
- * from silhouette data, or 0 if outside it's bounds.
+ * Internal helper function (in hopes that compiler can inline). Get the alpha value for a texel in the silhouette
+ * data, or 0 if outside it's bounds.
  * @private
- * @param {Silhouette} silhouette - has data width and height
- * @param {number} x - x
- * @param {number} y - y
+ * @param {Silhouette} $0 - has data, width, and height
+ * @param {number} x - X position in texels (0..width).
+ * @param {number} y - Y position in texels (0..height).
  * @return {number} Alpha value for x/y position
  */
 const getPoint = ({_width: width, _height: height, _data: data}, x, y) => {
-    // 0 if outside bouds, otherwise read from data.
+    // 0 if outside bounds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return 0;
     }
@@ -39,14 +39,14 @@ const __cornerWork = [
 
 /**
  * Get the color from a given silhouette at an x/y local texture position.
- * @param {Silhouette} The silhouette to sample.
- * @param {number} x X position of texture (0-1).
- * @param {number} y Y position of texture (0-1).
- * @param {Uint8ClampedArray} dst A color 4b space.
- * @return {Uint8ClampedArray} The dst vector.
+ * @param {Silhouette} $0 - The silhouette to sample.
+ * @param {number} x - X position in texels (0..width).
+ * @param {number} y - Y position in texels (0..height).
+ * @param {Uint8ClampedArray} dst - A color 4b space.
+ * @return {Uint8ClampedArray} - The dst vector.
  */
 const getColor4b = ({_width: width, _height: height, _colorData: data}, x, y, dst) => {
-    // 0 if outside bouds, otherwise read from data.
+    // 0 if outside bounds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return dst.fill(0);
     }
@@ -102,7 +102,7 @@ class Silhouette {
 
         this._data = new Uint8ClampedArray(imageData.data.length / 4);
         this._colorData = imageData.data;
-        // delete our custom overriden "uninitalized" color functions
+        // delete our custom overridden "uninitialized" color functions
         // let the prototype work for itself
         delete this.colorAtNearest;
         delete this.colorAtLinear;
@@ -120,12 +120,10 @@ class Silhouette {
      * @returns {Uint8ClampedArray} dst
      */
     colorAtNearest (vec, dst) {
-        return getColor4b(
-            this,
-            Math.floor(vec[0] * (this._width - 1)),
-            Math.floor(vec[1] * (this._height - 1)),
-            dst
-        );
+        const x = Math.round(vec[0] * this._width);
+        const y = Math.round(vec[1] * this._height);
+        const color = getColor4b(this, x, y, dst);
+        return color;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Fixes some causes of #214

### Proposed Changes

Functionality changes:
- Adjust the loops in `isTouchingColor` to avoid testing extra edge pixels
- Adjust the math in `colorAtNearest` to match hardware texture sampling results
- `sampleColor4b` no longer contains an early-out bounds test since `colorAtNearest` does the same test more accurately. For example, we were previously getting incorrect results when "zero" turned into a very small negative number due to floating point error.

Other changes:
- Move projection matrix calculation into a separate function
   - An earlier version of this code contained some adjustments to the projection matrix. It turns out those adjustments weren't needed, but I decided to keep the centralized function anyway.
- Spelling corrections in comments

### Reason for Changes

The CPU version of `isTouchingColor`, `sampleColor4b`, and a few related functions were not returning the same results as their GPU equivalents. This could cause unexpected behavior, especially if a project uses both paths.

### Test Coverage

See #406
