### PR TITLE
Update scratch-svg-renderer to required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minilog": "3.1.0",
     "raw-loader": "^0.5.1",
     "scratch-storage": "^1.0.0",
-    "scratch-svg-renderer": "0.2.0-prerelease.20200103191258",
+    "scratch-svg-renderer": "0.2.0-prerelease.20200103211543",
     "twgl.js": "4.4.0"
   }
 }


### PR DESCRIPTION
### Proposed Changes

This PR *actually* updates scratch-svg-renderer to the latest version.

### Reason for Changes

For whatever reason, the [Greenkeeper PR](https://github.com/LLK/scratch-render/pull/534) didn't auto-update like it normally does, and instead of getting the version of `scratch-svg-renderer` necessary to make #527 work, we got an outdated version. @fsih 

EDIT: you may need to do this for the other Scratch repos as well
