### PR TITLE
Move from UglifyJS to Terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "json": "^9.0.4",
     "scratch-vm": "0.2.0-prerelease.20190207224121",
     "tap": "^11.0.0",
+    "terser-webpack-plugin": "^1.2.4",
     "travis-after-all": "^1.4.4",
-    "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.8.0",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.4"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -26,7 +26,7 @@ const base = {
     },
     optimization: {
         minimizer: [
-            new UglifyJsPlugin({
+            new TerserPlugin({
                 include: /\.min\.js$/
             })
         ]


### PR DESCRIPTION
### Resolves

Closes #345

### Proposed Changes

This replaces `uglifyjs-webpack-plugin` with `terser-webpack-plugin`.

### Reason for Changes

Last September, `uglifyjs-webpack-plugin` switched from `uglify-es`, which supports ES6, to `uglify-js`, which does not. As a result, this codebase won't build with newer versions of `uglifyjs-webpack-plugin`. This is somewhat okay because it's pinned to the old version, but it's a good idea to switch to `terser-webpack-plugin`, which currently supports ES6, in order to stay up-to-date.