### PR TITLE
Fix Rectangle.Clamp()

### DIFF
--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -98,11 +98,11 @@ class Rectangle {
         this.right = Math.min(this.right, right);
         this.bottom = Math.max(this.bottom, bottom);
         this.top = Math.min(this.top, top);
-        // Ensure rectangle coordinates in order.
-        this.left = Math.min(this.left, this.right);
-        this.right = Math.max(this.right, this.left);
-        this.bottom = Math.min(this.bottom, this.top);
-        this.top = Math.max(this.top, this.bottom);
+        
+        this.left = Math.min(this.left, right);
+        this.right = Math.max(this.right, left);
+        this.bottom = Math.min(this.bottom, top);
+        this.top = Math.max(this.top, bottom);
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

This fixes ```Rectangle.Clamp()``` to do what it says on the tin.

Clamping a value _n_ between minimum _a_ and maximum _b_ is done with min(max(n, a), b), which we do in two parts here.

Before this change, it was comparing to the bounds it had *just* clamped, instead of the actual bounds, giving incorrect behavior.

### Reason for Changes

Mathematical functions should do what they say on the tin.
