### PR TITLE
Initialialize AABB Rectangle 

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -15,6 +15,7 @@
         "private": true,
         "readme": "README.md",
         "recurse": true,
-        "template": "node_modules/docdash"
+        "template": "node_modules/docdash",
+        "tutorials": "docs"
     }
 }

--- a/docs/Rectangle-AABB-Matrix.md
+++ b/docs/Rectangle-AABB-Matrix.md
@@ -1,0 +1,192 @@
+# Rectangle AABB Matrix
+
+Initialize a Rectangle to a 1 unit square centered at 0 x 0 transformed by a model matrix.
+
+-----
+
+Every drawable is a 1 x 1 unit square that is rotated by its direction, scaled by its skin size and scale, and offset by its rotation center and position. The square representation is made up of 4 points that are transformed by the drawable properties. Often we want a shape that simplifies those 4 points into a non-rotated shape, a axis aligned bounding box.
+
+One approach is to compare the x and y components of each transformed vector and find the minimum and maximum x component and the minimum and maximum y component.
+
+We can start from this approach and determine an alternative one that prodcues the same output with less work.
+
+Starting with transforming one point, here is a 3D point, `v`, transformation by a matrix, `m`.
+
+```js
+const v0 = v[0];
+const v1 = v[1];
+const v2 = v[2];
+
+const d = v0 * m[(0 * 4) + 3] + v1 * m[(1 * 4) + 3] + v2 * m[(2 * 4) + 3] + m[(3 * 4) + 3];
+dst[0] = (v0 * m[(0 * 4) + 0] + v1 * m[(1 * 4) + 0] + v2 * m[(2 * 4) + 0] + m[(3 * 4) + 0]) / d;
+dst[1] = (v0 * m[(0 * 4) + 1] + v1 * m[(1 * 4) + 1] + v2 * m[(2 * 4) + 1] + m[(3 * 4) + 1]) / d;
+dst[2] = (v0 * m[(0 * 4) + 2] + v1 * m[(1 * 4) + 2] + v2 * m[(2 * 4) + 2] + m[(3 * 4) + 2]) / d;
+```
+
+As this is a 2D rectangle we can cancel out the third dimension, and the determinant, 'd'.
+
+```js
+const v0 = v[0];
+const v1 = v[1];
+
+dst = [
+    v0 * m[(0 * 4) + 0] + v1 * m[(1 * 4) + 0] + m[(3 * 4) + 0,
+    v0 * m[(0 * 4) + 1] + v1 * m[(1 * 4) + 1] + m[(3 * 4) + 1
+];
+```
+
+Let's set the matrix points to shorter names for convenience.
+
+```js
+const m00 = m[(0 * 4) + 0];
+const m01 = m[(0 * 4) + 1];
+const m10 = m[(1 * 4) + 0];
+const m11 = m[(1 * 4) + 1];
+const m30 = m[(3 * 4) + 0];
+const m31 = m[(3 * 4) + 1];
+```
+
+We need 4 points with positive and negative 0.5 values so the square has sides of length 1.
+
+```js
+let p = [0.5, 0.5];
+let q = [-0.5, 0.5];
+let r = [-0.5, -0.5];
+let s = [0.5, -0.5];
+```
+
+Transform the points by the matrix.
+
+```js
+p = [
+    0.5 * m00 + 0.5 * m10 + m30,
+    0.5 * m01 + 0.5 * m11 + m31
+];
+q = [
+    -0.5 * m00 + -0.5 * m10 + m30,
+    0.5 * m01 + 0.5 * m11 + m31
+];
+r = [
+    -0.5 * m00 + -0.5 * m10 + m30,
+    -0.5 * m01 + -0.5 * m11 + m31
+];
+s = [
+    0.5 * m00 + 0.5 * m10 + m30,
+    -0.5 * m01 + -0.5 * m11 + m31
+];
+```
+
+With 4 transformed points we can build the left, right, top, and bottom values for the Rectangle. Each will use the minimum or the maximum of one of the components of all points.
+
+```js
+const left = Math.min(p[0], q[0], r[0], s[0]);
+const right = Math.max(p[0], q[0], r[0], s[0]);
+const top = Math.max(p[1], q[1], r[1], s[1]);
+const bottom = Math.min(p[1], q[1], r[1], s[1]);
+```
+
+Fill those calls with the vector expressions.
+
+```js
+const left = Math.min(
+    0.5 * m00 + 0.5 * m10 + m30,
+    -0.5 * m00 + 0.5 * m10 + m30,
+    -0.5 * m00 + -0.5 * m10 + m30,
+    0.5 * m00 + -0.5 * m10 + m30
+);
+const right = Math.max(
+    0.5 * m00 + 0.5 * m10 + m30,
+    -0.5 * m00 + 0.5 * m10 + m30,
+    -0.5 * m00 + -0.5 * m10 + m30,
+    0.5 * m00 + -0.5 * m10 + m30
+);
+const top = Math.max(
+    0.5 * m01 + 0.5 * m11 + m31,
+    -0.5 * m01 + 0.5 * m11 + m31,
+    -0.5 * m01 + -0.5 * m11 + m31,
+    0.5 * m01 + -0.5 * m11 + m31
+);
+const bottom = Math.min(
+    0.5 * m01 + 0.5 * m11 + m31,
+    -0.5 * m01 + 0.5 * m11 + m31,
+    -0.5 * m01 + -0.5 * m11 + m31,
+    0.5 * m01 + -0.5 * m11 + m31
+);
+```
+
+Pull out the `0.5 * m??` patterns.
+
+```js
+const x0 = 0.5 * m00;
+const x1 = 0.5 * m10;
+const y0 = 0.5 * m01;
+const y1 = 0.5 * m11;
+
+const left = Math.min(x0 + x1 + m30, -x0 + x1 + m30, -x0 + -x1 + m30, x0 + -x1 + m30);
+const right = Math.max(x0 + x1 + m30, -x0 + x1 + m30, -x0 + -x1 + m30, x0 + -x1 + m30);
+const top = Math.max(y0 + y1 + m31, -y0 + y1 + m31, -y0 + -y1 + m31, y0 + -y1 + m31);
+const bottom = Math.min(y0 + y1 + m31, -y0 + y1 + m31, -y0 + -y1 + m31, y0 + -y1 + m31);
+```
+
+Now each argument for the min and max calls take an expression like `(a * x0 + b * x1 + m3?)`. As each expression has the x0, x1, and m3? variables we can split the min and max calls on the addition operators. Each new call has all the coefficients of that variable.
+
+```js
+const left = Math.min(x0, -x0) + Math.min(x1, -x1) + Math.min(m30, m30);
+const right = Math.max(x0, -x0) + Math.max(x1, -x1) + Math.max(m30, m30);
+const top = Math.max(y0, -y0) + Math.max(y1, -y1) + Math.max(m31, m31);
+const bottom = Math.min(y0, -y0) + Math.min(y1, -y1) + Math.min(m31, m31);
+```
+
+The min or max of two copies of the same value will just be that value.
+
+```js
+const left = Math.min(x0, -x0) + Math.min(x1, -x1) + m30;
+const right = Math.max(x0, -x0) + Math.max(x1, -x1) + m30;
+const top = Math.max(y0, -y0) + Math.max(y1, -y1) + m31;
+const bottom = Math.min(y0, -y0) + Math.min(y1, -y1) + m31;
+```
+
+The max of a negative and positive variable will be the absolute value of that variable. The min of a negative and positive variable will the negated absolute value of that variable.
+
+```js
+const left = -Math.abs(x0) + -Math.abs(x1) + m30;
+const right = Math.abs(x0) + Math.abs(x1) + m30;
+const top = Math.abs(y0) + Math.abs(y1) + m31;
+const bottom = -Math.abs(y0) + -Math.abs(y1) + m31;
+```
+
+Pulling out the negations of the absolute values, left and right as well as top and bottom are the positive or negative sum of the absolute value of the saled and rotated unit value.
+
+```js
+const left = -(Math.abs(x0) + Math.abs(x1)) + m30;
+const right = Math.abs(x0) + Math.abs(x1) + m30;
+const top = Math.abs(y0) + Math.abs(y1) + m31;
+const bottom = -(Math.abs(y0) + Math.abs(y1)) + m31;
+```
+
+We call pull out those sums and use them twice.
+
+```js
+const x = Math.abs(x0) + Math.abs(x1);
+const y = Math.abs(y0) + Math.abs(y1);
+
+const left = -x + m30;
+const right = x + m30;
+const top = y + m31;
+const bottom = -y + m31;
+```
+
+This lets us arrive at our goal. Inlining some of our variables we get this block that will initialize a Rectangle to a unit square transformed by a matrix.
+
+```js
+const m30 = m[(3 * 4) + 0];
+const m31 = m[(3 * 4) + 1];
+
+const x = Math.abs(0.5 * m[(0 * 4) + 0]) + Math.abs(0.5 * m[(1 * 4) + 0]);
+const y = Math.abs(0.5 * m[(0 * 4) + 1]) + Math.abs(0.5 * m[(1 * 4) + 1]);
+
+const left = -x + m30;
+const right = x + m30;
+const top = y + m31;
+const bottom = -y + m31;
+```

--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -62,10 +62,11 @@ class BitmapSkin extends Skin {
     /**
      * Get the bounds of the drawable for determining its fenced position.
      * @param {Array<number>} drawable - The Drawable instance this skin is using.
+     * @param {?Rectangle} result - Optional destination for bounds calculation.
      * @return {!Rectangle} The drawable's bounds. For compatibility with Scratch 2, we always use getAABB for bitmaps.
      */
-    getFenceBounds (drawable) {
-        return drawable.getAABB();
+    getFenceBounds (drawable, result) {
+        return drawable.getAABB(result);
     }
 
     /**

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -451,9 +451,10 @@ class Drawable {
      * This function applies the transform matrix to the known convex hull,
      * and then finds the minimum box along the axes.
      * Before calling this, ensure the renderer has updated convex hull points.
+     * @param {?Rectangle} result optional destination for bounds calculation
      * @return {!Rectangle} Bounds for a tight box around the Drawable.
      */
-    getBounds (bounds) {
+    getBounds (result) {
         if (this.needsConvexHullPoints()) {
             throw new Error('Needs updated convex hull points before bounds calculation.');
         }
@@ -462,18 +463,19 @@ class Drawable {
         }
         const transformedHullPoints = this._getTransformedHullPoints();
         // Search through transformed points to generate box on axes.
-        bounds = bounds || new Rectangle();
-        bounds.initFromPointsAABB(transformedHullPoints);
-        return bounds;
+        result = result || new Rectangle();
+        result.initFromPointsAABB(transformedHullPoints);
+        return result;
     }
 
     /**
      * Get the precise bounds for the upper 8px slice of the Drawable.
      * Used for calculating where to position a text bubble.
      * Before calling this, ensure the renderer has updated convex hull points.
+     * @param {?Rectangle} result optional destination for bounds calculation
      * @return {!Rectangle} Bounds for a tight box around a slice of the Drawable.
      */
-    getBoundsForBubble (bounds) {
+    getBoundsForBubble (result) {
         if (this.needsConvexHullPoints()) {
             throw new Error('Needs updated convex hull points before bubble bounds calculation.');
         }
@@ -485,9 +487,9 @@ class Drawable {
         const maxY = Math.max.apply(null, transformedHullPoints.map(p => p[1]));
         const filteredHullPoints = transformedHullPoints.filter(p => p[1] > maxY - slice);
         // Search through filtered points to generate box on axes.
-        bounds = bounds || new Rectangle();
-        bounds.initFromPointsAABB(filteredHullPoints);
-        return bounds;
+        result = result || new Rectangle();
+        result.initFromPointsAABB(filteredHullPoints);
+        return result;
     }
 
     /**
@@ -497,30 +499,32 @@ class Drawable {
      * which is tightly snapped to account for a Drawable's transparent regions.
      * `getAABB` returns a much less accurate bounding box, but will be much
      * faster to calculate so may be desired for quick checks/optimizations.
+     * @param {?Rectangle} result optional destination for bounds calculation
      * @return {!Rectangle} Rough axis-aligned bounding box for Drawable.
      */
-    getAABB (bounds) {
+    getAABB (result) {
         if (this._transformDirty) {
             this._calculateTransform();
         }
         const tm = this._uniforms.u_modelMatrix;
-        bounds = bounds || new Rectangle();
-        bounds.initFromMatrixRadius(tm, 0.5);
-        return bounds;
+        result = result || new Rectangle();
+        result.initFromMatrixRadius(tm, 0.5);
+        return result;
     }
 
     /**
      * Return the best Drawable bounds possible without performing graphics queries.
      * I.e., returns the tight bounding box when the convex hull points are already
      * known, but otherwise return the rough AABB of the Drawable.
+     * @param {?Rectangle} result optional destination for bounds calculation
      * @return {!Rectangle} Bounds for the Drawable.
      */
-    getFastBounds (bounds) {
+    getFastBounds (result) {
         this.updateMatrix();
         if (!this.needsConvexHullPoints()) {
-            return this.getBounds(bounds);
+            return this.getBounds(result);
         }
-        return this.getAABB(bounds);
+        return this.getAABB(result);
     }
 
     /**

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -508,7 +508,7 @@ class Drawable {
         }
         const tm = this._uniforms.u_modelMatrix;
         result = result || new Rectangle();
-        result.initFromMatrixRadius(tm, 0.5);
+        result.initFromModelMatrix(tm);
         return result;
     }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -453,7 +453,7 @@ class Drawable {
      * Before calling this, ensure the renderer has updated convex hull points.
      * @return {!Rectangle} Bounds for a tight box around the Drawable.
      */
-    getBounds () {
+    getBounds (bounds) {
         if (this.needsConvexHullPoints()) {
             throw new Error('Needs updated convex hull points before bounds calculation.');
         }
@@ -462,7 +462,7 @@ class Drawable {
         }
         const transformedHullPoints = this._getTransformedHullPoints();
         // Search through transformed points to generate box on axes.
-        const bounds = new Rectangle();
+        bounds = bounds || new Rectangle();
         bounds.initFromPointsAABB(transformedHullPoints);
         return bounds;
     }
@@ -473,7 +473,7 @@ class Drawable {
      * Before calling this, ensure the renderer has updated convex hull points.
      * @return {!Rectangle} Bounds for a tight box around a slice of the Drawable.
      */
-    getBoundsForBubble () {
+    getBoundsForBubble (bounds) {
         if (this.needsConvexHullPoints()) {
             throw new Error('Needs updated convex hull points before bubble bounds calculation.');
         }
@@ -485,7 +485,7 @@ class Drawable {
         const maxY = Math.max.apply(null, transformedHullPoints.map(p => p[1]));
         const filteredHullPoints = transformedHullPoints.filter(p => p[1] > maxY - slice);
         // Search through filtered points to generate box on axes.
-        const bounds = new Rectangle();
+        bounds = bounds || new Rectangle();
         bounds.initFromPointsAABB(filteredHullPoints);
         return bounds;
     }
@@ -499,18 +499,13 @@ class Drawable {
      * faster to calculate so may be desired for quick checks/optimizations.
      * @return {!Rectangle} Rough axis-aligned bounding box for Drawable.
      */
-    getAABB () {
+    getAABB (bounds) {
         if (this._transformDirty) {
             this._calculateTransform();
         }
         const tm = this._uniforms.u_modelMatrix;
-        const bounds = new Rectangle();
-        bounds.initFromPointsAABB([
-            twgl.m4.transformPoint(tm, [-0.5, -0.5, 0]),
-            twgl.m4.transformPoint(tm, [0.5, -0.5, 0]),
-            twgl.m4.transformPoint(tm, [-0.5, 0.5, 0]),
-            twgl.m4.transformPoint(tm, [0.5, 0.5, 0])
-        ]);
+        bounds = bounds || new Rectangle();
+        bounds.initFromMatrixRadius(tm, 0.5);
         return bounds;
     }
 
@@ -520,12 +515,12 @@ class Drawable {
      * known, but otherwise return the rough AABB of the Drawable.
      * @return {!Rectangle} Bounds for the Drawable.
      */
-    getFastBounds () {
+    getFastBounds (bounds) {
         this.updateMatrix();
         if (!this.needsConvexHullPoints()) {
-            return this.getBounds();
+            return this.getBounds(bounds);
         }
-        return this.getAABB();
+        return this.getAABB(bounds);
     }
 
     /**

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -55,98 +55,24 @@ class Rectangle {
     }
 
     /**
-     * Initialize a Rectangle to a 1 unit square transformed by a model matrix.
+     * Initialize a Rectangle to a 1 unit square centered at 0 x 0 transformed
+     * by a model matrix.
      * @param {Array.<number>} m A 4x4 matrix to transform the rectangle by.
+     * @tutorial Rectangle-AABB-Matrix
      */
     initFromModelMatrix (m) {
-        // Treat this function like we are transforming a vector with each
-        // component set to 0.5 by a matrix m.
-        // const v0 = 0.5;
-        // const v1 = 0.5;
-        // const v2 = 0.5;
-
-        // Of the matrix to do this in 2D space, instead of the 3D provided by
-        // the matrix, we need the 2x2 "top left" that represents the scale and
-        // rotation ...
-        const m00 = m[(0 * 4) + 0];
-        const m01 = m[(0 * 4) + 1];
-        const m10 = m[(1 * 4) + 0];
-        const m11 = m[(1 * 4) + 1];
-        // ... and the 1x2 "top right" that represents position.
+        // In 2D space, we will soon use the 2x2 "top left" scale and rotation
+        // submatrix, while we store and the 1x2 "top right" that position
+        // vector.
         const m30 = m[(3 * 4) + 0];
         const m31 = m[(3 * 4) + 1];
 
-        // This is how we would normally transform the vector by the matrix.
-        // var determinant = v0 * m03 + v1 * m13 + v2 * m23 + m33;
-        // dst[0] = (v0 * m00 + v1 * m10 + v2 * m20 + m30) / determinant;
-        // dst[1] = (v0 * m01 + v1 * m11 + v2 * m21 + m31) / determinant;
-        // dst[2] = (v0 * m02 + v1 * m12 + v2 * m22 + m32) / determinant;
+        // "Transform" a (0.5, 0.5) vector by the scale and rotation matrix but
+        // sum the absolute of each component instead of use the signed values.
+        const x = Math.abs(0.5 * m[(0 * 4) + 0]) + Math.abs(0.5 * m[(1 * 4) + 0]);
+        const y = Math.abs(0.5 * m[(0 * 4) + 1]) + Math.abs(0.5 * m[(1 * 4) + 1]);
 
-        // We can skip the v2 multiplications and the determinant.
-
-        // Alternatively done with 4 vectors, those vectors would be reflected
-        // on the x and y axis. We can build those 4 vectors by transforming the
-        // parts of one vector and reflecting them on the axises after
-        // multiplication.
-
-        // const x0 = 0.5 * m00;
-        // const x1 = 0.5 * m10;
-        // const y0 = 0.5 * m01;
-        // const y1 = 0.5 * m11;
-
-        // const p0x = x0 + x1;
-        // const p0y = y0 + y1;
-        // const p1x = -x0 + x1;
-        // const p1y = -y0 + y1;
-        // const p2x = -x0 + -x1;
-        // const p2y = -y0 + -y1;
-        // const p3x = x0 + -x1;
-        // const p3y = y0 + -y1;
-
-        // Since we want to reduce those 4 points to a min and max for each
-        // axis, we can use those multiplied components to build the min and max
-        // values without comparing the points.
-
-        // We can start by getting the min and max for each of all the points.
-        // const left = Math.min(x0 + x1, -x0 + x1, -x0 + -x1, x0 + -x1);
-        // const right = Math.max(x0 + x1, -x0 + x1, -x0 + -x1, x0 + -x1);
-        // const top = Math.max(y0 + y1, -y0 + y1, -y0 + -y1, y0 + -y1);
-        // const bottom = Math.min(y0 + y1, -y0 + y1, -y0 + -y1, y0 + -y1);
-
-        // Each of those can be replaced with min and max operations on the 0
-        // and 1 matrix output components.
-        // const left = Math.min(x0, -x0) + Math.min(x1, -x1);
-        // const right = Math.max(x0, -x0) + Math.max(x1, -x1);
-        // const top = Math.max(y0, -y0) + Math.max(y1, -y1);
-        // const bottom = Math.min(y0, -y0) + Math.min(y1, -y1);
-
-        // And they can be replaced with absolute values.
-        // const left = -Math.abs(x0) + -Math.abs(x1);
-        // const right = Math.abs(x0) + Math.abs(x1);
-        // const top = Math.abs(y0) + Math.abs(y1);
-        // const bottom = -Math.abs(y0) + -Math.abs(y1);
-
-        // And those with positive and negative sums of the absolute values.
-        // const left = -(Math.abs(x0) + Math.abs(x1));
-        // const right = +(Math.abs(x0) + Math.abs(x1));
-        // const top = +(Math.abs(y0) + Math.abs(y1));
-        // const bottom = -(Math.abs(y0) + -Math.abs(y1));
-
-        // We can perform those sums once and reuse them for the bounds.
-        // const x = Math.abs(x0) + Math.abs(x1);
-        // const y = Math.abs(y0) + Math.abs(y1);
-        // const left = -x;
-        // const right = x;
-        // const top = y;
-        // const bottom = -y;
-
-        // Building those absolute sums for the 0.5 vector components by the
-        // matrix components ...
-        const x = Math.abs(0.5 * m00) + Math.abs(0.5 * m10);
-        const y = Math.abs(0.5 * m01) + Math.abs(0.5 * m11);
-
-        // And adding them to the position components in the matrices
-        // initializes our Rectangle.
+        // And adding them to the position components initializes our Rectangle.
         this.left = -x + m30;
         this.right = x + m30;
         this.top = y + m31;

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -54,6 +54,31 @@ class Rectangle {
         }
     }
 
+    initFromMatrixRadius (m, r) {
+        // const v0 = r;
+        // const v1 = r;
+        // const v2 = r;
+        const m00 = m[(0 * 4) + 0];
+        const m01 = m[(0 * 4) + 1];
+        const m10 = m[(1 * 4) + 0];
+        const m11 = m[(1 * 4) + 1];
+        const m30 = m[(3 * 4) + 0];
+        const m31 = m[(3 * 4) + 1];
+        // var d = v0 * m03 + v1 * m13 + v2 * m23 + m33;
+        // dst[0] = (
+        const x = Math.abs(r * m00) + Math.abs(r * m10);
+        // + v2 * m20 + m30) / d;
+        // dst[1] = (
+        const y = Math.abs(r * m01) + Math.abs(r * m11);
+        // + v2 * m21 + m31) / d;
+        // dst[2] = (v0 * m02 + v1 * m12 + v2 * m22 + m32) / d;
+
+        this.left = -x + m30;
+        this.right = x + m30;
+        this.top = y + m31;
+        this.bottom = -y + m31;
+    }
+
     /**
      * Determine if this Rectangle intersects some other.
      * Note that this is a comparison assuming the Rectangle was

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -54,25 +54,99 @@ class Rectangle {
         }
     }
 
-    initFromMatrixRadius (m, r) {
-        // const v0 = r;
-        // const v1 = r;
-        // const v2 = r;
+    /**
+     * Initialize a Rectangle to a 1 unit square transformed by a model matrix.
+     * @param {Array.<number>} m A 4x4 matrix to transform the rectangle by.
+     */
+    initFromModelMatrix (m) {
+        // Treat this function like we are transforming a vector with each
+        // component set to 0.5 by a matrix m.
+        // const v0 = 0.5;
+        // const v1 = 0.5;
+        // const v2 = 0.5;
+
+        // Of the matrix to do this in 2D space, instead of the 3D provided by
+        // the matrix, we need the 2x2 "top left" that represents the scale and
+        // rotation ...
         const m00 = m[(0 * 4) + 0];
         const m01 = m[(0 * 4) + 1];
         const m10 = m[(1 * 4) + 0];
         const m11 = m[(1 * 4) + 1];
+        // ... and the 1x2 "top right" that represents position.
         const m30 = m[(3 * 4) + 0];
         const m31 = m[(3 * 4) + 1];
-        // var d = v0 * m03 + v1 * m13 + v2 * m23 + m33;
-        // dst[0] = (
-        const x = Math.abs(r * m00) + Math.abs(r * m10);
-        // + v2 * m20 + m30) / d;
-        // dst[1] = (
-        const y = Math.abs(r * m01) + Math.abs(r * m11);
-        // + v2 * m21 + m31) / d;
-        // dst[2] = (v0 * m02 + v1 * m12 + v2 * m22 + m32) / d;
 
+        // This is how we would normally transform the vector by the matrix.
+        // var determinant = v0 * m03 + v1 * m13 + v2 * m23 + m33;
+        // dst[0] = (v0 * m00 + v1 * m10 + v2 * m20 + m30) / determinant;
+        // dst[1] = (v0 * m01 + v1 * m11 + v2 * m21 + m31) / determinant;
+        // dst[2] = (v0 * m02 + v1 * m12 + v2 * m22 + m32) / determinant;
+
+        // We can skip the v2 multiplications and the determinant.
+
+        // Alternatively done with 4 vectors, those vectors would be reflected
+        // on the x and y axis. We can build those 4 vectors by transforming the
+        // parts of one vector and reflecting them on the axises after
+        // multiplication.
+
+        // const x0 = 0.5 * m00;
+        // const x1 = 0.5 * m10;
+        // const y0 = 0.5 * m01;
+        // const y1 = 0.5 * m11;
+
+        // const p0x = x0 + x1;
+        // const p0y = y0 + y1;
+        // const p1x = -x0 + x1;
+        // const p1y = -y0 + y1;
+        // const p2x = -x0 + -x1;
+        // const p2y = -y0 + -y1;
+        // const p3x = x0 + -x1;
+        // const p3y = y0 + -y1;
+
+        // Since we want to reduce those 4 points to a min and max for each
+        // axis, we can use those multiplied components to build the min and max
+        // values without comparing the points.
+
+        // We can start by getting the min and max for each of all the points.
+        // const left = Math.min(x0 + x1, -x0 + x1, -x0 + -x1, x0 + -x1);
+        // const right = Math.max(x0 + x1, -x0 + x1, -x0 + -x1, x0 + -x1);
+        // const top = Math.max(y0 + y1, -y0 + y1, -y0 + -y1, y0 + -y1);
+        // const bottom = Math.min(y0 + y1, -y0 + y1, -y0 + -y1, y0 + -y1);
+
+        // Each of those can be replaced with min and max operations on the 0
+        // and 1 matrix output components.
+        // const left = Math.min(x0, -x0) + Math.min(x1, -x1);
+        // const right = Math.max(x0, -x0) + Math.max(x1, -x1);
+        // const top = Math.max(y0, -y0) + Math.max(y1, -y1);
+        // const bottom = Math.min(y0, -y0) + Math.min(y1, -y1);
+
+        // And they can be replaced with absolute values.
+        // const left = -Math.abs(x0) + -Math.abs(x1);
+        // const right = Math.abs(x0) + Math.abs(x1);
+        // const top = Math.abs(y0) + Math.abs(y1);
+        // const bottom = -Math.abs(y0) + -Math.abs(y1);
+
+        // And those with positive and negative sums of the absolute values.
+        // const left = -(Math.abs(x0) + Math.abs(x1));
+        // const right = +(Math.abs(x0) + Math.abs(x1));
+        // const top = +(Math.abs(y0) + Math.abs(y1));
+        // const bottom = -(Math.abs(y0) + -Math.abs(y1));
+
+        // We can perform those sums once and reuse them for the bounds.
+        // const x = Math.abs(x0) + Math.abs(x1);
+        // const y = Math.abs(y0) + Math.abs(y1);
+        // const left = -x;
+        // const right = x;
+        // const top = y;
+        // const bottom = -y;
+
+        // Building those absolute sums for the 0.5 vector components by the
+        // matrix components ...
+        const x = Math.abs(0.5 * m00) + Math.abs(0.5 * m10);
+        const y = Math.abs(0.5 * m01) + Math.abs(0.5 * m11);
+
+        // And adding them to the position components in the matrices
+        // initializes our Rectangle.
         this.left = -x + m30;
         this.right = x + m30;
         this.top = y + m31;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -16,6 +16,7 @@ const log = require('./util/log');
 
 const __isTouchingDrawablesPoint = twgl.v3.create();
 const __candidatesBounds = new Rectangle();
+const __fenceBounds = new Rectangle();
 const __touchingColor = new Uint8ClampedArray(4);
 const __blendColor = new Uint8ClampedArray(4);
 
@@ -1357,7 +1358,7 @@ class RenderWebGL extends EventEmitter {
 
         const dx = x - drawable._position[0];
         const dy = y - drawable._position[1];
-        const aabb = drawable._skin.getFenceBounds(drawable);
+        const aabb = drawable._skin.getFenceBounds(drawable, __fenceBounds);
         const inset = Math.floor(Math.min(aabb.width, aabb.height) / 2);
 
         const sx = this._xRight - Math.min(FENCE_WIDTH, inset);
@@ -1627,14 +1628,14 @@ class RenderWebGL extends EventEmitter {
             }
 
             twgl.setUniforms(currentShader, uniforms);
-            
+
             /* adjust blend function for this skin */
             if (drawable.skin.hasPremultipliedAlpha){
                 gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             } else {
                 gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             }
-            
+
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }
 

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -146,10 +146,11 @@ class Skin extends EventEmitter {
     /**
      * Get the bounds of the drawable for determining its fenced position.
      * @param {Array<number>} drawable - The Drawable instance this skin is using.
+     * @param {?Rectangle} result - Optional destination for bounds calculation.
      * @return {!Rectangle} The drawable's bounds.
      */
-    getFenceBounds (drawable, bounds) {
-        return drawable.getFastBounds(bounds);
+    getFenceBounds (drawable, result) {
+        return drawable.getFastBounds(result);
     }
 
     /**

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -148,8 +148,8 @@ class Skin extends EventEmitter {
      * @param {Array<number>} drawable - The Drawable instance this skin is using.
      * @return {!Rectangle} The drawable's bounds.
      */
-    getFenceBounds (drawable) {
-        return drawable.getFastBounds();
+    getFenceBounds (drawable, bounds) {
+        return drawable.getFastBounds(bounds);
     }
 
     /**


### PR DESCRIPTION
### Resolves

Render related VM performance, such as fencing a sprite inside the scratch canvas.

### Proposed Changes

- Initialize AABB Rectangle with a matrix and a radius
- Pass bounds as destination parameters to getBounds and like functions

### Reason for Changes

> - Initialize AABB Rectangle with a matrix and a radius

Current getAABB creates 4 3D vectors, transforms them by a 4x4 matrix and compares their axes to find the left, right, top, bottom extremes for the AABB. We can break that down into something like 2 function calls, 21 object member reads, 6 writes, 15 mulitplications, 13 additions, 2 created objects, and 5 comparisons per vectors. That is 64 operations per vector. Or 256 operations to construct the AABB.

This version by comparisons uses 6 object members reads, 6 multiplications, 6 additions, and 4 absolute value operations. In total that is 22 operations to construct the AABB.

The main cause in the difference in operations is that the current version transforms 4 vectors, and this version transform the 1 vector into the absolute value of its transformed components. Then the work is further reduced by contraining the transformation to 2 dimensions.

> - Pass bounds as destination parameters to getBounds and like functions

Passing a Rectangle to getBounds functions lets us reuse Rectangles to avoid creating lot of garbage that needs to be cleaned up. By chance we can't reuse a rectangle the functions can create their own to return.

### Test Coverage

The existing Drawable units that test getAABB.

### Benchmark Data

#### Chrome inspector

This table was collected from the Chrome Inspector's Javascript Profiler tab running the 14844969 benchmark. The values in this table are the percent of time spent under getFastBounds, which is used by SVGSkin to get the getFenceBounds to calculate the fence position when moving a sprite with motion_changex and other blocks. The values do not add up to 100 as many of the functions are nested in another.

|  function | before | after |
| --- | --- | --- |
|  Drawable.getFastBounds | 100.00% | 100.00% |
|  Drawable.getAABB | 53.12% | 0.00% |
|  twgl.m4.transformPoint | 50.47% | 0.00% |
|  twgl.m4.create | 22.87% | 0.00% |
|  Drawable.updateMatrix | 46.79% | 100.00% |
|  Drawable._calculateTransform | 17.11% | 61.47% |
|  twgl.m4.inverse | 14.74% | 32.47% |
|  twgl.m4.copy | 12.29% | 0.00% |

Some columns do not report any time spent. getAABB and copy are still being called, but time spent there was not captured by the profiler.

#### scratch-vm benchmark

The following values were collected the https://github.com/LLK/scratch-vm/pull/2196 change on scratch-vm.

<details>
<summary>Highlights</summary>

These highlighted benchmarks heavily use motion blocks that depend on the changed code.

**edit:** The before times in this table by accident do not reflect develop. This means the comparison has increased noise. I am leaving the table here for recording repurposes. This does not affect the chrome inspector table.

|  project id | vm initial state | device | before (bps) | after (bps) | difference | change |
| --- | --- | --- | ----: | ----: | ----: | ----: |
|  14844969 | warm up | chrome | 1822162 | 2053080 | 230918 | 12.67% |
|   |  | safari | 2208468 | 2426242 | 217774 | 9.86% |
|   |  | firefox | 1483425 | 1482271 | -1154 | -0.08% |
|   |  | chromebook | 388260 | 403689 | 15429 | 3.97% |
|   |  | ipad mini | 373459 | 387565 | 14106 | 3.78% |
|   |  | pi3b | 14287 | 14944 | 657 | 4.60% |
|   | ready | chrome | 2035920 | 2434038 | 398118 | 19.55% |
|   |  | safari | 2703129 | 2740529 | 37400 | 1.38% |
|   |  | firefox | 1548140 | 1673696 | 125556 | 8.11% |
|   |  | chromebook | 540785 | 553688 | 12903 | 2.39% |
|   |  | ipad mini | 689922 | 677317 | -12605 | -1.83% |
|   |  | pi3b | 69637 | 78292 | 8655 | 12.43% |
|  187694931 | warm up | chrome | 2331011 | 2422272 | 91261 | 3.92% |
|   |  | safari | 2921810 | 2874617 | -47193 | -1.62% |
|   |  | firefox | 1212903 | 1247634 | 34731 | 2.86% |
|   |  | chromebook | 273176 | 291418 | 18242 | 6.68% |
|   |  | ipad mini | 243227 | 294849 | 51622 | 21.22% |
|   | ready | chrome | 2386901 | 2487692 | 100791 | 4.22% |
|   |  | safari | 2972850 | 2940244 | -32606 | -1.10% |
|   |  | firefox | 1276710 | 1270102 | -6608 | -0.52% |
|   |  | chromebook | 306268 | 340126 | 33858 | 11.06% |
|   |  | ipad mini | 249506 | 333149 | 83643 | 33.52% |

</details>

<details>
<summary>Full Benchmark Suite</summary>

This is a table of the benchmarks with one run each for project id, vm state, device, before and after. As such the noise to signal ratio is high here, so there is a high margin of error in the amount performance changed. Most of the identifiable correlation is in the above highlights table.

**edit:** The before times in this table by accident do not reflect develop. This means the comparison has increased noise. I am leaving the table here for recording repurposes. This does not affect the chrome inspector table.

|  project id | vm initial state | device | before (bps) | after (bps) | difference | change |
| --- | --- | --- | ----: | ----: | ----: | ----: |
|  130041250 | warm up | chrome | 1399803 | 1419712 | 19909 | 1.42% |
|   |  | safari | 1732517 | 1690767 | -41750 | -2.41% |
|   |  | firefox | 1320150 | 1328215 | 8065 | 0.61% |
|   |  | chromebook | 218574 | 246146 | 27572 | 12.61% |
|   |  | ipad mini | 112293 | 112055 | -238 | -0.21% |
|   |  | pi3b | 3283 | 3540 | 257 | 7.83% |
|   | ready | chrome | 1717275 | 1836876 | 119601 | 6.96% |
|   |  | safari | 1900025 | 2350880 | 450855 | 23.73% |
|   |  | firefox | 1706225 | 1689923 | -16302 | -0.96% |
|   |  | chromebook | 431992 | 430162 | -1830 | -0.42% |
|   |  | ipad mini | 342573 | 353192 | 10619 | 3.10% |
|   |  | pi3b | 48458 | 43920 | -4538 | -9.36% |
|  14844969 | warm up | chrome | 1822162 | 2053080 | 230918 | 12.67% |
|   |  | safari | 2208468 | 2426242 | 217774 | 9.86% |
|   |  | firefox | 1483425 | 1482271 | -1154 | -0.08% |
|   |  | chromebook | 388260 | 403689 | 15429 | 3.97% |
|   |  | ipad mini | 373459 | 387565 | 14106 | 3.78% |
|   |  | pi3b | 14287 | 14944 | 657 | 4.60% |
|   | ready | chrome | 2035920 | 2434038 | 398118 | 19.55% |
|   |  | safari | 2703129 | 2740529 | 37400 | 1.38% |
|   |  | firefox | 1548140 | 1673696 | 125556 | 8.11% |
|   |  | chromebook | 540785 | 553688 | 12903 | 2.39% |
|   |  | ipad mini | 689922 | 677317 | -12605 | -1.83% |
|   |  | pi3b | 69637 | 78292 | 8655 | 12.43% |
|  173918262 | warm up | chrome | 1905545 | 1865995 | -39550 | -2.08% |
|   |  | safari | 1843594 | 1828518 | -15076 | -0.82% |
|   |  | firefox | 895659 | 911689 | 16030 | 1.79% |
|   |  | chromebook | 368340 | 358761 | -9579 | -2.60% |
|   |  | ipad mini | 161303 | 150228 | -11075 | -6.87% |
|   | ready | chrome | 1710787 | 1757966 | 47179 | 2.76% |
|   |  | safari | 1451462 | 1384875 | -66587 | -4.59% |
|   |  | firefox | 843498 | 849241 | 5743 | 0.68% |
|   |  | chromebook | 473729 | 468929 | -4800 | -1.01% |
|   |  | ipad mini | 212543 | 230708 | 18165 | 8.55% |
|  155128646 | warm up | chrome | 2206972 | 2319157 | 112185 | 5.08% |
|   |  | safari | 2477491 | 2508047 | 30556 | 1.23% |
|   |  | firefox | 927701 | 965063 | 37362 | 4.03% |
|   |  | chromebook | 235365 | 241038 | 5673 | 2.41% |
|   |  | ipad mini | 90149 | 89574 | -575 | -0.64% |
|   | ready | chrome | 857572 | 923222 | 65650 | 7.66% |
|   |  | safari | 777014 | 710031 | -66983 | -8.62% |
|   |  | firefox | 565102 | 589029 | 23927 | 4.23% |
|   |  | chromebook | 268654 | 274338 | 5684 | 2.12% |
|   |  | ipad mini | 125298 | 130533 | 5235 | 4.18% |
|  89811578 | warm up | chrome | 2505224 | 2358625 | -146599 | -5.85% |
|   |  | safari | 2692738 | 2792763 | 100025 | 3.71% |
|   |  | firefox | 1291667 | 1346687 | 55020 | 4.26% |
|   |  | chromebook | 649607 | 649992 | 385 | 0.06% |
|   |  | ipad mini | 768176 | 779387 | 11211 | 1.46% |
|   | ready | chrome | 2734624 | 2778133 | 43509 | 1.59% |
|   |  | safari | 2865553 | 2866529 | 976 | 0.03% |
|   |  | firefox | 1338340 | 1395615 | 57275 | 4.28% |
|   |  | chromebook | 747803 | 748825 | 1022 | 0.14% |
|   |  | ipad mini | 718363 | 763516 | 45153 | 6.29% |
|  139193539 | warm up | chrome | 2511984 | 2469733 | -42251 | -1.68% |
|   |  | safari | 3200181 | 3072939 | -127242 | -3.98% |
|   |  | firefox | 1950797 | 1984399 | 33602 | 1.72% |
|   |  | chromebook | 646954 | 622788 | -24166 | -3.74% |
|   |  | ipad mini | 455522 | 446547 | -8975 | -1.97% |
|   | ready | chrome | 2636520 | 2605132 | -31388 | -1.19% |
|   |  | safari | 3096980 | 3211043 | 114063 | 3.68% |
|   |  | firefox | 2116272 | 2031181 | -85091 | -4.02% |
|   |  | chromebook | 775236 | 739014 | -36222 | -4.67% |
|   |  | ipad mini | 670051 | 683807 | 13756 | 2.05% |
|  187694931 | warm up | chrome | 2331011 | 2422272 | 91261 | 3.92% |
|   |  | safari | 2921810 | 2874617 | -47193 | -1.62% |
|   |  | firefox | 1212903 | 1247634 | 34731 | 2.86% |
|   |  | chromebook | 273176 | 291418 | 18242 | 6.68% |
|   |  | ipad mini | 243227 | 294849 | 51622 | 21.22% |
|   | ready | chrome | 2386901 | 2487692 | 100791 | 4.22% |
|   |  | safari | 2972850 | 2940244 | -32606 | -1.10% |
|   |  | firefox | 1276710 | 1270102 | -6608 | -0.52% |
|   |  | chromebook | 306268 | 340126 | 33858 | 11.06% |
|   |  | ipad mini | 249506 | 333149 | 83643 | 33.52% |
|  219313833 | warm up | chrome | 182974 | 189544 | 6570 | 3.59% |
|   |  | safari | 120902 | 131059 | 10157 | 8.40% |
|   |  | firefox | 123623 | 123318 | -305 | -0.25% |
|   |  | chromebook | 33198 | 31862 | -1336 | -4.02% |
|   |  | ipad mini | 20226 | 21454 | 1228 | 6.07% |
|   | ready | chrome | 186524 | 195019 | 8495 | 4.55% |
|   |  | safari | 124610 | 121296 | -3314 | -2.66% |
|   |  | firefox | 129242 | 136102 | 6860 | 5.31% |
|   |  | chromebook | 35059 | 36306 | 1247 | 3.56% |
|   |  | ipad mini | 22227 | 23515 | 1288 | 5.79% |
|  236115215 | warm up | chrome | 5860 | 5798 | -62 | -1.06% |
|   |  | safari | 3795 | 3788 | -7 | -0.18% |
|   |  | firefox | 4712 | 4700 | -12 | -0.25% |
|   |  | chromebook | 1689 | 1705 | 16 | 0.95% |
|   |  | ipad mini | 1327 | 1514 | 187 | 14.09% |
|   | ready | chrome | 5994 | 5823 | -171 | -2.85% |
|   |  | safari | 3909 | 3957 | 48 | 1.23% |
|   |  | firefox | 4818 | 4873 | 55 | 1.14% |
|   |  | chromebook | 1656 | 1709 | 53 | 3.20% |
|   |  | ipad mini | 1633 | 1703 | 70 | 4.29% |
|  238750909 | warm up | chrome | 91077 | 91508 | 431 | 0.47% |
|   |  | safari | 79338 | 77245 | -2093 | -2.64% |
|   |  | firefox | 110566 | 122549 | 11983 | 10.84% |
|   |  | chromebook | 26546 | 24669 | -1877 | -7.07% |
|   |  | ipad mini | 9096 | 10238 | 1142 | 12.55% |
|   | ready | chrome | 95192 | 97301 | 2109 | 2.22% |
|   |  | safari | 76866 | 79563 | 2697 | 3.51% |
|   |  | firefox | 127337 | 130869 | 3532 | 2.77% |
|   |  | chromebook | 33367 | 34648 | 1281 | 3.84% |
|   |  | ipad mini | 7582 | 7626 | 44 | 0.58% |

</details>