### PR TITLE
Tweak scalingVector to make dots appear to be more circular

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -371,8 +371,10 @@ class PenSkin extends Skin {
         translationVector[1] = avgY + (alias / 4);
 
         const scalingVector = __modelScalingVector;
-        scalingVector[0] = diameter + alias;
-        scalingVector[1] = length + diameter - (alias / 2);
+        // Dots tend to be ovals that are longer on the y-axis, so we use a smaller alias
+        // for the y value than for the x value to make dots more circular.
+        scalingVector[0] = diameter + (alias / 2);
+        scalingVector[1] = length + diameter - (alias / 6);
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-gui/issues/4313

### Proposed Changes

Tweak the alias ratios for the scalingVector 

### Reason for Changes

These changes to the scalingVector helps make circles a little wider. Currently they are a little taller than they are wide, which makes them look like vertical ovals. This change to make the Y scalingVector smaller helps balances the circle dimensions. 

### Screenshots 
I took some screen shots to try to capture how these changes affect circles. I recommend clicking the screenshot to fullscreen it and see more detail.

| PR changes      | Production |
| ----------- | ----------- |
| **Project Link** | https://scratch.mit.edu/projects/245159517/fullscreen/ |
| ![Screen Shot 2019-03-18 at 10 43 39 AM](https://user-images.githubusercontent.com/7991694/54538491-bb585480-496a-11e9-9cb9-192fe0b93c62.png) | ![Screen Shot 2019-03-18 at 10 44 31 AM](https://user-images.githubusercontent.com/7991694/54538552-d4f99c00-496a-11e9-86ef-0a48763b59e5.png) |
| **Project Link**   | https://scratch.mit.edu/projects/220220160/fullscreen/       |
| ![Screen Shot 2019-03-18 at 10 56 31 AM](https://user-images.githubusercontent.com/7991694/54539523-a977b100-496c-11e9-82be-4ac949545d2d.png) | ![Screen Shot 2019-03-18 at 10 56 10 AM](https://user-images.githubusercontent.com/7991694/54539549-b5637300-496c-11e9-86e4-a9c47bc22e73.png) |
| **Project Link** | https://scratch.mit.edu/projects/89811578/fullscreen/ |
| ![Screen Shot 2019-03-18 at 11 02 10 AM](https://user-images.githubusercontent.com/7991694/54539839-4cc8c600-496d-11e9-83cf-6f888ba74683.png) | ![Screen Shot 2019-03-18 at 11 02 39 AM](https://user-images.githubusercontent.com/7991694/54539891-60742c80-496d-11e9-858d-6cabc336ac1c.png) |






