### PR TITLE
Always use linear interpolation on vector skins with distortion effects applied

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -432,7 +432,12 @@ class Drawable {
         }
 
         // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
-        if (this._effectBits & 0b0011110) {
+        if (this._effectBits & (
+            ShaderManager.EFFECT_INFO.fisheye.mask |
+            ShaderManager.EFFECT_INFO.whirl.mask |
+            ShaderManager.EFFECT_INFO.pixelate.mask |
+            ShaderManager.EFFECT_INFO.mosaic.mask
+        )) {
             return false;
         }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -431,6 +431,11 @@ class Drawable {
             return true;
         }
 
+        // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
+        if (this._effectBits & 0b0011110) {
+            return false;
+        }
+
         // We can't use nearest neighbor unless we are a multiple of 90 rotation
         if (this._direction % 90 !== 0) {
             return false;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -437,7 +437,7 @@ class Drawable {
             ShaderManager.EFFECT_INFO.whirl.mask |
             ShaderManager.EFFECT_INFO.pixelate.mask |
             ShaderManager.EFFECT_INFO.mosaic.mask
-        )) {
+        ) !== 0) {
             return false;
         }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -434,12 +434,12 @@ class Drawable {
         }
 
         // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
-        if (this._effectBits & (
+        if ((this._effectBits & (
             ShaderManager.EFFECT_INFO.fisheye.mask |
             ShaderManager.EFFECT_INFO.whirl.mask |
             ShaderManager.EFFECT_INFO.pixelate.mask |
             ShaderManager.EFFECT_INFO.mosaic.mask
-        ) !== 0) {
+        )) !== 0) {
             return false;
         }
 


### PR DESCRIPTION
### Resolves

There's no issue for it, but currently, vector sprites with distortion effects (fisheye, whirl, pixelate, and mosaic) appear jagged near 100% scale but smooth otherwise, as can be seen in [this test project](https://scratch.mit.edu/projects/303721927/):
![jaggies](https://user-images.githubusercontent.com/25993062/56457070-95e0b100-6343-11e9-966b-dcdb7902dbb2.gif)

### Proposed Changes

This change adds another check to ```Drawable.useNearest()``` so that it returns ```false``` on non-bitmap skins with fisheye, whirl, pixelate, and/or mosaic effects applied.