### PR TITLE
Don't updateSilhouette() for drawables when on touching color GPU path

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -719,11 +719,11 @@ class RenderWebGL extends EventEmitter {
         return skin.calculateRotationCenter();
     }
 
-    /** 
+    /**
      * Update the Silhouettes for every Drawable in the given array of candidates.
      * @param {Array< {id, drawable, intersection} >} candidates The Drawable candidates to update the Silhouettes of.
      */
-    _updateSilhouettesForCandidates(candidates) {
+    _updateSilhouettesForCandidates (candidates) {
         for (const candidate of candidates) {
             candidate.drawable.skin.updateSilhouette();
         }


### PR DESCRIPTION
### Proposed Changes

This PR removes the `Drawable.Skin.updateSilhouette` calls from `_touchingBounds()` and `_candidatesTouching()`, moving them to code paths that actually require the silhouettes to be updated. In particular, the GPU path for `RenderWebGL.isTouchingColor()` no longer calls `updateSilhouette`, as it does not operate using `Silhouette`s.

### Reason for Changes

These changes improve performance for "touching color" queries on the GPU path when the pen layer is rapidly being updated, as in [this benchmark](320224368):

|Current|This PR|
|-|-|
|![image](https://user-images.githubusercontent.com/25993062/60851031-b50f1200-a1bf-11e9-9a0e-766509d6cf40.png)|![image](https://user-images.githubusercontent.com/25993062/60851032-b6d8d580-a1bf-11e9-8aef-2eac4cd0664e.png)|


In addition, and arguably more importantly, they make the code more explicit-- the necessary step of updating silhouettes is no longer hidden in bounding box calculation code.
