### PR TITLE
Set PenSkin silhouette data directly

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -109,6 +109,12 @@ class PenSkin extends Skin {
         /** @type {boolean} */
         this._silhouetteDirty = false;
 
+        /** @type {Uint8Array} */
+        this._silhouettePixels = null;
+
+        /** @type {ImageData} */
+        this._silhouetteImageData = null;
+
         /** @type {object} */
         this._lineOnBufferDrawRegionId = {
             enter: () => this._enterDrawLineOnBuffer(),
@@ -597,6 +603,9 @@ class PenSkin extends Skin {
         gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
+        this._silhouettePixels = new Uint8Array(Math.floor(width * height * 4));
+        this._silhouetteImageData = this._canvas.getContext('2d').createImageData(width, height);
+
         this._silhouetteDirty = true;
     }
 
@@ -634,24 +643,17 @@ class PenSkin extends Skin {
             // Render export texture to another framebuffer
             const gl = this._renderer.gl;
 
-            const bounds = this._bounds;
-
             this._renderer.enterDrawRegion(this._toBufferDrawRegionId);
 
             // Sample the framebuffer's pixels into the silhouette instance
-            const skinPixels = new Uint8Array(Math.floor(this._canvas.width * this._canvas.height * 4));
-            gl.readPixels(0, 0, this._canvas.width, this._canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, skinPixels);
+            gl.readPixels(
+                0, 0,
+                this._canvas.width, this._canvas.height,
+                gl.RGBA, gl.UNSIGNED_BYTE, this._silhouettePixels
+            );
 
-            const skinCanvas = this._canvas;
-            skinCanvas.width = bounds.width;
-            skinCanvas.height = bounds.height;
-
-            const skinContext = skinCanvas.getContext('2d');
-            const skinImageData = skinContext.createImageData(bounds.width, bounds.height);
-            skinImageData.data.set(skinPixels);
-            skinContext.putImageData(skinImageData, 0, 0);
-
-            this._silhouette.update(this._canvas, true /* isPremultiplied */);
+            this._silhouetteImageData.data.set(this._silhouettePixels);
+            this._silhouette.update(this._silhouetteImageData, true /* isPremultiplied */);
 
             this._silhouetteDirty = false;
         }


### PR DESCRIPTION
### Proposed Changes

- Pre-allocate `ImageData` and an array for `gl.readPixels` for `PenSkin`s.
- Set `PenSkin`'s `Silhouette` directly from the skin's `ImageData`.

### Reason for Changes

The previous texture > silhouette pipeline for `PenSkin` was:
1. `gl.readPixels` of the `PenSkin`'s framebuffer into a newly created `Uint8Array`.
2. Create a new `ImageData` object from the array.
3. Draw the `ImageData` to the `PenSkin`'s canvas.
4. Pass the canvas to the `Silhouette`, which:
5. Draws the passed canvas to its own canvas, then
6. Reads its canvas' `ImageData` and stores it.

The new pipeline is:
1. `gl.readPixels`  of the `PenSkin`'s framebuffer into a previously allocated `Uint8Array`.
2. Read the array into a previously created `ImageData` object.
3. Pass the `ImageData` to the `Silhouette`, which uses it directly.

By only creating a new array and `ImageData` object when the `PenSkin`'s canvas size is changed, and passing the `Silhouette` the `ImageData` directly, we can greatly improve the speed of silhouette updates as shown in [this benchmark](https://scratch.mit.edu/projects/320184338/):

| Latest `develop` | This PR |
|-|-|
|![image](https://user-images.githubusercontent.com/25993062/60829555-1fee2800-a183-11e9-8b03-e0614ccbb120.png)|![image](https://user-images.githubusercontent.com/25993062/60830439-38f7d880-a185-11e9-998c-b47ca19749b0.png)|

