### PR TITLE
Remove setConvexHullDirty and setTransformDirty calls from _reskin

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -394,8 +394,6 @@ class RenderWebGL extends EventEmitter {
         for (const drawable of this._allDrawables) {
             if (drawable && drawable.skin === oldSkin) {
                 drawable.skin = newSkin;
-                drawable.setConvexHullDirty();
-                drawable.setTransformDirty();
             }
         }
         oldSkin.dispose();


### PR DESCRIPTION
### Proposed Changes

This PR removes calls to `Drawable.setConvexHullDirty` and `Drawable.setTransformDirty` from the `_reskin` function, called when an existing skin is updated.

### Reason for Changes

`_reskin` sets a `Drawable`'s skin, which in turn [calls `Drawable._skinWasAltered`](https://github.com/LLK/scratch-render/blob/13b9ed7e16373af9e7760bd7b7ed215c948bc4ae/src/Drawable.js#L151).

That function [itself calls `Drawable.setConvexHullDirty` and `Drawable.setTransformDirty`](https://github.com/LLK/scratch-render/blob/13b9ed7e16373af9e7760bd7b7ed215c948bc4ae/src/Drawable.js#L637).

Doing it in `_reskin` is redundant, and could be confusing to those looking over the code.