### PR TITLE
Remove u_fudge

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -335,8 +335,7 @@ class PenSkin extends Skin {
 
         const uniforms = {
             u_skin: this._texture,
-            u_projectionMatrix: projection,
-            u_fudge: 0
+            u_projectionMatrix: projection
         };
 
         twgl.setUniforms(currentShader, uniforms);
@@ -477,8 +476,7 @@ class PenSkin extends Skin {
                     0
                 ), __modelScalingMatrix),
                 __modelMatrix
-            ),
-            u_fudge: 0
+            )
         };
 
         twgl.setTextureParameters(gl, texture, {minMag: gl.NEAREST});

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1626,8 +1626,7 @@ class RenderWebGL extends EventEmitter {
                 gl.useProgram(currentShader.program);
                 twgl.setBuffersAndAttributes(gl, currentShader, this._bufferInfo);
                 Object.assign(uniforms, {
-                    u_projectionMatrix: projection,
-                    u_fudge: window.fudge || 0
+                    u_projectionMatrix: projection
                 });
             }
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -1,7 +1,5 @@
 precision mediump float;
 
-uniform float u_fudge;
-
 #ifdef DRAW_MODE_silhouette
 uniform vec4 u_silhouetteColor;
 #else // DRAW_MODE_silhouette


### PR DESCRIPTION
### Proposed Changes

This PR removes the `u_fudge` uniform from the GLSL code and all renderer code that sets uniforms.

### Reason for Changes

`u_fudge` was first used in the testing playground as a way to debug effects. By hooking it up to a slider, it could control an arbitrary shader component--this was useful for testing the shaders.

Now, the "fudge" slider in the playground does not control `u_fudge`, but can instead set many other properties of the playground's test drawable, including every effect.

Every call to `gl.uniform[*]` adds a small performance cost, so we want to avoid setting unnecessary uniforms.