### PR TITLE
Return early from EffectTransform methods if no effect bits are set

### DIFF
--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -123,6 +123,10 @@ class EffectTransform {
      * @returns {Uint8ClampedArray} dst filled with the transformed color
      */
     static transformColor (drawable, color4b, dst, effectMask) {
+        const effects = drawable.getEnabledEffects() & effectMask;
+        // If no effects are enabled, don't get anything, create anything, or set anything; just give back the input.
+        if (effects === 0) return color4b;
+
         dst = dst || new Uint8ClampedArray(4);
         effectMask = effectMask || 0xffffffff;
         dst.set(color4b);
@@ -131,7 +135,6 @@ class EffectTransform {
         }
 
         const uniforms = drawable.getUniforms();
-        const effects = drawable.getEnabledEffects() & effectMask;
 
         if ((effects & ShaderManager.EFFECT_INFO.ghost.mask) !== 0) {
             // gl_FragColor.a *= u_ghost
@@ -187,11 +190,13 @@ class EffectTransform {
      * @return {twgl.v3} dst - The coordinate after being transform by effects.
      */
     static transformPoint (drawable, vec, dst = twgl.v3.create()) {
+        const effects = drawable.getEnabledEffects();
+        // If no effects are enabled, don't get anything, create anything, or set anything; just give back the input.
+        if (effects === 0) return vec;
+
         twgl.v3.copy(vec, dst);
 
         const uniforms = drawable.getUniforms();
-        const effects = drawable.getEnabledEffects();
-
         if ((effects & ShaderManager.EFFECT_INFO.mosaic.mask) !== 0) {
             // texcoord0 = fract(u_mosaic * texcoord0);
             dst[0] = uniforms.u_mosaic * dst[0] % 1;

--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -123,14 +123,14 @@ class EffectTransform {
      * @returns {Uint8ClampedArray} dst filled with the transformed color
      */
     static transformColor (drawable, color4b, dst, effectMask) {
+        effectMask = effectMask || 0xffffffff;
         const effects = drawable.getEnabledEffects() & effectMask;
-        // If no effects are enabled, don't get anything, create anything, or set anything; just give back the input.
-        if (effects === 0) return color4b;
 
         dst = dst || new Uint8ClampedArray(4);
-        effectMask = effectMask || 0xffffffff;
+        
         dst.set(color4b);
-        if (dst[3] === 0) {
+        // If no effects are enabled, or the color is fully transparent, don't bother attempting any transformations.
+        if (effects === 0 || dst[3] === 0) {
             return dst;
         }
 
@@ -191,10 +191,9 @@ class EffectTransform {
      */
     static transformPoint (drawable, vec, dst = twgl.v3.create()) {
         const effects = drawable.getEnabledEffects();
-        // If no effects are enabled, don't get anything, create anything, or set anything; just give back the input.
-        if (effects === 0) return vec;
-
         twgl.v3.copy(vec, dst);
+        // If no effects are enabled, don't bother attempting any transformations.
+        if (effects === 0) return dst;
 
         const uniforms = drawable.getUniforms();
         if ((effects & ShaderManager.EFFECT_INFO.mosaic.mask) !== 0) {


### PR DESCRIPTION
### Proposed Changes

This PR changes `EffectTransform`'s `transformColor` and `transformPoint` methods to check if any effect bits are set, and if not, return their inputs before doing anything else (e.g. getting uniforms, copying the input to the output).

### Reason for Changes

These functions are called inside tight loops, and optimizing them in this way appears to yield a ~25-30% performance improvement on "touching color" checks, according to [this benchmark](https://scratch.mit.edu/projects/320660090/):

| Current | This PR |
|-|-|
|![image](https://user-images.githubusercontent.com/25993062/61103259-450ebf00-a43f-11e9-8ad7-7791f8cf9266.png)|![image](https://user-images.githubusercontent.com/25993062/61103268-4b04a000-a43f-11e9-96ae-6bdb9bec9287.png)


