### PR TITLE
Skin alter push

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -23,6 +23,12 @@ class BitmapSkin extends Skin {
 
         /** @type {Array<int>} */
         this._textureSize = [0, 0];
+
+        /**
+         * The "native" size, in texels, of this skin.
+         * @type {Array<number>}
+         */
+        this.size = [0, 0];
     }
 
     /**
@@ -41,13 +47,6 @@ class BitmapSkin extends Skin {
      */
     get isRaster () {
         return true;
-    }
-
-    /**
-     * @return {Array<number>} the "native" size, in texels, of this skin.
-     */
-    get size () {
-        return [this._textureSize[0] / this._costumeResolution, this._textureSize[1] / this._costumeResolution];
     }
 
     /**
@@ -109,6 +108,7 @@ class BitmapSkin extends Skin {
         // Do these last in case any of the above throws an exception
         this._costumeResolution = costumeResolution || 2;
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
+        this.size = [this._textureSize[0] / this._costumeResolution, this._textureSize[1] / this._costumeResolution];
 
         if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
         this.setRotationCenter.apply(this, rotationCenter);

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -3,7 +3,6 @@ const twgl = require('twgl.js');
 const Rectangle = require('./Rectangle');
 const RenderConstants = require('./RenderConstants');
 const ShaderManager = require('./ShaderManager');
-const Skin = require('./Skin');
 const EffectTransform = require('./EffectTransform');
 
 /**
@@ -101,8 +100,6 @@ class Drawable {
         /** @todo move convex hull functionality, maybe bounds functionality overall, to Skin classes */
         this._convexHullPoints = null;
         this._convexHullDirty = true;
-
-        this._skinWasAltered = this._skinWasAltered.bind(this);
     }
 
     /**
@@ -141,13 +138,7 @@ class Drawable {
      */
     set skin (newSkin) {
         if (this._skin !== newSkin) {
-            if (this._skin) {
-                this._skin.removeListener(Skin.Events.WasAltered, this._skinWasAltered);
-            }
             this._skin = newSkin;
-            if (this._skin) {
-                this._skin.addListener(Skin.Events.WasAltered, this._skinWasAltered);
-            }
             this._skinWasAltered();
         }
     }

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -88,6 +88,9 @@ class PenSkin extends Skin {
         /** @type {HTMLCanvasElement} */
         this._canvas = document.createElement('canvas');
 
+        /** @type {Array<number>} */
+        this._canvasSize = twgl.v3.create();
+
         /** @type {WebGLTexture} */
         this._texture = null;
 
@@ -165,7 +168,7 @@ class PenSkin extends Skin {
      * @return {Array<number>} the "native" size, in texels, of this skin. [width, height]
      */
     get size () {
-        return [this._canvas.width, this._canvas.height];
+        return this._canvasSize;
     }
 
     /**
@@ -188,13 +191,13 @@ class PenSkin extends Skin {
     clear () {
         const gl = this._renderer.gl;
         twgl.bindFramebufferInfo(gl, this._framebuffer);
-        
+
         /* Reset framebuffer to transparent black */
         gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         const ctx = this._canvas.getContext('2d');
-        ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
+        ctx.clearRect(0, 0, this._canvasSize[0], this._canvasSize[1]);
 
         this._silhouetteDirty = true;
     }
@@ -451,7 +454,7 @@ class PenSkin extends Skin {
      * @param {number} x - centered at x
      * @param {number} y - centered at y
      */
-    _drawRectangle (currentShader, texture, bounds, x = -this._canvas.width / 2, y = this._canvas.height / 2) {
+    _drawRectangle (currentShader, texture, bounds, x = -this._canvasSize[0] / 2, y = this._canvasSize[1] / 2) {
         const gl = this._renderer.gl;
 
         const projection = twgl.m4.ortho(
@@ -514,7 +517,7 @@ class PenSkin extends Skin {
      * @param {number} x - texture centered at x
      * @param {number} y - texture centered at y
      */
-    _drawToBuffer (texture = this._texture, x = -this._canvas.width / 2, y = this._canvas.height / 2) {
+    _drawToBuffer (texture = this._texture, x = -this._canvasSize[0] / 2, y = this._canvasSize[1] / 2) {
         if (texture !== this._texture && this._canvasDirty) {
             this._drawToBuffer();
         }
@@ -528,7 +531,7 @@ class PenSkin extends Skin {
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._canvas);
 
             const ctx = this._canvas.getContext('2d');
-            ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
+            ctx.clearRect(0, 0, this._canvasSize[0], this._canvasSize[1]);
 
             this._canvasDirty = false;
         }
@@ -564,8 +567,8 @@ class PenSkin extends Skin {
         this._bounds = new Rectangle();
         this._bounds.initFromBounds(width / 2, width / -2, height / 2, height / -2);
 
-        this._canvas.width = width;
-        this._canvas.height = height;
+        this._canvas.width = this._canvasSize[0] = width;
+        this._canvas.height = this._canvasSize[1] = height;
         this._rotationCenter[0] = width / 2;
         this._rotationCenter[1] = height / 2;
 
@@ -651,8 +654,8 @@ class PenSkin extends Skin {
             this._renderer.enterDrawRegion(this._toBufferDrawRegionId);
 
             // Sample the framebuffer's pixels into the silhouette instance
-            const skinPixels = new Uint8Array(Math.floor(this._canvas.width * this._canvas.height * 4));
-            gl.readPixels(0, 0, this._canvas.width, this._canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, skinPixels);
+            const skinPixels = new Uint8Array(Math.floor(this._canvasSize[0] * this._canvasSize[1] * 4));
+            gl.readPixels(0, 0, this._canvasSize[0], this._canvasSize[1], gl.RGBA, gl.UNSIGNED_BYTE, skinPixels);
 
             const skinCanvas = this._canvas;
             skinCanvas.width = bounds.width;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events');
 const hull = require('hull.js');
 const twgl = require('twgl.js');
 
+const Skin = require('./Skin');
 const BitmapSkin = require('./BitmapSkin');
 const Drawable = require('./Drawable');
 const Rectangle = require('./Rectangle');
@@ -291,6 +292,20 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
+     * Notify Drawables whose skin is the skin that changed.
+     * @param {Skin} skin - the skin that changed.
+     * @private
+     */
+    _skinWasAltered (skin) {
+        for (let i = 0; i < this._allDrawables.length; i++) {
+            const drawable = this._allDrawables[i];
+            if (drawable && drawable._skin === skin) {
+                drawable._skinWasAltered();
+            }
+        }
+    }
+
+    /**
      * Create a new bitmap skin from a snapshot of the provided bitmap data.
      * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} bitmapData - new contents for this skin.
      * @param {!int} [costumeResolution=1] - The resolution to use for this bitmap.
@@ -302,6 +317,7 @@ class RenderWebGL extends EventEmitter {
         const skinId = this._nextSkinId++;
         const newSkin = new BitmapSkin(skinId, this);
         newSkin.setBitmap(bitmapData, costumeResolution, rotationCenter);
+        newSkin.addListener(Skin.Events.WasAltered, this._skinWasAltered.bind(this, newSkin));
         this._allSkins[skinId] = newSkin;
         return skinId;
     }
@@ -317,6 +333,7 @@ class RenderWebGL extends EventEmitter {
         const skinId = this._nextSkinId++;
         const newSkin = new SVGSkin(skinId, this);
         newSkin.setSVG(svgData, rotationCenter);
+        newSkin.addListener(Skin.Events.WasAltered, this._skinWasAltered.bind(this, newSkin));
         this._allSkins[skinId] = newSkin;
         return skinId;
     }
@@ -328,6 +345,7 @@ class RenderWebGL extends EventEmitter {
     createPenSkin () {
         const skinId = this._nextSkinId++;
         const newSkin = new PenSkin(skinId, this);
+        newSkin.addListener(Skin.Events.WasAltered, this._skinWasAltered.bind(this, newSkin));
         this._allSkins[skinId] = newSkin;
         return skinId;
     }
@@ -344,6 +362,7 @@ class RenderWebGL extends EventEmitter {
         const skinId = this._nextSkinId++;
         const newSkin = new TextBubbleSkin(skinId, this);
         newSkin.setTextBubble(type, text, pointsLeft);
+        newSkin.addListener(Skin.Events.WasAltered, this._skinWasAltered.bind(this, newSkin));
         this._allSkins[skinId] = newSkin;
         return skinId;
     }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -30,6 +30,24 @@ class SVGSkin extends Skin {
 
         /** @type {Number} */
         this._maxTextureScale = 0;
+
+        /**
+         * The natural size, in Scratch units, of this skin.
+         * @type {Array<number>}
+         */
+        this.size = [0, 0];
+
+        /**
+         * The viewbox offset of the svg.
+         * @type {Array<number>}
+         */
+        this._viewOffset = [0, 0];
+
+        /**
+         * The rotation center before offset by _viewOffset.
+         * @type {Array<number>}
+         */
+        this._rawRotationCenter = [NaN, NaN];
     }
 
     /**
@@ -44,20 +62,16 @@ class SVGSkin extends Skin {
     }
 
     /**
-     * @return {Array<number>} the natural size, in Scratch units, of this skin.
-     */
-    get size () {
-        return this._svgRenderer.size;
-    }
-
-    /**
      * Set the origin, in object space, about which this Skin should rotate.
      * @param {number} x - The x coordinate of the new rotation center.
      * @param {number} y - The y coordinate of the new rotation center.
      */
     setRotationCenter (x, y) {
-        const viewOffset = this._svgRenderer.viewOffset;
-        super.setRotationCenter(x - viewOffset[0], y - viewOffset[1]);
+        if (x !== this._rawRotationCenter[0] || y !== this._rawRotationCenter[1]) {
+            this._rawRotationCenter[0] = x;
+            this._rawRotationCenter[1] = y;
+            super.setRotationCenter(x - this._viewOffset[0], y - this._viewOffset[1]);
+        }
     }
 
     /**
@@ -134,7 +148,11 @@ class SVGSkin extends Skin {
             }
 
             if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
-            this.setRotationCenter.apply(this, rotationCenter);
+            this.size = this._svgRenderer.size;
+            this._viewOffset = this._svgRenderer.viewOffset;
+            // Reset rawRotationCenter when we update viewOffset.
+            this._rawRotationCenter = [NaN, NaN];
+            this.setRotationCenter(rotationCenter[0], rotationCenter[1]);
             this.emit(Skin.Events.WasAltered);
         });
     }

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -34,6 +34,13 @@ class Skin extends EventEmitter {
         this._rotationCenter = twgl.v3.create(0, 0);
 
         /**
+         * The "native" size, in texels, of this skin.
+         * @member size
+         * @abstract
+         * @type {Array<number>}
+         */
+
+        /**
          * The uniforms to be used by the vertex and pixel shaders.
          * Some of these are used by other parts of the renderer as well.
          * @type {Object.<string,*>}
@@ -95,14 +102,6 @@ class Skin extends EventEmitter {
      */
     get rotationCenter () {
         return this._rotationCenter;
-    }
-
-    /**
-     * @abstract
-     * @return {Array<number>} the "native" size, in texels, of this skin.
-     */
-    get size () {
-        return [0, 0];
     }
 
     /**

--- a/test/fixtures/MockSkinPool.js
+++ b/test/fixtures/MockSkinPool.js
@@ -1,0 +1,35 @@
+const Skin = require('../../src/Skin');
+
+class MockSkinPool {
+    constructor () {
+        this._allDrawables = [];
+    }
+
+    static forDrawableSkin (drawable) {
+        const pool = new MockSkinPool();
+        pool.addDrawable(drawable);
+        pool.addSkin(drawable.skin);
+        return pool;
+    }
+
+    _skinWasAltered (skin) {
+        for (let i = 0; i < this._allDrawables.length; i++) {
+            const drawable = this._allDrawables[i];
+            if (drawable && drawable._skin === skin) {
+                drawable._skinWasAltered();
+            }
+        }
+    }
+
+    addDrawable (drawable) {
+        this._allDrawables.push(drawable);
+        return drawable;
+    }
+
+    addSkin (skin) {
+        skin.addListener(Skin.Events.WasAltered, this._skinWasAltered.bind(this, skin));
+        return skin;
+    }
+}
+
+module.exports = MockSkinPool;

--- a/test/unit/DrawableTests.js
+++ b/test/unit/DrawableTests.js
@@ -8,6 +8,7 @@ global.document = {
 
 const Drawable = require('../../src/Drawable');
 const MockSkin = require('../fixtures/MockSkin');
+const MockSkinPool = require('../fixtures/MockSkinPool');
 const Rectangle = require('../../src/Rectangle');
 
 /**
@@ -31,6 +32,7 @@ test('translate by position', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
+    MockSkinPool.forDrawableSkin(drawable);
 
     expected.initFromBounds(0, 200, -50, 0);
     t.same(snapToNearest(drawable.getAABB()), expected);
@@ -47,6 +49,7 @@ test('translate by costume center', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
+    MockSkinPool.forDrawableSkin(drawable);
 
     drawable.skin.setRotationCenter(1, 0);
     expected.initFromBounds(-1, 199, -50, 0);
@@ -64,6 +67,7 @@ test('translate and rotate', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
+    MockSkinPool.forDrawableSkin(drawable);
 
     drawable.updateProperties({position: [1, 2], direction: 0});
     expected.initFromBounds(1, 51, 2, 202);
@@ -90,6 +94,7 @@ test('rotate by non-right-angles', t => {
     drawable.skin = new MockSkin();
     drawable.skin.size = [10, 10];
     drawable.skin.setRotationCenter(5, 5);
+    MockSkinPool.forDrawableSkin(drawable);
 
     expected.initFromBounds(-5, 5, -5, 5);
     t.same(snapToNearest(drawable.getAABB()), expected);
@@ -106,6 +111,7 @@ test('scale', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
+    MockSkinPool.forDrawableSkin(drawable);
 
     drawable.updateProperties({scale: [100, 50]});
     expected.initFromBounds(0, 200, -25, 0);
@@ -128,6 +134,7 @@ test('rotate and scale', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [100, 1000];
+    MockSkinPool.forDrawableSkin(drawable);
 
     drawable.skin.setRotationCenter(50, 50);
     expected.initFromBounds(-50, 50, -950, 50);


### PR DESCRIPTION
### Resolves

Make switching costumes for lots of clones faster.

### Proposed Changes

- Remove skin altered listeners from Drawable.
- Add skin altered listener to RenderWebGL.
- Push skin alterations down to Drawables currently set to a skin from RenderWebGL.
- Replace skin size getter with a property.
- Cache viewOffset in SVGSkin.
- Check rotation center given to SVGSkin before calling parent.

### Reason for Changes

> - Remove skin altered listeners from Drawable.

This is very expensive for Clones sharing a skin with many other skins. The Drawable's listener has to be found in the list of listeners to remove it.

> - Add skin altered listener to RenderWebGL.

Adding a listener is cheaper than removing, but adding means we need to later remove.

> - Push skin alterations down to Drawables currently set to a skin from RenderWebGL.

Changes made by the GUI cause skin alterations. So skin alterations should not happen when a project is fullscreen or player only. And in the case they do happen, they happen at the rate the user can make changes instead of the rate the vm can instruct the costume to switch.

Given that "event design" that will support both these uses, fast switching, and user alterations, might be to push those alterations down to the Drawable from the RenderWebGL instance.

> - Replace skin size getter with a property.

`size` is used a lot. One use is determining if the rotation center changed in Skin.setRotationCenter. Size only changes when setBitmap, setSVG, or other Skin altering events occur. We can cache the value to decrease time spent creating the size array and later collecting its garbage.

> - Cache viewOffset in SVGSkin.

`viewOffset` is a dynamically created object in SVGRenderer. We use it enough and it only changes when the SVG changes that caching it will help in setRotationCenter performance.

> - Check rotation center given to SVGSkin before calling parent.

SVGSkin.setRotationCenter calls its parent Skin.setRotationCenter. This parent prototype lookup is ending up as a expensive cost to update the rotation center. This adds a check on the value for SVGSkin to avoid that most of the time.

### Benchmark Data

Here is a percent total time table from chrome's profiler, measuring total time over the total time of changeX in 14844969. 14844969 heavily switches costumes for a large number of clones.

| 14844969 switchCostume / changeX | before | after |
| --- | ----: | ----: |
|  scratch3_motion.changeX | 100.00% | 100.00% |
|  scratch3_looks.switchCostume | 25.14% | 9.73% |
|  scratch3_looks._setCostume | 22.92% | 7.86% |
|  rendered-target.setCostume | 21.31% | 7.64% |
|  RenderWebGL.updateDrawableProperties | 17.08% | 6.47% |
|  Drawable.updateProperties | 4.40% | 4.59% |
|  SVGSkin.setRotationCenter | 2.91% | 0.00% |
|  Skin.setRotationCenter | 0.49% | 0.00% |
|  svg-renderer.get viewOffset | 0.15% | 0.00% |
|  Drawable.set skin | 6.76% | 0.00% |
|  events.removeListener | 5.34% | 0.00% |
|  events.addListener | 0.75% | 0.00% |

The change in updateDrawableProperties is what we want to see with this change. The remaining time spent switching costumes is function overhead and improved by the updateDrawable* PR.
