### PR TITLE
pen transparency fix

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -599,7 +599,7 @@ class PenSkin extends Skin {
             this._silhouetteBuffer = twgl.createFramebufferInfo(gl, [{format: gl.RGBA}], width, height);
         }
 
-        gl.clearColor(1, 1, 1, 0);
+        gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         this._silhouetteDirty = true;

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -155,6 +155,13 @@ class PenSkin extends Skin {
     }
 
     /**
+     * @returns {boolean} true if alpha is premultiplied, false otherwise
+     */
+    get hasPremultipliedAlpha () {
+        return true;
+    }
+
+    /**
      * @return {Array<number>} the "native" size, in texels, of this skin. [width, height]
      */
     get size () {

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -181,8 +181,9 @@ class PenSkin extends Skin {
     clear () {
         const gl = this._renderer.gl;
         twgl.bindFramebufferInfo(gl, this._framebuffer);
-
-        gl.clearColor(1, 1, 1, 0);
+        
+        /* Reset framebuffer to transparent black */
+        gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         const ctx = this._canvas.getContext('2d');

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1624,7 +1624,7 @@ class RenderWebGL extends EventEmitter {
             /* adjust blend function for this skin */
             if (drawable.skin.hasPremultipliedAlpha){
                 gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-            }else {
+            } else {
                 gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             }
             

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1620,7 +1620,9 @@ class RenderWebGL extends EventEmitter {
             }
 
             twgl.setUniforms(currentShader, uniforms);
-
+            
+            gl.blendFuncSeparate(gl.ONE,gl.ONE_MINUS_SRC_ALPHA,gl.ONE,gl.ONE_MINUS_SRC_ALPHA);
+            
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1621,8 +1621,12 @@ class RenderWebGL extends EventEmitter {
 
             twgl.setUniforms(currentShader, uniforms);
             
-            /* set blend function to not use premultiplied alpha anymore */
-            gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            /* adjust blend function for this skin */
+            if (drawable.skin.hasPremultipliedAlpha){
+                gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            }else {
+                gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            }
             
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1621,7 +1621,8 @@ class RenderWebGL extends EventEmitter {
 
             twgl.setUniforms(currentShader, uniforms);
             
-            gl.blendFuncSeparate(gl.ONE,gl.ONE_MINUS_SRC_ALPHA,gl.ONE,gl.ONE_MINUS_SRC_ALPHA);
+            /* set blend function to work with premultiplied alpha */
+            gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1621,8 +1621,8 @@ class RenderWebGL extends EventEmitter {
 
             twgl.setUniforms(currentShader, uniforms);
             
-            /* set blend function to work with premultiplied alpha */
-            gl.blendFuncSeparate(gl.ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            /* set blend function to not use premultiplied alpha anymore */
+            gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1622,7 +1622,7 @@ class RenderWebGL extends EventEmitter {
             twgl.setUniforms(currentShader, uniforms);
             
             /* set blend function to work with premultiplied alpha */
-            gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            gl.blendFuncSeparate(gl.ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -77,6 +77,13 @@ class Skin extends EventEmitter {
     }
 
     /**
+     * @returns {boolean} true if alpha is premultiplied, false otherwise
+     */
+    get hasPremultipliedAlpha () {
+        return false;
+    }
+
+    /**
      * @return {int} the unique ID for this Skin.
      */
     get id () {

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -194,12 +194,6 @@ void main()
 		discard;
 	}
 	#endif // DRAW_MODE_colorMask
-
-	// WebGL defaults to premultiplied alpha
-	#ifndef DRAW_MODE_stamp
-	gl_FragColor.rgb *= gl_FragColor.a;
-	#endif // DRAW_MODE_stamp
-
 	#endif // DRAW_MODE_silhouette
 
 	#else // DRAW_MODE_lineSample


### PR DESCRIPTION
Clears the pen framebuffer with transparent black instead of transparent white so transparent parts of the pen layer don't show up lighter than they should anymore.

See https://scratch.mit.edu/projects/277120576/.