### PR TITLE
Expand convex hull bounds by half a pixel per side

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -521,7 +521,7 @@ class Drawable {
         const transformedHullPoints = this._getTransformedHullPoints();
         // Search through transformed points to generate box on axes.
         result = result || new Rectangle();
-        result.initFromPointsAABB(transformedHullPoints);
+        result.initFromPointsAABB(transformedHullPoints, Math.max(this._scale[0], this._scale[1]) * 0.01);
         return result;
     }
 
@@ -545,7 +545,7 @@ class Drawable {
         const filteredHullPoints = transformedHullPoints.filter(p => p[1] > maxY - slice);
         // Search through filtered points to generate box on axes.
         result = result || new Rectangle();
-        result.initFromPointsAABB(filteredHullPoints);
+        result.initFromPointsAABB(filteredHullPoints, Math.max(this._scale[0], this._scale[1]) * 0.01);
         return result;
     }
 

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -29,27 +29,35 @@ class Rectangle {
     /**
      * Initialize a Rectangle to the minimum AABB around a set of points.
      * @param {Array<Array<number>>} points Array of [x, y] points.
+     * @param {number} scale The "Scratch-space" area under each point sample.
      */
-    initFromPointsAABB (points) {
+    initFromPointsAABB (points, scale = 0) {
         this.left = Infinity;
         this.right = -Infinity;
         this.top = -Infinity;
         this.bottom = Infinity;
 
+        // Each point is the center of a pixel. However, said pixels each have area.
+        // We can think of the `scale` parameter as the 'diameter' of each area sample centered around each point.
+        // The bounds must be extended by the 'radius' of each sample on every side.
+        // Since nearest-neighbor sampling gives pixels a square area, the radius is sqrt(2) / 2 = 0.707...
+        // at its longest (from the center of the pixel to one of its corners).
+        const halfPixel = 0.7071067811865476 * scale;
+
         for (let i = 0; i < points.length; i++) {
             const x = points[i][0];
             const y = points[i][1];
-            if (x < this.left) {
-                this.left = x;
+            if ((x - halfPixel) < this.left) {
+                this.left = x - halfPixel;
             }
-            if (x > this.right) {
-                this.right = x;
+            if ((x + halfPixel) > this.right) {
+                this.right = x + halfPixel;
             }
-            if (y > this.top) {
-                this.top = y;
+            if ((y + halfPixel) > this.top) {
+                this.top = y + halfPixel;
             }
-            if (y < this.bottom) {
-                this.bottom = y;
+            if ((y - halfPixel) < this.bottom) {
+                this.bottom = y - halfPixel;
             }
         }
     }


### PR DESCRIPTION
### Resolves

Resolves #528

### Proposed Changes

This PR expands convex hull bounds by the radius of half a pixel on each side of the bounding box.

### Reason for Changes

Say you have a costume like this:
![image](https://user-images.githubusercontent.com/25993062/69791028-a090dd80-1191-11ea-81c0-26c8d2cd84f6.png)

The pixels of said costume can be treated as square color samples taken at the pixels' centers:
![image](https://user-images.githubusercontent.com/25993062/69791173-f2d1fe80-1191-11ea-9fc2-1eee009dec5e.png)

The convex hull algorithm calculates the hull based on the pixels' centers, not taking area into account:
![convhull](https://user-images.githubusercontent.com/25993062/69791366-6247ee00-1192-11ea-9fee-226671db2def.png)

As such, bounds calculated from the convex hull need to be enlarged by the "radius" of each pixel.
If pixels were circular, this would be half the "diameter" (aka the drawable's Scratch-space scale), but since they're square, it's actually (√2 / 2) * the diameter.

This will probably change:
- The position of text bubbles (probably not a big deal)
- "If on edge, bounce" behavior (probably a bigger deal)
- Fencing behavior ([shouldn't be using the convex hull anyway](https://github.com/LLK/scratch-render/pull/478))

If the "if on edge, bounce" behavioral change is a compatibility issue, I can redo this once there's architecture in place for [separating a sprite's "logical" bounds and texture bounds](https://github.com/LLK/scratch-render/issues/427), so the old tight bounds can be used for bouncing and the new expanded ones can be used for stamping.

EDIT: The current "if on edge, bounce" behavior is [extremely inconsistent](https://scratch.mit.edu/projects/349149479/) both with itself and 2.0 (you can get this sprite to begin phasing through the walls if you move it into a corner) so this hopefully shouldn't affect compatibility any more than the current behavior already has.

A semi-related issue you may run into when investigating this further is that `getConvexHullPointsForDrawable` does touching tests at the sprite's "logical size", so double-resolution bitmap costumes (in 3.0, that means all of them) are sampled at half their actual resolution.

This means that, incidentally, double-resolution bitmap sprites with odd-numbered resolution dimensions (like the black circle I linked above in 349149479) appear to be properly fenced currently, but will be fenced half a texel too far inwards by this change. This is because their "logical" sizes are their resolutions divided by 2, and we've started rounding that size up. However, bitmap sprites with even-numbered resolution dimensions were fenced too far *outwards*, and this change fixes that.