### PR TITLE
Optimize effect transforms

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -695,7 +695,7 @@ class Drawable {
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
 
         if (drawable.enabledEffects === 0) return textColor;
-        return EffectTransform.transformColor(drawable, textColor, textColor);
+        return EffectTransform.transformColor(drawable, textColor);
     }
 }
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -36,8 +36,12 @@ const getLocalPosition = (drawable, vec) => {
     // localPosition matches that transformation.
     localPosition[0] = 0.5 - (((v0 * m[0]) + (v1 * m[4]) + m[12]) / d);
     localPosition[1] = (((v0 * m[1]) + (v1 * m[5]) + m[13]) / d) + 0.5;
-    // Apply texture effect transform if the localPosition is within the drawable's space.
-    if ((localPosition[0] >= 0 && localPosition[0] < 1) && (localPosition[1] >= 0 && localPosition[1] < 1)) {
+    // Apply texture effect transform if the localPosition is within the drawable's space,
+    // and any effects are currently active.
+    if (drawable.enabledEffects !== 0 &&
+        (localPosition[0] >= 0 && localPosition[0] < 1) &&
+        (localPosition[1] >= 0 && localPosition[1] < 1)) {
+
         EffectTransform.transformPoint(drawable, localPosition, localPosition);
     }
     return localPosition;
@@ -96,7 +100,11 @@ class Drawable {
         this._inverseMatrix = twgl.m4.identity();
         this._inverseTransformDirty = true;
         this._visible = true;
-        this._effectBits = 0;
+
+        /** A bitmask identifying which effects are currently in use.
+         * @readonly
+         * @type {int} */
+        this.enabledEffects = 0;
 
         /** @todo move convex hull functionality, maybe bounds functionality overall, to Skin classes */
         this._convexHullPoints = null;
@@ -157,13 +165,6 @@ class Drawable {
      */
     get scale () {
         return [this._scale[0], this._scale[1]];
-    }
-
-    /**
-     * @returns {int} A bitmask identifying which effects are currently in use.
-     */
-    getEnabledEffects () {
-        return this._effectBits;
     }
 
     /**
@@ -242,9 +243,9 @@ class Drawable {
     updateEffect (effectName, rawValue) {
         const effectInfo = ShaderManager.EFFECT_INFO[effectName];
         if (rawValue) {
-            this._effectBits |= effectInfo.mask;
+            this.enabledEffects |= effectInfo.mask;
         } else {
-            this._effectBits &= ~effectInfo.mask;
+            this.enabledEffects &= ~effectInfo.mask;
         }
         const converter = effectInfo.converter;
         this._uniforms[effectInfo.uniformName] = converter(rawValue);
@@ -481,7 +482,7 @@ class Drawable {
         }
 
         // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
-        if ((this._effectBits & (
+        if ((this.enabledEffects & (
             ShaderManager.EFFECT_INFO.fisheye.mask |
             ShaderManager.EFFECT_INFO.whirl.mask |
             ShaderManager.EFFECT_INFO.pixelate.mask |
@@ -692,6 +693,8 @@ class Drawable {
         // drawable.useNearest() ?
              drawable.skin._silhouette.colorAtNearest(localPosition, dst);
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
+
+        if (drawable.enabledEffects === 0) return textColor;
         return EffectTransform.transformColor(drawable, textColor, textColor);
     }
 }

--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -123,15 +123,17 @@ class EffectTransform {
      * @returns {Uint8ClampedArray} dst filled with the transformed color
      */
     static transformColor (drawable, color4b, dst, effectMask) {
-        dst = dst || new Uint8ClampedArray(4);
-        effectMask = effectMask || 0xffffffff;
+        if (typeof effectMask === 'undefined') effectMask = 0xffffffff;
+        if (typeof dst === 'undefined') dst = new Uint8ClampedArray(4);
+        
         dst.set(color4b);
+        // If the color is fully transparent, don't bother attempting any transformations.
         if (dst[3] === 0) {
             return dst;
         }
 
+        const effects = drawable.enabledEffects & effectMask;
         const uniforms = drawable.getUniforms();
-        const effects = drawable.getEnabledEffects() & effectMask;
 
         if ((effects & ShaderManager.EFFECT_INFO.ghost.mask) !== 0) {
             // gl_FragColor.a *= u_ghost
@@ -186,12 +188,12 @@ class EffectTransform {
      * @param {?twgl.v3} dst A place to store the output coordinate.
      * @return {twgl.v3} dst - The coordinate after being transform by effects.
      */
-    static transformPoint (drawable, vec, dst = twgl.v3.create()) {
+    static transformPoint (drawable, vec, dst) {
+        if (typeof dst === 'undefined') dst = twgl.v3.create();
         twgl.v3.copy(vec, dst);
 
+        const effects = drawable.enabledEffects;
         const uniforms = drawable.getUniforms();
-        const effects = drawable.getEnabledEffects();
-
         if ((effects & ShaderManager.EFFECT_INFO.mosaic.mask) !== 0) {
             // texcoord0 = fract(u_mosaic * texcoord0);
             dst[0] = uniforms.u_mosaic * dst[0] % 1;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1701,7 +1701,7 @@ class RenderWebGL extends EventEmitter {
 
             const uniforms = {};
 
-            let effectBits = drawable.getEnabledEffects();
+            let effectBits = drawable.enabledEffects;
             effectBits &= opts.hasOwnProperty('effectMask') ? opts.effectMask : effectBits;
             const newShader = this._shaderManager.getShader(drawMode, effectBits);
 


### PR DESCRIPTION
### Proposed Changes

- Replace `Drawable.getEnabledEffects()` function with `Drawable.enabledEffects`
- Only apply effect transform in `Drawable.getLocalPosition` and `Drawable.sampleColor4b` if drawable effects are enabled
- Replace `possiblyDefinedArgument || defaultValue` pattern with `if (typeof possiblyDefinedArgument === 'undefined') possiblyDefinedArgument = defaultValue` in `EffectTransform` methods


### Reason for Changes

- Replace `Drawable.getEnabledEffects()` function with `Drawable.enabledEffects`
  - The `EffectTransform.transform[Color/Point]` methods, called once per pixel in touching tests, get a Drawable's enabled effects. Replacing the pseudo-getter function with a property speeds it up.
- Only apply effect transform in `Drawable.getLocalPosition` and `Drawable.sampleColor4b` if drawable effects are enabled
  - This is what I did in #481, but taken one step back to the functions that *call* the effect transform methods in question. This alone provides a bigger performance boost than #481.
- Replace `possiblyDefinedArgument || defaultValue` pattern with `if (typeof possiblyDefinedArgument === 'undefined') possiblyDefinedArgument = defaultValue` in `EffectTransform` methods
  - This provides a small performance boost, possibly by removing the "truthy/falsy cast".

This gives a ~40% performance improvement to "touching color" checks on drawables with no effects enabled, and a ~15% performance improvement to ones with effects enabled, as seen in [this benchmark](https://scratch.mit.edu/projects/321498300/):

Current | This PR
-|-
![image](https://user-images.githubusercontent.com/25993062/61490203-63624680-a97a-11e9-870f-e7bebed35817.png) | ![image](https://user-images.githubusercontent.com/25993062/61490220-6d844500-a97a-11e9-8d34-ea9e9b6cf73e.png)
