### PR TITLE
Fix calculateRotationCenter() for SVG skins

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -147,8 +147,9 @@ class SVGSkin extends Skin {
                 this._maxTextureScale = testScale;
             }
 
-            if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
             this.size = this._svgRenderer.size;
+            if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
+
             this._viewOffset = this._svgRenderer.viewOffset;
             // Reset rawRotationCenter when we update viewOffset.
             this._rawRotationCenter = [NaN, NaN];


### PR DESCRIPTION
### Proposed Change

This PR changes `SVGSkin.setSVG` to calculate the skin's rotation center after setting `skin.size`.

### Reason for Changes

#470 changed `skin.size` from a getter to a property, but set the `size` property in `SVGSkin` after calculating the rotation center, which requires `size` to be properly set. This resulted in `SVGSkin`s' rotation centers being improperly calculated.
