### PR TITLE
Add update drawable methods for each property

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -184,55 +184,98 @@ class Drawable {
     }
 
     /**
+     * Update the position if it is different. Marks the transform as dirty.
+     * @param {Array.<number>} position A new position.
+     */
+    updatePosition (position) {
+        if (this._position[0] !== position[0] ||
+            this._position[1] !== position[1]) {
+            this._position[0] = Math.round(position[0]);
+            this._position[1] = Math.round(position[1]);
+            this.setTransformDirty();
+        }
+    }
+
+    /**
+     * Update the direction if it is different. Marks the transform as dirty.
+     * @param {number} direction A new direction.
+     */
+    updateDirection (direction) {
+        if (this._direction !== direction) {
+            this._direction = direction;
+            this._rotationTransformDirty = true;
+            this.setTransformDirty();
+        }
+    }
+
+    /**
+     * Update the scale if it is different. Marks the transform as dirty.
+     * @param {Array.<number>} scale A new scale.
+     */
+    updateScale (scale) {
+        if (this._scale[0] !== scale[0] ||
+            this._scale[1] !== scale[1]) {
+            this._scale[0] = scale[0];
+            this._scale[1] = scale[1];
+            this._rotationCenterDirty = true;
+            this._skinScaleDirty = true;
+            this.setTransformDirty();
+        }
+    }
+
+    /**
+     * Update visibility if it is different. Marks the convex hull as dirty.
+     * @param {boolean} visible A new visibility state.
+     */
+    updateVisible (visible) {
+        if (this._visible !== visible) {
+            this._visible = visible;
+            this.setConvexHullDirty();
+        }
+    }
+
+    /**
+     * Update an effect. Marks the convex hull as dirty if the effect changes shape.
+     * @param {string} effectName The name of the effect.
+     * @param {number} rawValue A new effect value.
+     */
+    updateEffect (effectName, rawValue) {
+        const effectInfo = ShaderManager.EFFECT_INFO[effectName];
+        if (rawValue) {
+            this._effectBits |= effectInfo.mask;
+        } else {
+            this._effectBits &= ~effectInfo.mask;
+        }
+        const converter = effectInfo.converter;
+        this._uniforms[effectInfo.uniformName] = converter(rawValue);
+        if (effectInfo.shapeChanges) {
+            this.setConvexHullDirty();
+        }
+    }
+
+    /**
      * Update the position, direction, scale, or effect properties of this Drawable.
+     * @deprecated Use specific update* methods instead.
      * @param {object.<string,*>} properties The new property values to set.
      */
     updateProperties (properties) {
-        let dirty = false;
-        if ('position' in properties && (
-            this._position[0] !== properties.position[0] ||
-            this._position[1] !== properties.position[1])) {
-            this._position[0] = Math.round(properties.position[0]);
-            this._position[1] = Math.round(properties.position[1]);
-            dirty = true;
+        if ('position' in properties) {
+            this.updatePosition(properties.position);
         }
-        if ('direction' in properties && this._direction !== properties.direction) {
-            this._direction = properties.direction;
-            this._rotationTransformDirty = true;
-            dirty = true;
+        if ('direction' in properties) {
+            this.updateDirection(properties.direction);
         }
-        if ('scale' in properties && (
-            this._scale[0] !== properties.scale[0] ||
-            this._scale[1] !== properties.scale[1])) {
-            this._scale[0] = properties.scale[0];
-            this._scale[1] = properties.scale[1];
-            this._rotationCenterDirty = true;
-            this._skinScaleDirty = true;
-            dirty = true;
+        if ('scale' in properties) {
+            this.updateScale(properties.scale);
         }
         if ('visible' in properties) {
-            this._visible = properties.visible;
-            this.setConvexHullDirty();
-        }
-        if (dirty) {
-            this.setTransformDirty();
+            this.updateVisible(properties.visible);
         }
         const numEffects = ShaderManager.EFFECTS.length;
         for (let index = 0; index < numEffects; ++index) {
             const effectName = ShaderManager.EFFECTS[index];
             if (effectName in properties) {
-                const rawValue = properties[effectName];
-                const effectInfo = ShaderManager.EFFECT_INFO[effectName];
-                if (rawValue) {
-                    this._effectBits |= effectInfo.mask;
-                } else {
-                    this._effectBits &= ~effectInfo.mask;
-                }
-                const converter = effectInfo.converter;
-                this._uniforms[effectInfo.uniformName] = converter(rawValue);
-                if (effectInfo.shapeChanges) {
-                    this.setConvexHullDirty();
-                }
+                this.updateEffect(effectName, properties[effectName]);
             }
         }
     }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1313,9 +1313,122 @@ class RenderWebGL extends EventEmitter {
         }, null);
     }
 
+    /**
+     * Update a drawable's skin.
+     * @param {number} drawableID The drawable's id.
+     * @param {number} skinId The skin to update to.
+     */
+    updateDrawableSkinId (drawableID, skinId) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.skin = this._allSkins[skinId];
+    }
+
+    /**
+     * Update a drawable's skin rotation center.
+     * @param {number} drawableID The drawable's id.
+     * @param {Array.<number>} rotationCenter The rotation center for the skin.
+     */
+    updateDrawableRotationCenter (drawableID, rotationCenter) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
+    }
+
+    /**
+     * Update a drawable's skin and rotation center together.
+     * @param {number} drawableID The drawable's id.
+     * @param {number} skinId The skin to update to.
+     * @param {Array.<number>} rotationCenter The rotation center for the skin.
+     */
+    updateDrawableSkinIdRotationCenter (drawableID, skinId, rotationCenter) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.skin = this._allSkins[skinId];
+        drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
+    }
+
+    /**
+     * Update a drawable's position.
+     * @param {number} drawableID The drawable's id.
+     * @param {Array.<number>} position The new position.
+     */
+    updateDrawablePosition (drawableID, position) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updatePosition(position);
+    }
+
+    /**
+     * Update a drawable's direction.
+     * @param {number} drawableID The drawable's id.
+     * @param {number} direction A new direction.
+     */
+    updateDrawableDirection (drawableID, direction) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updateDirection(direction);
+    }
+
+    /**
+     * Update a drawable's scale.
+     * @param {number} drawableID The drawable's id.
+     * @param {Array.<number>} scale A new scale.
+     */
+    updateDrawableScale (drawableID, scale) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updateScale(scale);
+    }
+
+    /**
+     * Update a drawable's direction and scale together.
+     * @param {number} drawableID The drawable's id.
+     * @param {number} direction A new direction.
+     * @param {Array.<number>} scale A new scale.
+     */
+    updateDrawableDirectionScale (drawableID, direction, scale) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updateDirection(direction);
+        drawable.updateScale(scale);
+    }
+
+    /**
+     * Update a drawable's visibility.
+     * @param {number} drawableID The drawable's id.
+     * @param {boolean} visible Will the drawable be visible?
+     */
+    updateDrawableVisible (drawableID, visible) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updateVisible(visible);
+    }
+
+    /**
+     * Update a drawable's visual effect.
+     * @param {number} drawableID The drawable's id.
+     * @param {string} effectName The effect to change.
+     * @param {number} value A new effect value.
+     */
+    updateDrawableEffect (drawableID, effectName, value) {
+        const drawable = this._allDrawables[drawableID];
+        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        if (!drawable) return;
+        drawable.updateEffect(effectName, value);
+    }
 
     /**
      * Update the position, direction, scale, or effect properties of this Drawable.
+     * @deprecated Use specific updateDrawable* methods instead.
      * @param {int} drawableID The ID of the Drawable to update.
      * @param {object.<string,*>} properties The new property values to set.
      */
@@ -1329,11 +1442,10 @@ class RenderWebGL extends EventEmitter {
             return;
         }
         if ('skinId' in properties) {
-            drawable.skin = this._allSkins[properties.skinId];
+            this.updateDrawableSkinId(drawableID, properties.skinId);
         }
         if ('rotationCenter' in properties) {
-            const newRotationCenter = properties.rotationCenter;
-            drawable.skin.setRotationCenter(newRotationCenter[0], newRotationCenter[1]);
+            this.updateDrawableRotationCenter(drawableID, properties.rotationCenter);
         }
         drawable.updateProperties(properties);
     }
@@ -1627,14 +1739,14 @@ class RenderWebGL extends EventEmitter {
             }
 
             twgl.setUniforms(currentShader, uniforms);
-            
+
             /* adjust blend function for this skin */
             if (drawable.skin.hasPremultipliedAlpha){
                 gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             } else {
                 gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             }
-            
+
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1320,7 +1320,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableSkinId (drawableID, skinId) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.skin = this._allSkins[skinId];
     }
@@ -1332,7 +1332,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableRotationCenter (drawableID, rotationCenter) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
     }
@@ -1345,7 +1345,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableSkinIdRotationCenter (drawableID, skinId, rotationCenter) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.skin = this._allSkins[skinId];
         drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
@@ -1358,7 +1358,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawablePosition (drawableID, position) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updatePosition(position);
     }
@@ -1370,7 +1370,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableDirection (drawableID, direction) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updateDirection(direction);
     }
@@ -1382,7 +1382,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableScale (drawableID, scale) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updateScale(scale);
     }
@@ -1395,7 +1395,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableDirectionScale (drawableID, direction, scale) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updateDirection(direction);
         drawable.updateScale(scale);
@@ -1408,7 +1408,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableVisible (drawableID, visible) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updateVisible(visible);
     }
@@ -1421,7 +1421,7 @@ class RenderWebGL extends EventEmitter {
      */
     updateDrawableEffect (drawableID, effectName, value) {
         const drawable = this._allDrawables[drawableID];
-        // TODO: vm's requests to drawableID that do not have a Drawable object.
+        // TODO: https://github.com/LLK/scratch-vm/issues/2288
         if (!drawable) return;
         drawable.updateEffect(effectName, value);
     }
@@ -1436,7 +1436,7 @@ class RenderWebGL extends EventEmitter {
         const drawable = this._allDrawables[drawableID];
         if (!drawable) {
             /**
-             * @todo fix whatever's wrong in the VM which causes this, then add a warning or throw here.
+             * @todo(https://github.com/LLK/scratch-vm/issues/2288) fix whatever's wrong in the VM which causes this, then add a warning or throw here.
              * Right now this happens so much on some projects that a warning or exception here can hang the browser.
              */
             return;
@@ -1462,7 +1462,7 @@ class RenderWebGL extends EventEmitter {
 
         const drawable = this._allDrawables[drawableID];
         if (!drawable) {
-            // TODO: fix whatever's wrong in the VM which causes this, then add a warning or throw here.
+            // @todo(https://github.com/LLK/scratch-vm/issues/2288) fix whatever's wrong in the VM which causes this, then add a warning or throw here.
             // Right now this happens so much on some projects that a warning or exception here can hang the browser.
             return [x, y];
         }


### PR DESCRIPTION
### Resolves

Make VM and Render faster.

### Proposed Changes

- Add an update method for RenderWebGL and Drawable for each Drawable Property.
- Deprecate RenderWebGL.updateDrawableProperties and Drawable.updateProperties.

### Reason for Changes

> - Add an update method for RenderWebGL and Drawable for each Drawable Property.

The current updateDrawableProperties and updateProperties spend more time looking for what the changes are in the given properties than actually making changes to Drawable.

This is because most updateDrawableProperties calls from RenderedTarget change 1 or 2 properties. So of the 13 properties (6 base properties and 7 effect properties) 1 or 2 change. The remaining 12 or 11 checks for if something is in properties are false.

If we use an active api in place of the current passive api, we can inform renderer with Drawable changes much faster.

> - Deprecate RenderWebGL.updateDrawableProperties and Drawable.updateProperties.

I think it may be best to deprecate existing methods to use one common path for changing drawable values. An additional benefit of this will be decreasing our temporary objects. Each update call currently creates at least one object. We can at a minimum decrease that by one.

### Test Coverage

There does not currently seem to be a clear path to test these changes. RenderWebGL does not have a unit testing environment.

I could create new integration scratch file tests. Direction on this would be greatly appreciated.

### Benchmark Data

I've opted to include % of function time results from chrome inspector for 14844969 and 130041250. These motion block heavy projects provide a good way to see the relative performance inside these functions.

<details>
<summary>14844969</summary>

|  14844969 changeX | before | after |
| ---- | ---: | ---: |
|  RenderedTarget.setXY | 100.00% | 100.00% |
|  RenderWebGL.getFencedPositionOfDrawable | 61.71% | 81.41% |
|  EventEmitter.emit | 6.90% | 7.41% |
|  RenderWebGL.updateDrawableProperties | 23.27% | 0.00% |
|  Drawable.updateProperties | 22.73% | 0.00% |
|  RenderWebGL.updateDrawablePosition | 0.00% | 1.52% |
|  Drawable.updatePosition | 0.00% | 1.52% |

changeX changes the x position of a sprite. This version does not include the other changes that will improve getFencedPosition. Using the new position calls releases a lot of time to be instead spent in getFencedPosition.

|  14844969 switchCostume | before | after |
| ---- | ---: | ---: |
|  RenderedTarget.setCostume | 100.00% | 100.00% |
|  RenderWebGL.updateDrawableProperties | 86.17% | 0.00% |
|  Drawable.updateProperties | 26.78% | 0.00% |
|  RenderWebGL.updateDrawableSkinIdRotationCenter | 0.00% | 94.68% |
|  SVGSkin.setRotationCenter | 10.66% | 23.62% |
|  Drawable.set skin | 38.32% | 61.49% |
|  events.emit | 2.54% | 2.34% |

Changing skins is a unique case with the update calls. Relative to the other update calls changing the skin and rotation center do a lot more work. This will be improved separately from this change.

This table also illustrates well the time spent in updateProperties not performing any changes for skin changes. switchCostume doesn't modify effects, position, direction, scale or visibility. So that time is spent just checking if blocks and looping over the effects.

</details>

<details>
<summary>130041250</summary>

|  130041250 moveSteps | before | after |
| --- | ---: | ---: |
|  RenderedTarget.setXY | 100.00% | 100.00% |
|  RenderWebGL.getFencedPositionOfDrawable | 68.16% | 82.28% |
|  events.emit | 3.02% | 3.47% |
|  RenderWebGL.updateDrawableProperties | 17.76% | 0.00% |
|  Drawable.updateProperties | 17.50% | 0.00% |

Like the changeX in the other project, the time is able to shift to time in getFenced. The improvement was to the point that the profiler did not sample any calls in the new function.

|  130041250 turnLeft | before | after |
| --- | ---: | ---: |
|  RenderedTarget.setDirection | 100.00% | 100.00% |
|  events.emit | 9.26% | 50.35% |
|  RenderWebGL.updateDrawableProperties | 90.62% | 0.00% |
|  Drawable.updateProperties | 89.45% | 0.00% |

Since turnLeft and setDirection do not need to check the fenced position, this call goes from almost all time spent in update calls to no time.

An additional thread is clear here like switchCostume, there is spent in some work emitting events from RenderedTarget, that we can improve in a later PR.

</details>
