### PR TITLE
Fix useNearest() to take renderer scale into account, take two

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -420,6 +420,7 @@ class Drawable {
     /**
      * Should the drawable use NEAREST NEIGHBOR or LINEAR INTERPOLATION mode
      * @param {?Array<Number>} scale Optionally, the screen-space scale of the drawable.
+     * @return {boolean} True if the drawable should use nearest-neighbor interpolation.
      */
     useNearest (scale = this.scale) {
         // Raster skins (bitmaps) should always prefer nearest neighbor

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -409,7 +409,9 @@ class Drawable {
 
         const localPosition = getLocalPosition(this, vec);
 
-        if (this.useNearest) {
+        // We're not passing in a scale to useNearest, but that's okay because "touching" queries
+        // happen at the "native" size anyway.
+        if (this.useNearest()) {
             return this.skin.isTouchingNearest(localPosition);
         }
         return this.skin.isTouchingLinear(localPosition);
@@ -417,8 +419,9 @@ class Drawable {
 
     /**
      * Should the drawable use NEAREST NEIGHBOR or LINEAR INTERPOLATION mode
+     * @param {?Array<Number>} scale Optionally, the screen-space scale of the drawable.
      */
-    get useNearest () {
+    useNearest (scale = this.scale) {
         // Raster skins (bitmaps) should always prefer nearest neighbor
         if (this.skin.isRaster) {
             return true;
@@ -430,8 +433,8 @@ class Drawable {
         }
 
         // If the scale of the skin is very close to 100 (0.99999 variance is okay I guess)
-        if (Math.abs(this.scale[0]) > 99 && Math.abs(this.scale[0]) < 101 &&
-            Math.abs(this.scale[1]) > 99 && Math.abs(this.scale[1]) < 101) {
+        if (Math.abs(scale[0]) > 99 && Math.abs(scale[0]) < 101 &&
+            Math.abs(scale[1]) > 99 && Math.abs(scale[1]) < 101) {
             return true;
         }
         return false;
@@ -624,7 +627,7 @@ class Drawable {
         }
         const textColor =
         // commenting out to only use nearest for now
-        // drawable.useNearest ?
+        // drawable.useNearest() ?
              drawable.skin._silhouette.colorAtNearest(localPosition, dst);
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
         return EffectTransform.transformColor(drawable, textColor, textColor);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1642,7 +1642,7 @@ class RenderWebGL extends EventEmitter {
 
             if (uniforms.u_skin) {
                 twgl.setTextureParameters(
-                    gl, uniforms.u_skin, {minMag: drawable.useNearest ? gl.NEAREST : gl.LINEAR}
+                    gl, uniforms.u_skin, {minMag: drawable.useNearest(drawableScale) ? gl.NEAREST : gl.LINEAR}
                 );
             }
 


### PR DESCRIPTION
### Resolves

Resolves #334, resolves #437

### Proposed Changes

This change replaces the `Drawable`'s `useNearest` getter with a function that takes, optionally, its `Drawable`'s screen-space scale as input.

### Reason for Changes

The old code assumes that the `Drawable`'s `scale` attribute is the scale that it will actually be rendered at. If the stage is scaled up (as full-screen mode does) or down (as small-stage mode does), this assumption is rendered false, but `useNearest` will happily tell the renderer to use nearest-neighbor scaling anyway, producing ugly jaggies.

The new code takes into account the actual target scale of the drawable, preventing jaggies.