### PR TITLE
Use premultiplied alpha everywhere, take 2

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -18,9 +18,6 @@ class BitmapSkin extends Skin {
         /** @type {!RenderWebGL} */
         this._renderer = renderer;
 
-        /** @type {WebGLTexture} */
-        this._texture = null;
-
         /** @type {Array<int>} */
         this._textureSize = [0, 0];
     }
@@ -95,21 +92,16 @@ class BitmapSkin extends Skin {
             textureData = context.getImageData(0, 0, bitmapData.width, bitmapData.height);
         }
 
-        if (this._texture) {
-            gl.bindTexture(gl.TEXTURE_2D, this._texture);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, textureData);
-            this._silhouette.update(textureData);
-        } else {
-            // TODO: mipmaps?
+        if (this._texture === null) {
             const textureOptions = {
-                auto: true,
-                wrap: gl.CLAMP_TO_EDGE,
-                src: textureData
+                auto: false,
+                wrap: gl.CLAMP_TO_EDGE
             };
 
             this._texture = twgl.createTexture(gl, textureOptions);
-            this._silhouette.update(textureData);
         }
+
+        this._setTexture(textureData);
 
         // Do these last in case any of the above throws an exception
         this._costumeResolution = costumeResolution || 2;

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -685,6 +685,9 @@ class Drawable {
         const localPosition = getLocalPosition(drawable, vec);
         if (localPosition[0] < 0 || localPosition[1] < 0 ||
             localPosition[0] > 1 || localPosition[1] > 1) {
+            dst[0] = 0;
+            dst[1] = 0;
+            dst[2] = 0;
             dst[3] = 0;
             return dst;
         }

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -79,6 +79,9 @@ class PenSkin extends Skin {
     constructor (id, renderer) {
         super(id);
 
+        // This silhouette will be updated with data from `gl.readPixels`, which is premultiplied.
+        this._silhouette.premultiplied = true;
+
         /**
          * @private
          * @type {RenderWebGL}
@@ -87,9 +90,6 @@ class PenSkin extends Skin {
 
         /** @type {HTMLCanvasElement} */
         this._canvas = document.createElement('canvas');
-
-        /** @type {WebGLTexture} */
-        this._texture = null;
 
         /** @type {WebGLTexture} */
         this._exportTexture = null;
@@ -123,7 +123,7 @@ class PenSkin extends Skin {
 
         const NO_EFFECTS = 0;
         /** @type {twgl.ProgramInfo} */
-        this._stampShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.stamp, NO_EFFECTS);
+        this._stampShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.default, NO_EFFECTS);
 
         /** @type {twgl.ProgramInfo} */
         this._lineShader = this._renderer._shaderManager.getShader(ShaderManager.DRAW_MODE.lineSample, NO_EFFECTS);
@@ -317,13 +317,6 @@ class PenSkin extends Skin {
 
         twgl.bindFramebufferInfo(gl, this._framebuffer);
 
-        // Needs a blend function that blends a destination that starts with
-        // no alpha.
-        gl.blendFuncSeparate(
-            gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA,
-            gl.ONE, gl.ONE_MINUS_SRC_ALPHA
-        );
-
         gl.viewport(0, 0, bounds.width, bounds.height);
 
         gl.useProgram(currentShader.program);
@@ -343,8 +336,6 @@ class PenSkin extends Skin {
      */
     _exitDrawLineOnBuffer () {
         const gl = this._renderer.gl;
-
-        gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
 
         twgl.bindFramebufferInfo(gl, null);
     }
@@ -490,8 +481,6 @@ class PenSkin extends Skin {
 
         twgl.bindFramebufferInfo(gl, this._framebuffer);
 
-        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-
         this._drawRectangleRegionEnter(this._stampShader, this._bounds);
     }
 
@@ -500,8 +489,6 @@ class PenSkin extends Skin {
      */
     _exitDrawToBuffer () {
         const gl = this._renderer.gl;
-
-        gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
 
         twgl.bindFramebufferInfo(gl, null);
     }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -196,7 +196,7 @@ class RenderWebGL extends EventEmitter {
         gl.disable(gl.DEPTH_TEST);
         /** @todo disable when no partial transparency? */
         gl.enable(gl.BLEND);
-        gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE);
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
     }
 
     /**
@@ -834,7 +834,8 @@ class RenderWebGL extends EventEmitter {
                 projection,
                 {
                     extraUniforms,
-                    ignoreVisibility: true // Touching color ignores sprite visibility
+                    ignoreVisibility: true, // Touching color ignores sprite visibility,
+                    effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask
                 });
 
             gl.stencilFunc(gl.EQUAL, 1, 1);
@@ -1554,7 +1555,7 @@ class RenderWebGL extends EventEmitter {
         const projection = twgl.m4.ortho(bounds.left, bounds.right, bounds.top, bounds.bottom, -1, 1);
 
         // Draw the stamped sprite onto the PenSkin's framebuffer.
-        this._drawThese([stampID], ShaderManager.DRAW_MODE.stamp, projection, {ignoreVisibility: true});
+        this._drawThese([stampID], ShaderManager.DRAW_MODE.default, projection, {ignoreVisibility: true});
         skin._silhouetteDirty = true;
     }
 
@@ -1744,14 +1745,6 @@ class RenderWebGL extends EventEmitter {
             }
 
             twgl.setUniforms(currentShader, uniforms);
-
-            /* adjust blend function for this skin */
-            if (drawable.skin.hasPremultipliedAlpha){
-                gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-            } else {
-                gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-            }
-
             twgl.drawBufferInfo(gl, this._bufferInfo, gl.TRIANGLES);
         }
 
@@ -1903,12 +1896,10 @@ class RenderWebGL extends EventEmitter {
             */
             Drawable.sampleColor4b(vec, drawables[index].drawable, __blendColor);
             // if we are fully transparent, go to the next one "down"
-            const sampleAlpha = __blendColor[3] / 255;
-            // premultiply alpha
-            dst[0] += __blendColor[0] * blendAlpha * sampleAlpha;
-            dst[1] += __blendColor[1] * blendAlpha * sampleAlpha;
-            dst[2] += __blendColor[2] * blendAlpha * sampleAlpha;
-            blendAlpha *= (1 - sampleAlpha);
+            dst[0] += __blendColor[0] * blendAlpha;
+            dst[1] += __blendColor[1] * blendAlpha;
+            dst[2] += __blendColor[2] * blendAlpha;
+            blendAlpha *= (1 - (__blendColor[3] / 255));
         }
         // Backdrop could be transparent, so we need to go to the "clear color" of the
         // draw scene (white) as a fallback if everything was alpha

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1895,7 +1895,7 @@ class RenderWebGL extends EventEmitter {
             }
             */
             Drawable.sampleColor4b(vec, drawables[index].drawable, __blendColor);
-            // if we are fully transparent, go to the next one "down"
+            // Equivalent to gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
             dst[0] += __blendColor[0] * blendAlpha;
             dst[1] += __blendColor[1] * blendAlpha;
             dst[2] += __blendColor[2] * blendAlpha;

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -90,7 +90,8 @@ class SVGSkin extends Skin {
         const textureOptions = {
             auto: false,
             wrap: this._renderer.gl.CLAMP_TO_EDGE,
-            src: textureData
+            src: textureData,
+            premultiplyAlpha: true
         };
 
         const mip = twgl.createTexture(this._renderer.gl, textureOptions);

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -171,12 +171,7 @@ ShaderManager.DRAW_MODE = {
     /**
      * Sample a "texture" to draw a line with caps.
      */
-    lineSample: 'lineSample',
-
-    /**
-     * Draw normally except for pre-multiplied alpha
-     */
-    stamp: 'stamp'
+    lineSample: 'lineSample'
 };
 
 module.exports = ShaderManager;

--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -39,6 +39,7 @@ const __cornerWork = [
 
 /**
  * Get the color from a given silhouette at an x/y local texture position.
+ * Multiply color values by alpha for proper blending.
  * @param {Silhouette} The silhouette to sample.
  * @param {number} x X position of texture (0-1).
  * @param {number} y Y position of texture (0-1).
@@ -46,6 +47,30 @@ const __cornerWork = [
  * @return {Uint8ClampedArray} The dst vector.
  */
 const getColor4b = ({_width: width, _height: height, _colorData: data}, x, y, dst) => {
+    // 0 if outside bouds, otherwise read from data.
+    if (x >= width || y >= height || x < 0 || y < 0) {
+        return dst.fill(0);
+    }
+    const offset = ((y * width) + x) * 4;
+    // premultiply alpha
+    const alpha = data[offset + 3] / 255;
+    dst[0] = data[offset] * alpha;
+    dst[1] = data[offset + 1] * alpha;
+    dst[2] = data[offset + 2] * alpha;
+    dst[3] = data[offset + 3];
+    return dst;
+};
+
+/**
+ * Get the color from a given silhouette at an x/y local texture position.
+ * Do not multiply color values by alpha, as it has already been done.
+ * @param {Silhouette} The silhouette to sample.
+ * @param {number} x X position of texture (0-1).
+ * @param {number} y Y position of texture (0-1).
+ * @param {Uint8ClampedArray} dst A color 4b space.
+ * @return {Uint8ClampedArray} The dst vector.
+ */
+const getPremultipliedColor4b = ({_width: width, _height: height, _colorData: data}, x, y, dst) => {
     // 0 if outside bouds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return dst.fill(0);
@@ -78,7 +103,43 @@ class Silhouette {
          */
         this._colorData = null;
 
+        /**
+         * Whether or not the color data is premultiplied with its alpha channel.
+         * If it isn't, it will be multiplied here.
+         * @type {boolean}
+         */
+        this._isPremultiplied = false;
+
+        // By default, silhouettes are assumed not to contain premultiplied image data,
+        // so when we get a color, we want to multiply it by its alpha channel.
+        // Point `_getColor` to the version of the function that multiplies.
+        this._getColor = getColor4b;
+
         this.colorAtNearest = this.colorAtLinear = (_, dst) => dst.fill(0);
+    }
+
+    /**
+     * @returns {boolean} true if the silhouette color data is premultiplied, false if not.
+     */
+    get premultiplied () {
+        return this._isPremultiplied;
+    }
+
+    /**
+     * Set the alpha premultiplication state of this silhouette, to ensure proper color values are returned.
+     * If set to true, the silhouette will assume it is being set with premultiplied color data,
+     * and will not multiply color values by alpha.
+     * If set to false, it will multiply color values by alpha.
+     * @param {boolean} isPremultiplied Whether this silhouette will be populated with premultiplied color data.
+     */
+    set premultiplied (isPremultiplied) {
+        this._isPremultiplied = isPremultiplied;
+
+        if (isPremultiplied) {
+            this._getColor = getPremultipliedColor4b;
+        } else {
+            this._getColor = getColor4b;
+        }
     }
 
     /**
@@ -124,7 +185,7 @@ class Silhouette {
      * @returns {Uint8ClampedArray} dst
      */
     colorAtNearest (vec, dst) {
-        return getColor4b(
+        return this._getColor(
             this,
             Math.floor(vec[0] * (this._width - 1)),
             Math.floor(vec[1] * (this._height - 1)),
@@ -151,10 +212,10 @@ class Silhouette {
         const xFloor = Math.floor(x);
         const yFloor = Math.floor(y);
 
-        const x0y0 = getColor4b(this, xFloor, yFloor, __cornerWork[0]);
-        const x1y0 = getColor4b(this, xFloor + 1, yFloor, __cornerWork[1]);
-        const x0y1 = getColor4b(this, xFloor, yFloor + 1, __cornerWork[2]);
-        const x1y1 = getColor4b(this, xFloor + 1, yFloor + 1, __cornerWork[3]);
+        const x0y0 = this._getColor(this, xFloor, yFloor, __cornerWork[0]);
+        const x1y0 = this._getColor(this, xFloor + 1, yFloor, __cornerWork[1]);
+        const x0y1 = this._getColor(this, xFloor, yFloor + 1, __cornerWork[2]);
+        const x1y1 = this._getColor(this, xFloor + 1, yFloor + 1, __cornerWork[3]);
 
         dst[0] = (x0y0[0] * x0D * y0D) + (x0y1[0] * x0D * y1D) + (x1y0[0] * x1D * y0D) + (x1y1[0] * x1D * y1D);
         dst[1] = (x0y0[1] * x0D * y0D) + (x0y1[1] * x0D * y1D) + (x1y0[1] * x1D * y0D) + (x1y1[1] * x1D * y1D);

--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -20,7 +20,7 @@ let __SilhouetteUpdateCanvas;
  * @return {number} Alpha value for x/y position
  */
 const getPoint = ({_width: width, _height: height, _colorData: data}, x, y) => {
-    // 0 if outside bouds, otherwise read from data.
+    // 0 if outside bounds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return 0;
     }
@@ -47,7 +47,7 @@ const __cornerWork = [
  * @return {Uint8ClampedArray} The dst vector.
  */
 const getColor4b = ({_width: width, _height: height, _colorData: data}, x, y, dst) => {
-    // 0 if outside bouds, otherwise read from data.
+    // 0 if outside bounds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return dst.fill(0);
     }
@@ -71,7 +71,7 @@ const getColor4b = ({_width: width, _height: height, _colorData: data}, x, y, ds
  * @return {Uint8ClampedArray} The dst vector.
  */
 const getPremultipliedColor4b = ({_width: width, _height: height, _colorData: data}, x, y, dst) => {
-    // 0 if outside bouds, otherwise read from data.
+    // 0 if outside bounds, otherwise read from data.
     if (x >= width || y >= height || x < 0 || y < 0) {
         return dst.fill(0);
     }
@@ -103,13 +103,6 @@ class Silhouette {
          */
         this._colorData = null;
 
-        /**
-         * Whether or not the color data is premultiplied with its alpha channel.
-         * If it isn't, it will be multiplied here.
-         * @type {boolean}
-         */
-        this._isPremultiplied = false;
-
         // By default, silhouettes are assumed not to contain premultiplied image data,
         // so when we get a color, we want to multiply it by its alpha channel.
         // Point `_getColor` to the version of the function that multiplies.
@@ -119,35 +112,12 @@ class Silhouette {
     }
 
     /**
-     * @returns {boolean} true if the silhouette color data is premultiplied, false if not.
-     */
-    get premultiplied () {
-        return this._isPremultiplied;
-    }
-
-    /**
-     * Set the alpha premultiplication state of this silhouette, to ensure proper color values are returned.
-     * If set to true, the silhouette will assume it is being set with premultiplied color data,
-     * and will not multiply color values by alpha.
-     * If set to false, it will multiply color values by alpha.
-     * @param {boolean} isPremultiplied Whether this silhouette will be populated with premultiplied color data.
-     */
-    set premultiplied (isPremultiplied) {
-        this._isPremultiplied = isPremultiplied;
-
-        if (isPremultiplied) {
-            this._getColor = getPremultipliedColor4b;
-        } else {
-            this._getColor = getColor4b;
-        }
-    }
-
-    /**
      * Update this silhouette with the bitmapData for a skin.
-     * @param {*} bitmapData An image, canvas or other element that the skin
+     * @param {ImageData|HTMLCanvasElement|HTMLImageElement} bitmapData An image, canvas or other element that the skin
+     * @param {boolean} isPremultiplied True if the source bitmap data comes premultiplied (e.g. from readPixels).
      * rendering can be queried from.
      */
-    update (bitmapData) {
+    update (bitmapData, isPremultiplied = false) {
         let imageData;
         if (bitmapData instanceof ImageData) {
             // If handed ImageData directly, use it directly.
@@ -168,6 +138,12 @@ class Silhouette {
             ctx.clearRect(0, 0, width, height);
             ctx.drawImage(bitmapData, 0, 0, width, height);
             imageData = ctx.getImageData(0, 0, width, height);
+        }
+
+        if (isPremultiplied) {
+            this._getColor = getPremultipliedColor4b;
+        } else {
+            this._getColor = getColor4b;
         }
 
         this._colorData = imageData.data;

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -33,6 +33,9 @@ class Skin extends EventEmitter {
         /** @type {Vec3} */
         this._rotationCenter = twgl.v3.create(0, 0);
 
+        /** @type {WebGLTexture} */
+        this._texture = null;
+
         /**
          * The uniforms to be used by the vertex and pixel shaders.
          * Some of these are used by other parts of the renderer as well.
@@ -170,6 +173,23 @@ class Skin extends EventEmitter {
      * @abstract
      */
     updateSilhouette () {}
+
+    /**
+     * Set this skin's texture to the given image.
+     * @param {ImageData|HTMLCanvasElement} textureData - The canvas or image data to set the texture to.
+     */
+    _setTexture (textureData) {
+        const gl = this._renderer.gl;
+
+        gl.bindTexture(gl.TEXTURE_2D, this._texture);
+        // Premultiplied alpha is necessary for proper blending.
+        // See http://www.realtimerendering.com/blog/gpus-prefer-premultiplication/
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, textureData);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+        this._silhouette.update(textureData);
+    }
 
     /**
      * Set the contents of this skin to an empty skin.

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -80,13 +80,6 @@ class Skin extends EventEmitter {
     }
 
     /**
-     * @returns {boolean} true if alpha is premultiplied, false otherwise
-     */
-    get hasPremultipliedAlpha () {
-        return false;
-    }
-
-    /**
      * @return {int} the unique ID for this Skin.
      */
     get id () {

--- a/src/TextBubbleSkin.js
+++ b/src/TextBubbleSkin.js
@@ -42,9 +42,6 @@ class TextBubbleSkin extends Skin {
         /** @type {HTMLCanvasElement} */
         this._canvas = document.createElement('canvas');
 
-        /** @type {WebGLTexture} */
-        this._texture = null;
-
         /** @type {Array<number>} */
         this._size = [0, 0];
 
@@ -272,9 +269,7 @@ class TextBubbleSkin extends Skin {
                 this._texture = twgl.createTexture(gl, textureOptions);
             }
 
-            gl.bindTexture(gl.TEXTURE_2D, this._texture);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, textureData);
-            this._silhouette.update(textureData);
+            this._setTexture(textureData);
         }
 
         return this._texture;

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -153,16 +153,12 @@ void main()
 
 	gl_FragColor = texture2D(u_skin, texcoord0);
 
-    #ifdef ENABLE_ghost
-    gl_FragColor.a *= u_ghost;
-    #endif // ENABLE_ghost
+	#if defined(ENABLE_color) || defined(ENABLE_brightness)
+	// Divide premultiplied alpha values for proper color processing
+	// Add epsilon to avoid dividing by 0 for fully transparent pixels
+	gl_FragColor.rgb /= gl_FragColor.a + epsilon;
 
-	#ifdef DRAW_MODE_silhouette
-	// switch to u_silhouetteColor only AFTER the alpha test
-	gl_FragColor = u_silhouetteColor;
-	#else // DRAW_MODE_silhouette
-
-	#if defined(ENABLE_color)
+	#ifdef ENABLE_color
 	{
 		vec3 hsv = convertRGB2HSV(gl_FragColor.xyz);
 
@@ -178,11 +174,29 @@ void main()
 
 		gl_FragColor.rgb = convertHSV2RGB(hsv);
 	}
-	#endif // defined(ENABLE_color)
+	#endif // ENABLE_color
 
-	#if defined(ENABLE_brightness)
+	#ifdef ENABLE_brightness
 	gl_FragColor.rgb = clamp(gl_FragColor.rgb + vec3(u_brightness), vec3(0), vec3(1));
-	#endif // defined(ENABLE_brightness)
+	#endif // ENABLE_brightness
+
+	// Re-multiply color values
+	gl_FragColor.rgb *= gl_FragColor.a + epsilon;
+
+	#endif // defined(ENABLE_color) || defined(ENABLE_brightness)
+
+	#ifdef ENABLE_ghost
+	gl_FragColor *= u_ghost;
+	#endif // ENABLE_ghost
+
+	#ifdef DRAW_MODE_silhouette
+	// Discard fully transparent pixels for stencil test
+	if (gl_FragColor.a == 0.0) {
+		discard;
+	}
+	// switch to u_silhouetteColor only AFTER the alpha test
+	gl_FragColor = u_silhouetteColor;
+	#else // DRAW_MODE_silhouette
 
 	#ifdef DRAW_MODE_colorMask
 	vec3 maskDistance = abs(gl_FragColor.rgb - u_colorMask);
@@ -195,8 +209,9 @@ void main()
 	#endif // DRAW_MODE_silhouette
 
 	#else // DRAW_MODE_lineSample
-	gl_FragColor = u_lineColor;
-	gl_FragColor.a *= clamp(
+	// Pen skins use premultiplied alpha, but u_lineColor is not premultiplied, so multiply it here
+	vec4 premulColor = vec4(u_lineColor.rgb * u_lineColor.a, u_lineColor.a);
+	gl_FragColor = premulColor * clamp(
 		// Scale the capScale a little to have an aliased region.
 		(u_capScale + u_aliasAmount -
 			u_capScale * 2.0 * distance(v_texCoord, vec2(0.5, 0.5))


### PR DESCRIPTION
### Resolves

Resolves #513 
Resolves #237 

### Proposed Changes

- Set `gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL` before  calling `texImage2D`
  - Move `_texture` to `Skin` base class
  - Add `_setTexture` helper function to `Skin` base class
  - Disable "automatically attempt mipmaps" in `twgl.createTexture`
- Use `gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)` for all blending
- Premultiply alpha in ghost effect and pen shader
- Remove `stamp` draw mode
- Move software-pipeline alpha premultiplication step from `RenderWebGL.sampleColor3b` to `Silhouette.getColor` methods
  - Allow `Silhouette`s to take both non-premultiplied and premultiplied image data by splitting `getColor4b` into `getColor4b` and `getPremultipliedColor4b`

### Reason for Changes

- Set `gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL` before binding textures

This causes textures' alpha channels to be premultiplied before being sent to the GPU. This is necessary for proper blending around edges of sprites; see [this article ("GPUs prefer premultiplication")](http://www.realtimerendering.com/blog/gpus-prefer-premultiplication/) for more info

- Move `_texture` to `Skin` base class
- Add `_setTexture` helper function to `Skin` base class

These changes reduce code duplication.
`_texture` was previously initialized by every implementation of `Skin`, so I moved it to the base class to reduce redundancy.
`_setTexture` performs the steps of binding the texture, setting and unsetting `gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL`, calling `texImage2D`, and updating the skin's silhouette. This would otherwise have to be done in every place that sets a `Skin` implementation's texture to an image.

- Disable "automatically attempt mipmaps" in `twgl.createTexture`

Because `Skin` textures are non-power-of-two, no mipmaps can be generated, but for some reason twgl will attempt anyway unless explicitly told not to. This change makes `twgl.createTexture` throw out tons of `glGenerateMipmap` warning messages because it is no longer passed a texture (the texture is now set outside the function that creates it).

- Use `gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)` for all blending

This is the proper blend function for compositing premultiplied textures.

- Premultiply alpha in ghost effect and pen shader

Everything should be premultiplied.

- Remove `stamp` draw mode

The `stamp` draw mode has not done what it's been said to do ("Draw normally except for pre-multiplied alpha") since #418. It has, in fact, done nothing differently than the `default` draw mode.

- Move software-pipeline alpha premultiplication step from `RenderWebGL.sampleColor3b` to `Silhouette.getColor` methods

As described in the article I linked above, color values must be multiplied by alpha *before* interpolation to avoid fringing artifacts.

- Allow `Silhouette`s to take both non-premultiplied and premultiplied image data by splitting `getColor4b` into `getColor4b` and `getPremultipliedColor4b`

A `Silhouette` can take either data from an image, which is not premultiplied, or data from the GPU, which is premultiplied. If the data does not come premultiplied, we want to premultiply it. If it does come premultiplied, we don't want to multiply it again.

I accomplished this by adding the `premultiplied` getter/setter to `Silhouette`. If set to `true`, it indicates that data passed to the silhouette already comes premultiplied, and if set to `false` it indicates that it is not premultiplied.

I added a `_getColor` member to `Silhouette` which the `Silhouette.colorAt` functions now call instead of `getColor4b`. If the silhouette is `premultiplied`, the member will point towards the `getPremultipliedColor4b` function. If not, it will point towards the `getColor4b` function.

This does not appear to regress performance of `Silhouette` operations.


### Unanswered Questions
- It was previously determined that [setting textures from `ImageData` was faster than setting them from `HTMLCanvasElement`s](https://github.com/LLK/scratch-render/pull/414). This may have been because `ImageData` was not premultiplied, and the textures were not either, allowing the browser to copy the texture data to the GPU directly rather than dividing each individual pixel by its alpha.
With this PR, textures are now premultiplied, like an `HTMLCanvasElement`'s backing store. **So is it faster to set premultiplied textures from a canvas instead of grabbing the `ImageData`?**

- ~~The current shader applies the "ghost" effect (which now multiplies all color values) before the "brightness" and "color" effects (which read color values). This appears to produce correct results, but is probably incorrect. However, I cannot find a way to fix it without spaghettifying the code. **How should this be handled? Should the shader divide alpha values if brightness/color are enabled and multiply them again afterwards?**~~
    - Regarding the above, I have decided to divide by alpha values before applying brightness/color effects and multiply afterwards.


- Both in the current code and here, `extractDrawable` returns a premultiplied image. This produces a dark fringe around dragged sprites. **Is this something to fix in the future?**