### PR TITLE
Add safeGetImageData util function to handle empty image data. 

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -2,6 +2,8 @@ const twgl = require('twgl.js');
 
 const Skin = require('./Skin');
 
+const safeGetImageData = require('./util/safe-get-image-data');
+
 class BitmapSkin extends Skin {
     /**
      * Create a new Bitmap Skin.
@@ -88,7 +90,7 @@ class BitmapSkin extends Skin {
             // Given a HTMLCanvasElement get the image data to pass to webgl and
             // Silhouette.
             const context = bitmapData.getContext('2d');
-            textureData = context.getImageData(0, 0, bitmapData.width, bitmapData.height);
+            textureData = safeGetImageData(context, bitmapData.width, bitmapData.height);
         }
 
         if (this._texture) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -13,6 +13,7 @@ const SVGSkin = require('./SVGSkin');
 const TextBubbleSkin = require('./TextBubbleSkin');
 const EffectTransform = require('./EffectTransform');
 const log = require('./util/log');
+const safeGetImageData = require('./util/safe-get-image-data');
 
 const __isTouchingDrawablesPoint = twgl.v3.create();
 const __candidatesBounds = new Rectangle();
@@ -861,7 +862,7 @@ class RenderWebGL extends EventEmitter {
             this._debugCanvas.width = bounds.width;
             this._debugCanvas.height = bounds.height;
             const context = this._debugCanvas.getContext('2d');
-            const imageData = context.getImageData(0, 0, bounds.width, bounds.height - stop);
+            const imageData = safeGetImageData(context, bounds.width, bounds.height - stop);
             imageData.data.set(pixels);
             context.putImageData(imageData, 0, 0);
         }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -3,6 +3,8 @@ const twgl = require('twgl.js');
 const Skin = require('./Skin');
 const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
 
+const safeGetImageData = require('./util/safe-get-image-data');
+
 const MAX_TEXTURE_DIMENSION = 2048;
 
 class SVGSkin extends Skin {
@@ -79,7 +81,8 @@ class SVGSkin extends Skin {
                 if (this._textureScale === newScale) {
                     const canvas = this._svgRenderer.canvas;
                     const context = canvas.getContext('2d');
-                    const textureData = context.getImageData(0, 0, canvas.width, canvas.height);
+                    const textureData = safeGetImageData(context, canvas.width, canvas.height);
+
 
                     const gl = this._renderer.gl;
                     gl.bindTexture(gl.TEXTURE_2D, this._texture);
@@ -109,7 +112,7 @@ class SVGSkin extends Skin {
             // regards to memory.
             const canvas = this._svgRenderer.canvas;
             const context = canvas.getContext('2d');
-            const textureData = context.getImageData(0, 0, canvas.width, canvas.height);
+            const textureData = safeGetImageData(context, canvas.width, canvas.height);
 
             if (this._texture) {
                 gl.bindTexture(gl.TEXTURE_2D, this._texture);

--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -4,6 +4,8 @@
  * renders a pixel where it is drawn.
  */
 
+const safeGetImageData = require('./util/safe-get-image-data');
+
 /**
  * <canvas> element used to update Silhouette data from skin bitmap data.
  * @type {CanvasElement}
@@ -106,7 +108,7 @@ class Silhouette {
             }
             ctx.clearRect(0, 0, width, height);
             ctx.drawImage(bitmapData, 0, 0, width, height);
-            imageData = ctx.getImageData(0, 0, width, height);
+            imageData = safeGetImageData(ctx, width, height);
         }
 
         this._colorData = imageData.data;

--- a/src/TextBubbleSkin.js
+++ b/src/TextBubbleSkin.js
@@ -3,6 +3,7 @@ const twgl = require('twgl.js');
 const TextWrapper = require('./util/text-wrapper');
 const CanvasMeasurementProvider = require('./util/canvas-measurement-provider');
 const Skin = require('./Skin');
+const safeGetImageData = require('./util/safe-get-image-data');
 
 const BubbleStyle = {
     MAX_LINE_WIDTH: 170, // Maximum width, in Scratch pixels, of a single line of text
@@ -261,7 +262,7 @@ class TextBubbleSkin extends Skin {
             this._textureDirty = false;
 
             const context = this._canvas.getContext('2d');
-            const textureData = context.getImageData(0, 0, this._canvas.width, this._canvas.height);
+            const textureData = safeGetImageData(context, this._canvas.width, this._canvas.height);
 
             const gl = this._renderer.gl;
 

--- a/src/util/safe-get-image-data.js
+++ b/src/util/safe-get-image-data.js
@@ -1,0 +1,16 @@
+/**
+ * Given a CanvasRenderingContext2D, and values for width and height
+ * of a proposed image snapshot, return the ImageData for the context.
+ * @param {CanvasRenderingContext2D} ctx The 2D canvas rendering context
+ * @param {number} width The width of the proposed image snapshot
+ * @param {number} height The height of the proposed image snapshot
+ * @returns {Array} The list of values in the object
+ */
+const safeGetImageData = function (ctx, width, height) {
+    const safeWidth = width || 1;
+    const safeHeight = height || 1;
+
+    return ctx.getImageData(0, 0, safeWidth, safeHeight);
+};
+
+module.exports = safeGetImageData;


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-paint#901
Resolves LLK/scratch-paint#859

Unfortunately this one remains unresolved: LLK/scratch-paint#836

### Proposed Changes

Replace all instances of `getImageData` with new util `safeGetImageData` which handles calling the former with the unsafe value of 0 for width or height which results in an error being thrown.

This PR is one option for resolving the fact that we do not handle empty images well (the root cause of the issues being resolved above). 
