### PR TITLE
Draw pen lines via fragment shader

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -217,8 +217,8 @@ class PenSkin extends Skin {
 
         this._drawLineOnBuffer(
             penAttributes,
-            x0 + offset, -y0 + offset,
-            x1 + offset, -y1 + offset
+            x0 + offset, y0 + offset,
+            x1 + offset, y1 + offset
         );
 
         this._silhouetteDirty = true;
@@ -297,28 +297,6 @@ class PenSkin extends Skin {
 
         this._renderer.enterDrawRegion(this._lineOnBufferDrawRegionId);
 
-        const diameter = penAttributes.diameter || DefaultPenAttributes.diameter;
-        const radius = diameter / 2;
-        // Expand line bounds by sqrt(2) / 2 each side-- this ensures that all antialiased pixels
-        // fall within the quad, even at a 45-degree diagonal
-        const expandedRadius = radius + 1.4142135623730951;
-
-        const lineLength = Math.hypot(x1 - x0, y1 - y0);
-        const lineAngle = Math.atan2(y1 - y0, x1 - x0);
-
-        const halfWidth = this._bounds.width * 0.5;
-        const halfHeight = this._bounds.height * 0.5;
-
-        const transformMatrix = __modelMatrix;
-        twgl.m4.identity(transformMatrix);
-        // Apply view transform to matrix
-        twgl.m4.scale(transformMatrix, [1 / halfWidth, 1 / halfHeight, 1], transformMatrix);
-
-        twgl.m4.translate(transformMatrix, [x0, y0, 0], transformMatrix);
-        twgl.m4.rotateZ(transformMatrix, lineAngle, transformMatrix);
-        twgl.m4.translate(transformMatrix, [-expandedRadius, -expandedRadius, 0], transformMatrix);
-        twgl.m4.scale(transformMatrix, [lineLength + (expandedRadius * 2), (expandedRadius * 2), 1], transformMatrix);
-
         // Premultiply pen color by pen transparency
         const penColor = penAttributes.color4f || DefaultPenAttributes.color4f;
         __premultipliedColor[0] = penColor[0] * penColor[3];
@@ -327,10 +305,9 @@ class PenSkin extends Skin {
         __premultipliedColor[3] = penColor[3];
 
         const uniforms = {
-            u_modelMatrix: transformMatrix,
             u_lineColor: __premultipliedColor,
-            u_lineThickness: diameter,
-            u_penPoints: [x0 + halfWidth, y0 + halfHeight, x1 + halfWidth, y1 + halfHeight],
+            u_lineThickness: penAttributes.diameter || DefaultPenAttributes.diameter,
+            u_penPoints: [x0, -y0, x1, -y1],
             u_stageSize: this.size
         };
 

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -210,9 +210,10 @@ class PenSkin extends Skin {
      * @param {number} y1 - the Y coordinate of the end of the line.
      */
     drawLine (penAttributes, x0, y0, x1, y1) {
-        // Width 1 and 3 lines need to be offset by 0.5.
+        // For compatibility with Scratch 2.0, offset pen lines of width 1 and 3 so they're pixel-aligned.
+        // See https://github.com/LLK/scratch-render/pull/314
         const diameter = penAttributes.diameter || DefaultPenAttributes.diameter;
-        const offset = (Math.max(4 - diameter, 0) % 2) / 2;
+        const offset = (diameter === 1 || diameter === 3) ? 0.5 : 0;
 
         this._drawLineOnBuffer(
             penAttributes,

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -169,9 +169,9 @@ ShaderManager.DRAW_MODE = {
     colorMask: 'colorMask',
 
     /**
-     * Sample a "texture" to draw a line with caps.
+     * Draw a line with caps.
      */
-    lineSample: 'lineSample'
+    line: 'line'
 };
 
 module.exports = ShaderManager;

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -36,8 +36,7 @@ uniform float u_ghost;
 #ifdef DRAW_MODE_line
 uniform vec4 u_lineColor;
 uniform float u_lineThickness;
-uniform vec2 u_p1;
-uniform vec2 u_p2;
+uniform vec4 u_penPoints;
 #endif // DRAW_MODE_line
 
 uniform sampler2D u_skin;
@@ -215,7 +214,7 @@ void main()
 	// Maaaaagic antialiased-line-with-round-caps shader.
 	// Adapted from Inigo Quilez' 2D distance function cheat sheet
 	// https://www.iquilezles.org/www/articles/distfunctions2d/distfunctions2d.htm
-	vec2 pa = v_texCoord - u_p1, ba = u_p2 - u_p1;
+	vec2 pa = v_texCoord - u_penPoints.xy, ba = u_penPoints.zw - u_penPoints.xy;
 	float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
 
 	float cappedLine = clamp((u_lineThickness + 1.0) * 0.5 - length(pa - ba*h), 0.0, 1.0);

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -1,11 +1,18 @@
-uniform mat4 u_modelMatrix;
+precision mediump float;
 
 #ifdef DRAW_MODE_line
 uniform vec2 u_stageSize;
+uniform float u_lineThickness;
+uniform vec4 u_penPoints;
+
+// Add this to divisors to prevent division by 0, which results in NaNs propagating through calculations.
+// Smaller values can cause problems on some mobile devices.
+const float epsilon = 1e-3;
 #endif
 
 #ifndef DRAW_MODE_line
 uniform mat4 u_projectionMatrix;
+uniform mat4 u_modelMatrix;
 attribute vec2 a_texCoord;
 #endif
 
@@ -14,13 +21,37 @@ attribute vec2 a_position;
 varying vec2 v_texCoord;
 
 void main() {
-    #ifdef DRAW_MODE_line
-    vec4 screenCoord = u_modelMatrix * vec4(a_position, 0, 1);
+	#ifdef DRAW_MODE_line
+	// Calculate a rotated ("tight") bounding box around the two pen points.
+	// Yes, we're doing this 6 times (once per vertex), but on actual GPU hardware,
+	// it's still faster than doing it in JS combined with the cost of uniformMatrix4fv.
 
-    gl_Position = screenCoord;
-    v_texCoord = ((screenCoord.xy * 0.5) + 0.5) * u_stageSize;
-    #else
-    gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
-    v_texCoord = a_texCoord;
-    #endif
+	// Expand line bounds by sqrt(2) / 2 each side-- this ensures that all antialiased pixels
+	// fall within the quad, even at a 45-degree diagonal
+	vec2 position = a_position;
+	float expandedRadius = (u_lineThickness * 0.5) + 1.4142135623730951;
+
+	float lineLength = length(u_penPoints.zw - u_penPoints.xy);
+
+	position.x *= lineLength + (2.0 * expandedRadius);
+	position.y *= 2.0 * expandedRadius;
+
+	// Center around first pen point
+	position -= expandedRadius;
+
+	// Rotate quad to line angle
+	vec2 normalized = (u_penPoints.zw - u_penPoints.xy + epsilon) / (lineLength + epsilon);
+	position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
+	// Translate quad
+	position += u_penPoints.xy;
+
+	// Apply view transform
+	position *= 2.0 / u_stageSize;
+
+	gl_Position = vec4(position, 0, 1);
+	v_texCoord = position * 0.5 * u_stageSize;
+	#else
+	gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
+	v_texCoord = a_texCoord;
+	#endif
 }

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -6,10 +6,10 @@ uniform vec2 u_stageSize;
 
 #ifndef DRAW_MODE_line
 uniform mat4 u_projectionMatrix;
+attribute vec2 a_texCoord;
 #endif
 
 attribute vec2 a_position;
-attribute vec2 a_texCoord;
 
 varying vec2 v_texCoord;
 

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -1,22 +1,26 @@
-uniform mat4 u_projectionMatrix;
 uniform mat4 u_modelMatrix;
+
+#ifdef DRAW_MODE_line
+uniform vec2 u_stageSize;
+#endif
+
+#ifndef DRAW_MODE_line
+uniform mat4 u_projectionMatrix;
+#endif
 
 attribute vec2 a_position;
 attribute vec2 a_texCoord;
 
 varying vec2 v_texCoord;
 
-#ifdef DRAW_MODE_lineSample
-uniform float u_positionScalar;
-#endif
-
 void main() {
-    #ifdef DRAW_MODE_lineSample
-    vec2 position = a_position;
-    position.y = clamp(position.y * u_positionScalar, -0.5, 0.5);
-    gl_Position = u_projectionMatrix * u_modelMatrix * vec4(position, 0, 1);
+    #ifdef DRAW_MODE_line
+    vec4 screenCoord = u_modelMatrix * vec4(a_position, 0, 1);
+
+    gl_Position = screenCoord;
+    v_texCoord = ((screenCoord.xy * 0.5) + 0.5) * u_stageSize;
     #else
     gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
-    #endif
     v_texCoord = a_texCoord;
+    #endif
 }


### PR DESCRIPTION
### Resolves

Kinda resolves #420?
Also resolves https://github.com/LLK/scratch-gui/issues/4313 [EDIT: and now resolves #306]

### Proposed Changes

This changes the PenSkin's line-drawing routine from a primarily vertex-based operation to a fragment-based one. Lines are now drawn via a screen-space pixel shader that provides proper antialiasing.

```PenSkin.drawLineOnBuffer()``` now draws a single ~~axis-aligned~~ quad. The quad's fragment shader, given the endpoints, color, and thickness of the line, properly computes antialiased line coverage for each pixel inside it.

This has two effects:
1. It gets rid of all the jaggies on the edges of each line
2. It makes dots truly circular

This still doesn't completely match 2.0. In 2.0, "size 1" lines appear thicker at certain angles, and pen *points* render at a different offset from pen *lines*. The former might be worth investigating, but in my opinion the latter behavior is too confusing/annoying to be worth emulating.

On My Machine™, it runs [236783324](https://scratch.mit.edu/projects/236783324/) at the same speed, suggesting the bottleneck is in the VM now, but more comprehensive benchmarking across different GPUs would be wise.

~~I've done very little WebGL, so a lot of cleanup/refinement is probably necessary.~~

Current | This PR | Scratch 2.0
---|---|---
![1-before](https://user-images.githubusercontent.com/25993062/56542622-fdae1c00-653c-11e9-8171-728f17ae9f82.png) | ![1-after](https://user-images.githubusercontent.com/25993062/56499639-4205d180-64d5-11e9-8a8d-f9b768ae75e2.png) | ![1-scratch2](https://user-images.githubusercontent.com/25993062/56455573-ea793180-632d-11e9-9b41-cf48f651ba1a.png)
[Pen stroke test](https://scratch.mit.edu/projects/303669200/)
![2-before](https://user-images.githubusercontent.com/25993062/56455592-2ad8af80-632e-11e9-8e00-deb57e42af30.png) | ![2-after](https://user-images.githubusercontent.com/25993062/56499645-47631c00-64d5-11e9-9ffe-0c29abdbdcbb.png) | ![2-scratch2](https://user-images.githubusercontent.com/25993062/56455595-31672700-632e-11e9-8f18-777277108555.png)
[Pen stroke test 2](https://scratch.mit.edu/projects/303711585/)
![3-before](https://user-images.githubusercontent.com/25993062/56455613-8145ee00-632e-11e9-96a1-927ed8eb1b9a.png) | ![3-after](https://user-images.githubusercontent.com/25993062/56499658-4d58fd00-64d5-11e9-9db6-4f53f9d964a0.png) | ![3-scratch2](https://user-images.githubusercontent.com/25993062/56455616-85720b80-632e-11e9-8980-47fce8bb97ed.png)
[Pen roundness test](https://scratch.mit.edu/projects/303711508/)

EDIT: [This](https://scratch.mit.edu/projects/55619918/) may be a good test project. Make sure to run this multiple times-- there's a lot of weird variance. It looks like most of the time (in both the current code and this PR's) is spent in setUniforms, but fixing that would likely require UBOs, which are a WebGL 2 feature.