### PR TITLE
Set zero-sized SVG MIPs to empty texture

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -80,6 +80,10 @@ class SVGSkin extends Skin {
         // updating Silhouette and is better handled by more browsers in
         // regards to memory.
         const canvas = this._svgRenderer.canvas;
+        // If one of the canvas dimensions is 0, set this MIP to an empty image texture.
+        // This avoids an IndexSizeError from attempting to getImageData when one of the dimensions is 0.
+        if (canvas.width === 0 || canvas.height === 0) return super.getTexture();
+
         const context = canvas.getContext('2d');
         const textureData = context.getImageData(0, 0, canvas.width, canvas.height);
 
@@ -105,10 +109,6 @@ class SVGSkin extends Skin {
      * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given scale.
      */
     getTexture (scale) {
-        if (!this._svgRenderer.canvas.width || !this._svgRenderer.canvas.height) {
-            return super.getTexture();
-        }
-
         // The texture only ever gets uniform scale. Take the larger of the two axes.
         const scaleMax = scale ? Math.max(Math.abs(scale[0]), Math.abs(scale[1])) : 100;
         const requestedScale = Math.min(scaleMax / 100, this._maxTextureScale);


### PR DESCRIPTION
Depends on https://github.com/LLK/scratch-svg-renderer/pull/116

### Resolves

Resolves #538

### Proposed Changes

This PR adds a check in `SVGSkin.createMIP` that checks if one of the SVG renderer's canvas dimensions is 0. If so, it returns an empty image texture.

It also removes the check from `getTexture` that checks whether the SVG renderer's canvas width or height are 0, as it is now unnecessary and may cause an error: it checks the *current* canvas width or height, not the width and height of the proper *mipmap*'s canvas.
This means if you e.g. render a mipmap at scale 1, then render it at a very small scale that makes one of its texture dimensions 0, it won't appear again even at mipmap scale 1, because it was last rendered at that small scale and so the SVG renderer's canvas width/height will remain 0.

### Reason for Changes

Along with https://github.com/LLK/scratch-svg-renderer/pull/116, this prevents `IndexSizeError`s from messing up SVG skin rendering.

Note that `IndexSizeError`s have, for a long time now, been thrown when zero-sized skins have been rendered, but they only became a problem with #527 because thrown errors can't propagate through callbacks, which the previous SVG drawing API used extensively.

EDIT: actually, it looks like it was the *original* SVGMIP patch that introduced the issue (although #527 didn't fix it; if you go into fullscreen with a 0x0 sprite, it still breaks). `scratch-gui` wasn't getting the updated version of `scratch-render`.