### PR TITLE
Only check position against effect transform if it falls within the Drawable's space

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -36,8 +36,10 @@ const getLocalPosition = (drawable, vec) => {
     // localPosition matches that transformation.
     localPosition[0] = 0.5 - (((v0 * m[0]) + (v1 * m[4]) + m[12]) / d);
     localPosition[1] = (((v0 * m[1]) + (v1 * m[5]) + m[13]) / d) + 0.5;
-    // Apply texture effect transform.
-    EffectTransform.transformPoint(drawable, localPosition, localPosition);
+    // Apply texture effect transform if the localPosition is within the drawable's space.
+    if ((localPosition[0] >= 0 && localPosition[0] < 1) && (localPosition[1] >= 0 && localPosition[1] < 1)) {
+        EffectTransform.transformPoint(drawable, localPosition, localPosition);
+    }
     return localPosition;
 };
 


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/366

### Proposed Changes

Check if the local position is within the drawable's space (ie the x and y values are equal to zero or less than one) before transforming that point using `EffectTransform`.

### Reason for Changes

If we use the effect transform on points outside the drawable, it can falsely give the impression that a point is within a drawable when you transform it. Without this if-statement, blocks like "touching mouse-pointer" will think a transformed point is part of the drawable if [the mosaic effect returns a positive modded value here](https://github.com/LLK/scratch-render/blob/develop/src/EffectTransform.js#L195-L199)

Here is a project that demos the fix: https://scratch.mit.edu/projects/293415549/editor

After clicking the green flag, click the block to add the mosaic effect. The sprite will change colors to the bottom right of it in production, even if the mouse isn't touching the sprite. With these fixes, it will only change color when it's actually being touched. 
