### PR TITLE
Cache and don't re-create transformed hull points

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -102,6 +102,12 @@ class Drawable {
         this._convexHullPoints = null;
         this._convexHullDirty = true;
 
+        // The precise bounding box will be from the transformed convex hull points,
+        // so initialize the array of transformed hull points in setConvexHullPoints.
+        // Initializing it once per convex hull recalculation avoids unnecessary creation of twgl.v3 objects.
+        this._transformedHullPoints = null;
+        this._transformedHullDirty = true;
+
         this._skinWasAltered = this._skinWasAltered.bind(this);
     }
 
@@ -120,6 +126,7 @@ class Drawable {
     setTransformDirty () {
         this._transformDirty = true;
         this._inverseTransformDirty = true;
+        this._transformedHullDirty = true;
     }
 
     /**
@@ -447,6 +454,14 @@ class Drawable {
     setConvexHullPoints (points) {
         this._convexHullPoints = points;
         this._convexHullDirty = false;
+
+        // Re-create the "transformed hull points" array.
+        // We only do this when the hull points change to avoid unnecessary allocations and GC.
+        this._transformedHullPoints = [];
+        for (let i = 0; i < points.length; i++) {
+            this._transformedHullPoints.push(twgl.v3.create());
+        }
+        this._transformedHullDirty = true;
     }
 
     /**
@@ -591,23 +606,27 @@ class Drawable {
      * @private
      */
     _getTransformedHullPoints () {
+        if (!this._transformedHullDirty) {
+            return this._transformedHullPoints;
+        }
+
         const projection = twgl.m4.ortho(-1, 1, -1, 1, -1, 1);
         const skinSize = this.skin.size;
         const halfXPixel = 1 / skinSize[0] / 2;
         const halfYPixel = 1 / skinSize[1] / 2;
         const tm = twgl.m4.multiply(this._uniforms.u_modelMatrix, projection);
-        const transformedHullPoints = [];
         for (let i = 0; i < this._convexHullPoints.length; i++) {
             const point = this._convexHullPoints[i];
-            const glPoint = twgl.v3.create(
-                0.5 + (-point[0] / skinSize[0]) - halfXPixel,
-                (point[1] / skinSize[1]) - 0.5 + halfYPixel,
-                0
-            );
-            twgl.m4.transformPoint(tm, glPoint, glPoint);
-            transformedHullPoints.push(glPoint);
+            const dstPoint = this._transformedHullPoints[i];
+
+            dstPoint[0] = 0.5 + (-point[0] / skinSize[0]) - halfXPixel;
+            dstPoint[1] = (point[1] / skinSize[1]) - 0.5 + halfYPixel;
+            twgl.m4.transformPoint(tm, dstPoint, dstPoint);
         }
-        return transformedHullPoints;
+
+        this._transformedHullDirty = false;
+
+        return this._transformedHullPoints;
     }
 
     /**


### PR DESCRIPTION
### Resolves

~~One~~ Two of the concerns in #365 

### Proposed Changes

- Create `Rectangle`s per-`Drawable` for holding `get(Fast)Bounds` results
- Store transformed convex hull points in an array initialized when un-transformed convex hull points are initialized
- Add "transformed convex hull dirty" flag

### Reason for Changes

- Create `Rectangle`s per-`Drawable` for holding `get(Fast)Bounds` results

`Drawable.getBounds`, `Drawable.getBoundsForBubble`, `Drawable.getFastBounds`, and `Drawable.getAABB` take an optional `result` parameter (a `Rectangle`). If given, it will be set to the drawable's bounds.

If a `result` parameter was not passed, however, those functions would create an entirely new `Rectangle` on each call. To make things worse, they're called from several places in the codebase without a `result` being passed.

Now, each `Drawable` instantiates its own `Rectangle`s to hold the bounds results only once: when the `Drawable` itself is created. This should prevent unnecessary creation of `Rectangle`s.

- Store transformed convex hull points in an array initialized when un-transformed convex hull points are initialized

Previously, calling `_getTransformedHullPoints` would result in an entirely new array being created and filled up with `twgl.v3` objects each time.

Now, the array is created and filled with `twgl.v3` objects only when the convex hull itself changes. `_getTransformedHullPoints` now modifies these `twgl.v3` objects in-place. This change should greatly reduce the number of unnecessary objects created.

- Add "transformed convex hull dirty" flag

Previously, calling `_getTransformedHullPoints` meant always recalculating the positions of transformed convex hull points. Now, they are only recalculated when the transform has actually changed.


These changes greatly reduce the allocations made by convex-hull functions:

["Vector scaling performance test 2"](https://scratch.mit.edu/projects/298553174/) (makes heavy use of "if on edge, bounce")

Before | After
-|-
![image](https://user-images.githubusercontent.com/25993062/56576578-be141e00-6596-11e9-8a6a-b1513784fca0.png) | ![image](https://user-images.githubusercontent.com/25993062/56576520-9b820500-6596-11e9-8448-08c0b2df14b7.png)
![image](https://user-images.githubusercontent.com/25993062/56576590-c8ceb300-6596-11e9-912b-0dbae2e2ef33.png) | ![image](https://user-images.githubusercontent.com/25993062/56576551-a5a40380-6596-11e9-9520-f25ca60a03c9.png)

