### PR TITLE
Revert "remove updateMatrix call from getFastBounds"

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -573,6 +573,7 @@ class Drawable {
      * @return {!Rectangle} Bounds for the Drawable.
      */
     getFastBounds (result) {
+        this.updateMatrix();
         if (!this.needsConvexHullPoints()) {
             return this.getBounds(result);
         }


### PR DESCRIPTION
Reverts LLK/scratch-render#468

The PR caused a regression with video sensing where video motion on sprite reports 0 if the sprite has moved from its original position.