### PR TITLE
penStamp() directly to the PenSkin's framebuffer

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1464,6 +1464,7 @@ class RenderWebGL extends EventEmitter {
 
         // Draw the stamped sprite onto the PenSkin's framebuffer.
         this._drawThese([stampID], ShaderManager.DRAW_MODE.stamp, projection, {ignoreVisibility: true});
+        skin._silhouetteDirty = true;
     }
 
     /* ******

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1454,7 +1454,12 @@ class RenderWebGL extends EventEmitter {
         twgl.bindFramebufferInfo(gl, skin._framebuffer);
 
         // Limit size of viewport to the bounds around the stamp Drawable and create the projection matrix for the draw.
-        gl.viewport(240 + bounds.left, 180 - bounds.top, bounds.width, bounds.height);
+        gl.viewport(
+            (this._nativeSize[0] * 0.5) + bounds.left,
+            (this._nativeSize[1] * 0.5) - bounds.top,
+            bounds.width,
+            bounds.height
+        );
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
 
         // Draw the stamped sprite onto the PenSkin's framebuffer.

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1451,23 +1451,14 @@ class RenderWebGL extends EventEmitter {
         const skin = /** @type {PenSkin} */ this._allSkins[penSkinID];
 
         const gl = this._gl;
-        twgl.bindFramebufferInfo(gl, this._queryBufferInfo);
+        twgl.bindFramebufferInfo(gl, skin._framebuffer);
 
         // Limit size of viewport to the bounds around the stamp Drawable and create the projection matrix for the draw.
-        gl.viewport(0, 0, bounds.width, bounds.height);
+        gl.viewport(240 + bounds.left, 180 - bounds.top, bounds.width, bounds.height);
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
 
-        gl.clearColor(0, 0, 0, 0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-
-        try {
-            gl.disable(gl.BLEND);
-            this._drawThese([stampID], ShaderManager.DRAW_MODE.stamp, projection, {ignoreVisibility: true});
-        } finally {
-            gl.enable(gl.BLEND);
-        }
-
-        skin._drawToBuffer(this._queryBufferInfo.attachments[0], bounds.left, bounds.top);
+        // Draw the stamped sprite onto the PenSkin's framebuffer.
+        this._drawThese([stampID], ShaderManager.DRAW_MODE.stamp, projection, {ignoreVisibility: true});
     }
 
     /* ******


### PR DESCRIPTION
### Proposed Changes

This PR changes `RenderWebGL.penStamp` to draw directly to the `PenSkin`'s framebuffer, instead of drawing to the query buffer then drawing the query buffer to the `PenSkin`'s framebuffer as it currently does.

### Reason for Changes

This improves pen stamp performance by ~2.5-3x, according to [this benchmark](https://scratch.mit.edu/projects/322227433/):

Current | This PR
-|-
![image](https://user-images.githubusercontent.com/25993062/61873165-41555080-aeb3-11e9-9aca-7d51b1380ad6.png) | ![image](https://user-images.githubusercontent.com/25993062/61873167-45816e00-aeb3-11e9-8089-cd210c342ee5.png)
