### PR TITLE
Fix SVGSkin silhouettes

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -100,6 +100,11 @@ class SVGSkin extends Skin {
         return mip;
     }
 
+    updateSilhouette (scale = 1) {
+        // Ensure a silhouette exists.
+        this.getTexture(scale);
+    }
+
     /**
      * @param {Array<number>} scale - The scaling factors to be used, each in the [0,100] range.
      * @return {WebGLTexture} The GL texture representation of this skin when drawing at the given scale.


### PR DESCRIPTION
### Resolves

Resolves #543

### Proposed Changes

This PR implements `updateSilhouette` for `SVGSkin`s, so that even if an `SVGSkin` has never been rendered, its silhouette still exists.

This PR also adds a new helper function, `_getDrawableScreenSpaceScale`, to `RenderWebGL`. This function's result is now passed to `Skin.updateSilhouette` so that the skin's silhouette can be properly scaled.

### Reason for Changes

This resolves the aforementioned bug, first [reported on the Bugs and Glitches forum](https://scratch.mit.edu/discuss/topic/381936/).

### Test Coverage

Incoming...
