### PR TITLE
Reduce unnecessary traversal

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1012,21 +1012,25 @@ class RenderWebGL extends EventEmitter {
      * RenderConstants.ID_NONE if there is no Drawable at that location.
      */
     pick (centerX, centerY, touchWidth, touchHeight, candidateIDs) {
+        const bounds = this.clientSpaceToScratchBounds(centerX, centerY, touchWidth, touchHeight);
+        if (bounds.left === -Infinity || bounds.bottom === -Infinity) {
+            return false;
+        }
+
         candidateIDs = (candidateIDs || this._drawList).filter(id => {
             const drawable = this._allDrawables[id];
             // default pick list ignores visible and ghosted sprites.
             if (drawable.getVisible() && drawable.getUniforms().u_ghost !== 0) {
+                const drawableBounds = drawable.getFastBounds();
+                const inRange = bounds.intersects(drawableBounds);
+                if (!inRange) return false;
+
                 drawable.updateCPURenderAttributes();
                 return true;
             }
             return false;
         });
         if (candidateIDs.length === 0) {
-            return false;
-        }
-
-        const bounds = this.clientSpaceToScratchBounds(centerX, centerY, touchWidth, touchHeight);
-        if (bounds.left === -Infinity || bounds.bottom === -Infinity) {
             return false;
         }
 


### PR DESCRIPTION
### Resolves
Resolves https://github.com/LLK/scratch-render/issues/640
Optimized the pick method to traverse the drawable

### Proposed Changes

Optimized the pick method to traverse the drawable

### Reason for Changes

Increase the speed of the pick

### Test Coverage

chrome
