### PR TITLE
Deobfuscate _getConvexHullPointsForDrawable and remove unnecessary hull.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "grapheme-breaker": "0.3.2",
-    "hull.js": "0.2.10",
     "ify-loader": "1.0.4",
     "linebreak": "0.3.0",
     "minilog": "3.1.0",

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1673,6 +1673,9 @@ class RenderWebGL extends EventEmitter {
         const leftHull = [];
         const rightHull = [];
 
+        // While convex hull algorithms usually push and pop values from the list of hull points,
+        // here, we keep indices for the "last" point in each array. Any points past these indices are ignored.
+        // This is functionally equivalent to pushing and popping from a "stack" of hull points.
         let leftEndPointIndex = -1;
         let rightEndPointIndex = -1;
 
@@ -1749,7 +1752,7 @@ class RenderWebGL extends EventEmitter {
 
         // Start off "hullPoints" with the left hull points. This is where we get rid of those dangling extra points.
         const hullPoints = leftHull.slice(0, leftEndPointIndex + 1);
-        // Add points from the right side to in reverse order so all points are clockwise from each other.
+        // Add points from the right side in reverse order so all points are ordered clockwise.
         for (let j = rightEndPointIndex; j >= 0; --j) {
             hullPoints.push(rightHull[j]);
         }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1707,9 +1707,9 @@ class RenderWebGL extends EventEmitter {
 
             // Because leftEndPointIndex is initialized to -1, this is skipped for the bottom two rows.
             // It runs only when there are enough points in the left hull to make at least one line.
-            // If appending the current point to the left hull makes a clockwise turn,
+            // If appending the current point to the left hull makes a counter-clockwise turn,
             // we want to append the current point. Otherwise, we decrement the index of the "last" hull point until the
-            // current point makes a clockwise turn.
+            // current point makes a counter-clockwise turn.
             // This decrementing has the same effect as popping from the point list, but is hopefully faster.
             while (leftEndPointIndex > 0) {
                 if (determinant(leftHull[leftEndPointIndex], leftHull[leftEndPointIndex - 1], currentPoint) > 0) {
@@ -1738,7 +1738,7 @@ class RenderWebGL extends EventEmitter {
                 }
             }
 
-            // Because we're coming at this from the right, it goes counter-clockwise this time.
+            // Because we're coming at this from the right, it goes clockwise this time.
             while (rightEndPointIndex > 0) {
                 if (determinant(rightHull[rightEndPointIndex], rightHull[rightEndPointIndex - 1], currentPoint) < 0) {
                     break;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,6 @@ module.exports = [
         externals: {
             '!ify-loader!grapheme-breaker': 'grapheme-breaker',
             '!ify-loader!linebreak': 'linebreak',
-            'hull.js': true,
             'scratch-svg-renderer': true,
             'twgl.js': true,
             'xml-escape': true


### PR DESCRIPTION
### Resolves

Resolves #455

### Proposed Changes

This PR makes two changes (which I will gladly separate if needed!):
 - It re-annotates, and changes some of the variable names used in, the convex hull calculation code for `_getConvexHullPointsForDrawable`. This should make it a bit clearer to understand.
 - It removes the dependency on, and use of, hull.js. In discovering how the hull algorithm works, I have confirmed that the hull it generates is already convex, and thus there is no need to bring in an external dependency to make sure it's extra-convex.

### Reason for Changes

These changes make the codebase more friendly to those looking over it for the first time.

(Also, cwillisf, I couldn't find a description of this algorithm anywhere [in Numerical Recipes](https://github.com/LLK/scratch-render/pull/196/files#r151581952). How could you lie to me like this :stuck_out_tongue:)