### PR TITLE
Turn off antialias

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -104,7 +104,7 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     static _getContext (canvas) {
-        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true});
+        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true , antialias: false});
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -104,7 +104,7 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     static _getContext (canvas) {
-        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true , antialias: false});
+        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true, antialias: false});
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-render/issues/500

Also, antialias isn't supported on all browsers, so this should make behavior more consistent. The downside is that vectors will have pixely edges, especially on lower density devices