### PR TITLE
Revert "Tweak scalingVector to make dots appear to be more circular"

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -379,10 +379,8 @@ class PenSkin extends Skin {
         translationVector[1] = avgY + (alias / 4);
 
         const scalingVector = __modelScalingVector;
-        // Dots tend to be ovals that are longer on the y-axis, so we use a smaller alias
-        // for the y value than for the x value to make dots more circular.
-        scalingVector[0] = diameter + (alias / 2);
-        scalingVector[1] = length + diameter - (alias / 6);
+        scalingVector[0] = diameter + alias;
+        scalingVector[1] = length + diameter - (alias / 2);
 
         const radius = diameter / 2;
         const yScalar = (0.50001 - (radius / (length + diameter)));


### PR DESCRIPTION
Reverts LLK/scratch-render#423

* #423 improved pen appearance at small sizes, by making dots appear to be more circular
* However, #423 also made some pen rendering look worse, especially when aliasing the edges of large circles

Production version:

* Note the horizontally squashed look of the smaller circles
* Note the nicely aliased boundary of the larger circles

![image](https://user-images.githubusercontent.com/3431616/58645580-aa648180-82d1-11e9-9ef7-ab81ed91abb8.png)


Changes with #423: 

* Note the more rounded look of the smaller circles
* Note the not so nicely aliased boundary of the larger circles, especially the bottoms

![image](https://user-images.githubusercontent.com/3431616/58645563-9de02900-82d1-11e9-9117-0c4cfbbed58a.png)
