### PR TITLE
Attach V2 adapters in CPU render playground

### DIFF
--- a/test/integration/cpu-render.html
+++ b/test/integration/cpu-render.html
@@ -1,6 +1,7 @@
 <body>
     <script src="../../node_modules/scratch-vm/dist/web/scratch-vm.js"></script>
     <script src="../../node_modules/scratch-storage/dist/web/scratch-storage.js"></script>
+    <script src="../../node_modules/scratch-svg-renderer/dist/web/scratch-svg-renderer.js"></script>
     <!-- note: this uses the BUILT version of scratch-render!  make sure to npm run build -->
     <script src="../../dist/web/scratch-render.js"></script>
 
@@ -21,6 +22,8 @@
 
         vm.attachStorage(storage);
         vm.attachRenderer(render);
+        vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
+        vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
         document.getElementById('file').addEventListener('click', e => {
             document.body.removeChild(document.getElementById('loaded'));


### PR DESCRIPTION
### Resolves

Resolves #483

### Proposed Changes

This PR attaches adapters for V2 SVGs and bitmap images to the VM in `test/integration/cpu-render.html`.

### Reason for Changes

The VM will not run properly without a V2 bitmap adapter. While the V2 SVG adapter is not strictly necessary, it mirrors the main integration test setup.