### PR TITLE
Playground improvements

### DIFF
--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -33,8 +33,8 @@
     <input type="range" style="width:50%" id="stage-scale" value="1" min="1" max="2.5" step="any">
 </p>
 <p>
-    <label for="fudgeMin">Min:</label><input id="fudgeMin" type="number">
-    <label for="fudgeMax">Max:</label><input id="fudgeMax" type="number">
+    <label for="fudgeMin">Min:</label><input id="fudgeMin" type="number" value="0">
+    <label for="fudgeMax">Max:</label><input id="fudgeMax" type="number" value="200">
 </p>
 <script src="playground.js"></script>
 </body>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -16,6 +16,7 @@
         <option value="direction">Direction</option>
         <option value="scalex">Scale X</option>
         <option value="scaley">Scale Y</option>
+        <option value="scaleboth">Scale (both dimensions)</option>
         <option value="color">Color</option>
         <option value="fisheye">Fisheye</option>
         <option value="whirl">Whirl</option>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch WebGL rendering demo</title>
-    <style>
-        #scratch-stage { width: 480px; }
-    </style>
 </head>
 <body style="background: lightsteelblue">
 <canvas id="scratch-stage" width="10" height="10" style="border:3px dashed black"></canvas>
@@ -28,6 +25,10 @@
     </select>
     <label for="fudge">Property Value:</label>
     <input type="range" id="fudge" style="width:50%" value="90" min="-90" max="270" step="any">
+</p>
+<p>
+    <label for="stage-scale">Stage scale:</label>
+    <input type="range" style="width:50%" id="stage-scale" value="1" min="1" max="2.5" step="any">
 </p>
 <p>
     <label for="fudgeMin">Min:</label><input id="fudgeMin" type="number">

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -3,10 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch WebGL rendering demo</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
 </head>
-<body style="background: lightsteelblue">
-<canvas id="scratch-stage" width="10" height="10" style="border:3px dashed black"></canvas>
-<canvas id="debug-canvas" width="10" height="10" style="border:3px dashed red"></canvas>
+<body>
+<canvas id="scratch-stage" width="10" height="10"></canvas>
+<canvas id="debug-canvas" width="10" height="10"></canvas>
 <p>
     <label for="fudgeproperty">Property to tweak:</label>
     <select id="fudgeproperty">

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -13,15 +13,20 @@ renderer.updateDrawableProperties(drawableID, {
     direction: 90
 });
 
+const WantedSkinType = {
+    bitmap: 'bitmap',
+    vector: 'vector',
+    pen: 'pen'
+};
+
 const drawableID2 = renderer.createDrawable('group1');
-const wantBitmapSkin = false;
-const wantPenSkin = false;
+const wantedSkin = WantedSkinType.vector;
 
 // Bitmap (squirrel)
 const image = new Image();
 image.addEventListener('load', () => {
     const bitmapSkinId = renderer.createBitmapSkin(image);
-    if (wantBitmapSkin && !wantPenSkin) {
+    if (wantedSkin === WantedSkinType.bitmap) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: bitmapSkinId
         });
@@ -34,7 +39,7 @@ image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e
 const xhr = new XMLHttpRequest();
 xhr.addEventListener('load', function () {
     const skinId = renderer.createSVGSkin(xhr.responseText);
-    if (!(wantBitmapSkin || wantPenSkin)) {
+    if (wantedSkin === WantedSkinType.vector) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: skinId
         });
@@ -43,7 +48,7 @@ xhr.addEventListener('load', function () {
 xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/b7853f557e4426412e64bb3da6531a99.svg/get/');
 xhr.send();
 
-if (wantPenSkin) {
+if (wantedSkin === WantedSkinType.pen) {
     const penSkinID = renderer.createPenSkin();
 
     renderer.updateDrawableProperties(drawableID2, {

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -60,7 +60,7 @@ if (wantPenSkin) {
             color4f: [Math.random(), Math.random(), Math.random(), 1],
             diameter: 8
         },
-        x - 240, 180 - y, Math.random() * 480 - 240, Math.random() * 360 - 180);
+        x - 240, 180 - y, (Math.random() * 480) - 240, (Math.random() * 360) - 180);
     });
 }
 
@@ -70,31 +70,32 @@ var scaleX = 100;
 var scaleY = 100;
 var fudgeProperty = 'posx';
 
+const fudgeInput = document.getElementById('fudge');
 const fudgePropertyInput = document.getElementById('fudgeproperty');
+const fudgeMinInput = document.getElementById('fudgeMin');
+const fudgeMaxInput = document.getElementById('fudgeMax');
+
+/* eslint require-jsdoc: 0 */
+const updateFudgeProperty = event => {
+    fudgeProperty = event.target.value;
+};
+
+const updateFudgeMin = event => {
+    fudgeInput.min = event.target.valueAsNumber;
+};
+
+const updateFudgeMax = event => {
+    fudgeInput.max = event.target.valueAsNumber;
+};
+
 fudgePropertyInput.addEventListener('change', updateFudgeProperty);
 fudgePropertyInput.addEventListener('init', updateFudgeProperty);
 
-const fudgeInput = document.getElementById('fudge');
-
-const fudgeMinInput = document.getElementById('fudgeMin');
 fudgeMinInput.addEventListener('change', updateFudgeMin);
 fudgeMinInput.addEventListener('init', updateFudgeMin);
 
-const fudgeMaxInput = document.getElementById('fudgeMax');
 fudgeMaxInput.addEventListener('change', updateFudgeMax);
 fudgeMaxInput.addEventListener('init', updateFudgeMax);
-
-function updateFudgeProperty (event) {
-    fudgeProperty = event.target.value;
-}
-
-function updateFudgeMin (event) {
-    fudgeInput.min = event.target.valueAsNumber;
-}
-
-function updateFudgeMax (event) {
-    fudgeInput.max = event.target.valueAsNumber;
-}
 
 // Ugly hack to properly set the values of the inputs on page load,
 // since they persist across reloads, at least in Firefox.
@@ -161,14 +162,14 @@ fudgeInput.addEventListener('input', handleFudgeChanged);
 fudgeInput.addEventListener('change', handleFudgeChanged);
 fudgeInput.addEventListener('init', handleFudgeChanged);
 
+const updateStageScale = event => {
+    renderer.resize(480 * event.target.valueAsNumber, 360 * event.target.valueAsNumber);
+};
+
 const stageScaleInput = document.getElementById('stage-scale');
 
 stageScaleInput.addEventListener('input', updateStageScale);
 stageScaleInput.addEventListener('change', updateStageScale);
-
-function updateStageScale (event) {
-    renderer.resize(480 * event.target.valueAsNumber, 360 * event.target.valueAsNumber);
-}
 
 canvas.addEventListener('mousemove', event => {
     var mousePos = getMousePosition(event, canvas);

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -134,6 +134,15 @@ fudgeInput.addEventListener('input', handleFudgeChanged);
 fudgeInput.addEventListener('change', handleFudgeChanged);
 fudgeInput.addEventListener('init', handleFudgeChanged);
 
+const stageScaleInput = document.getElementById("stage-scale");
+
+stageScaleInput.addEventListener('input', updateStageScale);
+stageScaleInput.addEventListener('change', updateStageScale);
+
+function updateStageScale(event) {
+    renderer.resize(480 * event.target.valueAsNumber, 360 * event.target.valueAsNumber);
+}
+
 canvas.addEventListener('mousemove', event => {
     var mousePos = getMousePosition(event, canvas);
     renderer.extractColor(mousePos.x, mousePos.y, 30);

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -80,6 +80,7 @@ function updateFudgeMax(event) {
 fudgePropertyInput.dispatchEvent(new CustomEvent("init"));
 fudgeMinInput.dispatchEvent(new CustomEvent("init"));
 fudgeMaxInput.dispatchEvent(new CustomEvent("init"));
+fudgeInput.dispatchEvent(new CustomEvent("init"));
 
 const handleFudgeChanged = function (event) {
     fudge = event.target.valueAsNumber;
@@ -128,9 +129,10 @@ const handleFudgeChanged = function (event) {
     }
     renderer.updateDrawableProperties(drawableID2, props);
 };
+
 fudgeInput.addEventListener('input', handleFudgeChanged);
 fudgeInput.addEventListener('change', handleFudgeChanged);
-fudgeInput.addEventListener('load', handleFudgeChanged);
+fudgeInput.addEventListener('init', handleFudgeChanged);
 
 canvas.addEventListener('mousemove', event => {
     var mousePos = getMousePosition(event, canvas);

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -62,25 +62,25 @@ const fudgeMaxInput = document.getElementById('fudgeMax');
 fudgeMaxInput.addEventListener('change', updateFudgeMax);
 fudgeMaxInput.addEventListener('init', updateFudgeMax);
 
-function updateFudgeProperty(event) {
+function updateFudgeProperty (event) {
     fudgeProperty = event.target.value;
 }
 
-function updateFudgeMin(event) {
+function updateFudgeMin (event) {
     fudgeInput.min = event.target.valueAsNumber;
 }
 
-function updateFudgeMax(event) {
+function updateFudgeMax (event) {
     fudgeInput.max = event.target.valueAsNumber;
 }
 
 // Ugly hack to properly set the values of the inputs on page load,
 // since they persist across reloads, at least in Firefox.
 // The best ugly hacks are the ones that reduce code duplication!
-fudgePropertyInput.dispatchEvent(new CustomEvent("init"));
-fudgeMinInput.dispatchEvent(new CustomEvent("init"));
-fudgeMaxInput.dispatchEvent(new CustomEvent("init"));
-fudgeInput.dispatchEvent(new CustomEvent("init"));
+fudgePropertyInput.dispatchEvent(new CustomEvent('init'));
+fudgeMinInput.dispatchEvent(new CustomEvent('init'));
+fudgeMaxInput.dispatchEvent(new CustomEvent('init'));
+fudgeInput.dispatchEvent(new CustomEvent('init'));
 
 const handleFudgeChanged = function (event) {
     fudge = event.target.valueAsNumber;
@@ -103,6 +103,11 @@ const handleFudgeChanged = function (event) {
         break;
     case 'scaley':
         props.scale = [scaleX, fudge];
+        scaleY = fudge;
+        break;
+    case 'scaleboth':
+        props.scale = [fudge, fudge];
+        scaleX = fudge;
         scaleY = fudge;
         break;
     case 'color':
@@ -134,12 +139,12 @@ fudgeInput.addEventListener('input', handleFudgeChanged);
 fudgeInput.addEventListener('change', handleFudgeChanged);
 fudgeInput.addEventListener('init', handleFudgeChanged);
 
-const stageScaleInput = document.getElementById("stage-scale");
+const stageScaleInput = document.getElementById('stage-scale');
 
 stageScaleInput.addEventListener('input', updateStageScale);
 stageScaleInput.addEventListener('change', updateStageScale);
 
-function updateStageScale(event) {
+function updateStageScale (event) {
     renderer.resize(480 * event.target.valueAsNumber, 360 * event.target.valueAsNumber);
 }
 

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -1,26 +1,26 @@
 const ScratchRender = require('../RenderWebGL');
 const getMousePosition = require('./getMousePosition');
 
-var canvas = document.getElementById('scratch-stage');
-var fudge = 90;
-var renderer = new ScratchRender(canvas);
+const canvas = document.getElementById('scratch-stage');
+let fudge = 90;
+const renderer = new ScratchRender(canvas);
 renderer.setLayerGroupOrdering(['group1']);
 
-var drawableID = renderer.createDrawable('group1');
+const drawableID = renderer.createDrawable('group1');
 renderer.updateDrawableProperties(drawableID, {
     position: [0, 0],
     scale: [100, 100],
     direction: 90
 });
 
-var drawableID2 = renderer.createDrawable('group1');
-var wantBitmapSkin = false;
-var wantPenSkin = false;
+const drawableID2 = renderer.createDrawable('group1');
+const wantBitmapSkin = false;
+const wantPenSkin = false;
 
 // Bitmap (squirrel)
-var image = new Image();
+const image = new Image();
 image.addEventListener('load', () => {
-    var bitmapSkinId = renderer.createBitmapSkin(image);
+    const bitmapSkinId = renderer.createBitmapSkin(image);
     if (wantBitmapSkin && !wantPenSkin) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: bitmapSkinId
@@ -31,9 +31,9 @@ image.crossOrigin = 'anonymous';
 image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e52f8e7f9004416fa34.png/get/';
 
 // SVG (cat 1-a)
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.addEventListener('load', function () {
-    var skinId = renderer.createSVGSkin(xhr.responseText);
+    const skinId = renderer.createSVGSkin(xhr.responseText);
     if (!(wantBitmapSkin || wantPenSkin)) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: skinId
@@ -44,7 +44,7 @@ xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/b7853f557e
 xhr.send();
 
 if (wantPenSkin) {
-    var penSkinID = renderer.createPenSkin();
+    const penSkinID = renderer.createPenSkin();
 
     renderer.updateDrawableProperties(drawableID2, {
         skinId: penSkinID
@@ -64,11 +64,11 @@ if (wantPenSkin) {
     });
 }
 
-var posX = 0;
-var posY = 0;
-var scaleX = 100;
-var scaleY = 100;
-var fudgeProperty = 'posx';
+let posX = 0;
+let posY = 0;
+let scaleX = 100;
+let scaleY = 100;
+let fudgeProperty = 'posx';
 
 const fudgeInput = document.getElementById('fudge');
 const fudgePropertyInput = document.getElementById('fudgeproperty');
@@ -107,7 +107,7 @@ fudgeInput.dispatchEvent(new CustomEvent('init'));
 
 const handleFudgeChanged = function (event) {
     fudge = event.target.valueAsNumber;
-    var props = {};
+    const props = {};
     switch (fudgeProperty) {
     case 'posx':
         props.position = [fudge, posY];
@@ -172,13 +172,13 @@ stageScaleInput.addEventListener('input', updateStageScale);
 stageScaleInput.addEventListener('change', updateStageScale);
 
 canvas.addEventListener('mousemove', event => {
-    var mousePos = getMousePosition(event, canvas);
+    const mousePos = getMousePosition(event, canvas);
     renderer.extractColor(mousePos.x, mousePos.y, 30);
 });
 
 canvas.addEventListener('click', event => {
-    var mousePos = getMousePosition(event, canvas);
-    var pickID = renderer.pick(mousePos.x, mousePos.y);
+    const mousePos = getMousePosition(event, canvas);
+    const pickID = renderer.pick(mousePos.x, mousePos.y);
     console.log('You clicked on ' + (pickID < 0 ? 'nothing' : 'ID# ' + pickID));
     if (pickID >= 0) {
         console.dir(renderer.extractDrawable(pickID, mousePos.x, mousePos.y));
@@ -193,5 +193,5 @@ const drawStep = function () {
 };
 drawStep();
 
-var debugCanvas = /** @type {canvas} */ document.getElementById('debug-canvas');
+const debugCanvas = /** @type {canvas} */ document.getElementById('debug-canvas');
 renderer.setDebugCanvas(debugCanvas);

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -39,7 +39,7 @@ xhr.addEventListener('load', function () {
         });
     }
 });
-xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/f88bf1935daea28f8ca098462a31dbb0.svg/get/');
+xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/b7853f557e4426412e64bb3da6531a99.svg/get/');
 xhr.send();
 
 var posX = 0;

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -49,21 +49,37 @@ var scaleY = 100;
 var fudgeProperty = 'posx';
 
 const fudgePropertyInput = document.getElementById('fudgeproperty');
-fudgePropertyInput.addEventListener('change', event => {
-    fudgeProperty = event.target.value;
-});
+fudgePropertyInput.addEventListener('change', updateFudgeProperty);
+fudgePropertyInput.addEventListener('init', updateFudgeProperty);
 
 const fudgeInput = document.getElementById('fudge');
 
 const fudgeMinInput = document.getElementById('fudgeMin');
-fudgeMinInput.addEventListener('change', event => {
-    fudgeInput.min = event.target.valueAsNumber;
-});
+fudgeMinInput.addEventListener('change', updateFudgeMin);
+fudgeMinInput.addEventListener('init', updateFudgeMin);
 
 const fudgeMaxInput = document.getElementById('fudgeMax');
-fudgeMaxInput.addEventListener('change', event => {
+fudgeMaxInput.addEventListener('change', updateFudgeMax);
+fudgeMaxInput.addEventListener('init', updateFudgeMax);
+
+function updateFudgeProperty(event) {
+    fudgeProperty = event.target.value;
+}
+
+function updateFudgeMin(event) {
+    fudgeInput.min = event.target.valueAsNumber;
+}
+
+function updateFudgeMax(event) {
     fudgeInput.max = event.target.valueAsNumber;
-});
+}
+
+// Ugly hack to properly set the values of the inputs on page load,
+// since they persist across reloads, at least in Firefox.
+// The best ugly hacks are the ones that reduce code duplication!
+fudgePropertyInput.dispatchEvent(new CustomEvent("init"));
+fudgeMinInput.dispatchEvent(new CustomEvent("init"));
+fudgeMaxInput.dispatchEvent(new CustomEvent("init"));
 
 const handleFudgeChanged = function (event) {
     fudge = event.target.valueAsNumber;
@@ -114,6 +130,7 @@ const handleFudgeChanged = function (event) {
 };
 fudgeInput.addEventListener('input', handleFudgeChanged);
 fudgeInput.addEventListener('change', handleFudgeChanged);
+fudgeInput.addEventListener('load', handleFudgeChanged);
 
 canvas.addEventListener('mousemove', event => {
     var mousePos = getMousePosition(event, canvas);

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -15,12 +15,13 @@ renderer.updateDrawableProperties(drawableID, {
 
 var drawableID2 = renderer.createDrawable('group1');
 var wantBitmapSkin = false;
+var wantPenSkin = false;
 
 // Bitmap (squirrel)
 var image = new Image();
 image.addEventListener('load', () => {
     var bitmapSkinId = renderer.createBitmapSkin(image);
-    if (wantBitmapSkin) {
+    if (wantBitmapSkin && !wantPenSkin) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: bitmapSkinId
         });
@@ -33,7 +34,7 @@ image.src = 'https://cdn.assets.scratch.mit.edu/internalapi/asset/7e24c99c1b853e
 var xhr = new XMLHttpRequest();
 xhr.addEventListener('load', function () {
     var skinId = renderer.createSVGSkin(xhr.responseText);
-    if (!wantBitmapSkin) {
+    if (!(wantBitmapSkin || wantPenSkin)) {
         renderer.updateDrawableProperties(drawableID2, {
             skinId: skinId
         });
@@ -41,6 +42,27 @@ xhr.addEventListener('load', function () {
 });
 xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/b7853f557e4426412e64bb3da6531a99.svg/get/');
 xhr.send();
+
+if (wantPenSkin) {
+    var penSkinID = renderer.createPenSkin();
+
+    renderer.updateDrawableProperties(drawableID2, {
+        skinId: penSkinID
+    });
+
+    canvas.addEventListener('click', event => {
+        let rect = canvas.getBoundingClientRect();
+
+        let x = event.clientX - rect.left;
+        let y = event.clientY - rect.top;
+
+        renderer.penLine(penSkinID, {
+            color4f: [Math.random(), Math.random(), Math.random(), 1],
+            diameter: 8
+        },
+        x - 240, 180 - y, Math.random() * 480 - 240, Math.random() * 360 - 180);
+    });
+}
 
 var posX = 0;
 var posY = 0;

--- a/src/playground/queryPlayground.html
+++ b/src/playground/queryPlayground.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Scratch WebGL Query Playground</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
     <style>
         input[type=range][orient=vertical] {
             writing-mode: bt-lr; /* IE */
@@ -11,8 +12,6 @@
             padding: 0 0.5rem;
         }
         canvas {
-            border: 3px dashed black;
-
             /* https://stackoverflow.com/a/7665647 */
             image-rendering: optimizeSpeed; /* Older versions of FF */
             image-rendering: -moz-crisp-edges; /* FF 6.0+ */
@@ -23,7 +22,7 @@
         }
     </style>
 </head>
-<body style="background: lightsteelblue">
+<body>
     <div>
         <fieldset>
             <legend>Query Canvases</legend>
@@ -63,7 +62,7 @@
                         <input id="cursorY" type="range" orient="vertical" step="0.25" value="0" />
                     </td>
                     <td>
-                        <canvas id="renderCanvas" width="480" height="360" style="border:3px dashed black"></canvas>
+                        <canvas id="renderCanvas" width="480" height="360"></canvas>
                     </td>
                 </tr>
             </table>

--- a/src/playground/style.css
+++ b/src/playground/style.css
@@ -1,0 +1,11 @@
+body {
+	background: lightsteelblue;
+}
+
+canvas {
+	border: 3px dashed black;
+}
+
+#debug-canvas {
+	border-color: red;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = [
             new CopyWebpackPlugin([
                 {
                     context: 'src/playground',
-                    from: '*'
+                    from: '*.+(html|css)'
                 }
             ])
         ])

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = [
             new CopyWebpackPlugin([
                 {
                     context: 'src/playground',
-                    from: '*.html'
+                    from: '*'
                 }
             ])
         ])


### PR DESCRIPTION
### Proposed Changes

I made a number of improvements to the rendering playground, including adding a stage size slider, making the page re-read the slider and spinbox(?) values after reloading, using the redrawn Scratch cat SVG, and moving inline styles into a separate stylesheet.

### Reason for Changes

These changes improve the functionality of the testing playground.