### PR TITLE
Add JavaScript MIPs for scaling textures larger and smaller

### DIFF
--- a/src/SVGMIP.js
+++ b/src/SVGMIP.js
@@ -1,0 +1,56 @@
+const twgl = require('twgl.js');
+
+class SVGMIP {
+    /**
+    * Create a new SVG MIP for a given scale.
+    * @param {RenderWebGL} renderer - The renderer which this MIP's skin uses.
+    * @param {SvgRenderer} svgRenderer - The svg renderer which this MIP's skin uses.
+    * @param {number} scale - The relative size of the MIP
+    * @param {function} callback - A callback that should always fire after draw()
+    * @constructor
+    */
+    constructor (renderer, svgRenderer, scale, callback) {
+        this._renderer = renderer;
+        this._svgRenderer = svgRenderer;
+        this._scale = scale;
+        this._texture = null;
+        this._callback = callback;
+
+        this.draw();
+    }
+
+    draw () {
+        this._svgRenderer._draw(this._scale, () => {
+            const textureData = this._getTextureData();
+            const textureOptions = {
+                auto: false,
+                wrap: this._renderer.gl.CLAMP_TO_EDGE,
+                src: textureData
+            };
+
+            this._texture = twgl.createTexture(this._renderer.gl, textureOptions);
+            this._callback(textureData);
+        });
+    }
+
+    dispose () {
+        this._renderer.gl.deleteTexture(this.getTexture());
+    }
+
+    getTexture () {
+        return this._texture;
+    }
+
+    _getTextureData () {
+        // Pull out the ImageData from the canvas. ImageData speeds up
+        // updating Silhouette and is better handled by more browsers in
+        // regards to memory.
+        const canvas = this._svgRenderer.canvas;
+        const context = canvas.getContext('2d');
+        const textureData = context.getImageData(0, 0, canvas.width, canvas.height);
+
+        return textureData;
+    }
+}
+
+module.exports = SVGMIP;


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-render/issues/374, potentially also https://github.com/LLK/scratch-render/issues/334

### Proposed Changes

[As discussed on other issues](https://github.com/LLK/scratch-render/issues/334), adding mipmap functionality will be helpful for scaling images at a good resolution in Scratch. This PR:

- Adds a SVGMIP as a wrapper for WebGL textures to handle creating them at a certain scale and updating them if needed
- Stores JavaScript mips on SVGSkin in an array `_scaledMIPs` using an index offset to allow for mips that have a scale of less than one. We're using an array here for better performance instead of an object with more descriptive keys
- Extends while loop in `SVGSkin.getTexture` to get smaller scales in addition to larger ones

Here is an example repro project. After the green flag click, the original sprite is scaled up and down while the clone remains unscaled. Both have a better resolution because they no longer share a texture at all times and use the one at its requested scale. https://scratch.mit.edu/projects/295219677/editor/

The screenshots' differences are a little tough to see at a smaller size, but it's clear when you click them and see them in a new tab. Also these were taken on a lower resolution monitor. If your screen has a hidpi, these differences are harder to see. 

| Production     | PR Changes |
| ----------- | ----------- |
| ![Screen Shot 2019-04-01 at 2 28 15 PM](https://user-images.githubusercontent.com/7991694/55350589-719f5c00-548a-11e9-8046-99b480af4fde.png) |  ![Screen Shot 2019-04-01 at 2 25 26 PM](https://user-images.githubusercontent.com/7991694/55350453-238a5880-548a-11e9-84fb-7ceff3e45116.png) |

### Memory usage

[In our previous discussion of this topic,](https://github.com/LLK/scratch-render/issues/334#issuecomment-449143929) one point against scaling mips with JavaScript instead of automatically on the GPU is that this method would use more memory. From some profiling I did with [Chrome](https://www.lifewire.com/google-chrome-task-manager-4103619) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Performance/about:memory), it seems like [this test project](https://scratch.mit.edu/projects/295219677/editor/) hovers around the same amount of memory on the `develop` branch and this feature branch. Here are the results I found:

| **Chrome**  | `develop`      | `javascript-scaled-textures` |
| ----------- | ----------- | ----------- |
| **Memory Footprint** | 192 MB |  190 MB  |
| **GPU Memory**  |  28.3 MB      |    28.5 MB |

| **Firefox**  | `develop`      | `javascript-scaled-textures` |
| ----------- | ----------- | ----------- |
|Trial 1  |  81.96 MB (09.74%)  | 82.49 MB (09.79%) |
|Trial 2  | 73.19 MB (08.73%)  | 104.62 MB (11.86%) |
|Trial 3  | 99.08 MB (11.43%) | 84.35 MB (09.85%) |


Theoretically there should be a memory usage increase because there are more textures. I added the surface areas of power of 2 sized images between 2x2 and 1024x1024 and found that they would use about 33% more memory than just a single 1024x1024 image, but perhaps in the way we're using them in this branch, the browser is able to release some of that memory. From what I can see using Chrome and Firefox's tools, multiple JavaScript scaled textures hasn't had much of an impact on a tab's memory usage. I'm curious to hear more thoughts on this though!

### What this hasn't solved yet

I've found this implementation of mips successfully scales sprites that have been changes by a "looks" block, but sprites that haven't been scaled by a block still don't scale well. For example, when you reduce the browser's width while using the editor, the stage scales down and the sprite's quality is reduced:

| Full size stage      | Smaller stage |
| -----------            | ----------- |
| ![Screen Shot 2019-04-01 at 2 17 11 PM](https://user-images.githubusercontent.com/7991694/55350065-318ba980-5489-11e9-8cf8-ce7567154d1c.png)     | ![Screen Shot 2019-04-01 at 2 17 23 PM](https://user-images.githubusercontent.com/7991694/55350080-3ea89880-5489-11e9-89a9-d4d04e2dc2a3.png) |

Fullscreen mode is another example of this:

![Screen Shot 2019-04-01 at 2 32 13 PM](https://user-images.githubusercontent.com/7991694/55350862-0609be80-548b-11e9-980f-92b8e58b1f31.png)

Thoughts on how to scale sprites in this scenario and also thoughts on this approach for mipmaps are much appreciated!

