### PR TITLE
Don't _doExitDrawRegion in penStamp until we're sure we're stamping

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1409,8 +1409,6 @@ class RenderWebGL extends EventEmitter {
      * @param {int} stampID - the unique ID of the Drawable to use as the stamp.
      */
     penStamp (penSkinID, stampID) {
-        this._doExitDrawRegion();
-
         const stampDrawable = this._allDrawables[stampID];
         if (!stampDrawable) {
             return;
@@ -1420,6 +1418,8 @@ class RenderWebGL extends EventEmitter {
         if (!bounds) {
             return;
         }
+
+        this._doExitDrawRegion();
 
         const skin = /** @type {PenSkin} */ this._allSkins[penSkinID];
 


### PR DESCRIPTION
### Resolves

Resolves #425, but not the root cause. See #441 for that fix.

### Proposed Changes

```WebGLRender.penStamp()``` calls ```_doExitDrawRegion()``` before it does the actual graphics work. However, it calls it before it checks whether it should actually do any graphics work. This change moves the ```_doExitDrawRegion()``` call after the checks for the drawable existing and being in bounds.

### Reason for Changes

I wanted to separate this out from #441.

EDIT: This change may improve performance by reducing GL calls.