### PR TITLE
Handle matrix + silhouette updates better

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -5,6 +5,7 @@ const RenderConstants = require('./RenderConstants');
 const ShaderManager = require('./ShaderManager');
 const Skin = require('./Skin');
 const EffectTransform = require('./EffectTransform');
+const log = require('./util/log');
 
 /**
  * An internal workspace for calculating texture locations from world vectors
@@ -640,7 +641,11 @@ class Drawable {
     updateCPURenderAttributes () {
         this.updateMatrix();
         // CPU rendering always occurs at the "native" size, so no need to scale up this._scale
-        if (this.skin) this.skin.updateSilhouette(this._scale);
+        if (this.skin) {
+            this.skin.updateSilhouette(this._scale);
+        } else {
+            log.warn(`Could not find skin for drawable with id: ${this._id}`);
+        }
     }
 
     /**

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -452,6 +452,8 @@ class Drawable {
 
     /**
      * Check if the world position touches the skin.
+     * The caller is responsible for ensuring this drawable's inverse matrix & its skin's silhouette are up-to-date.
+     * @see updateCPURenderAttributes
      * @param {twgl.v3} vec World coordinate vector.
      * @return {boolean} True if the world position touches the skin.
      */
@@ -633,6 +635,15 @@ class Drawable {
     }
 
     /**
+     * Update everything necessary to render this drawable on the CPU.
+     */
+    updateCPURenderAttributes () {
+        this.updateMatrix();
+        // CPU rendering always occurs at the "native" size, so no need to scale up this._scale
+        if (this.skin) this.skin.updateSilhouette(this._scale);
+    }
+
+    /**
      * Respond to an internal change in the current Skin.
      * @private
      */
@@ -676,6 +687,8 @@ class Drawable {
 
     /**
      * Sample a color from a drawable's texture.
+     * The caller is responsible for ensuring this drawable's inverse matrix & its skin's silhouette are up-to-date.
+     * @see updateCPURenderAttributes
      * @param {twgl.v3} vec The scratch space [x,y] vector
      * @param {Drawable} drawable The drawable to sample the texture from
      * @param {Uint8ClampedArray} dst The "color4b" representation of the texture at point.

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -985,12 +985,7 @@ class RenderWebGL extends EventEmitter {
         const bounds = this.clientSpaceToScratchBounds(centerX, centerY, touchWidth, touchHeight);
         const worldPos = twgl.v3.create();
 
-        drawable.updateMatrix();
-        if (drawable.skin) {
-            drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
-        } else {
-            log.warn(`Could not find skin for drawable with id: ${drawableID}`);
-        }
+        drawable.updateCPURenderAttributes();
 
         for (worldPos[1] = bounds.bottom; worldPos[1] <= bounds.top; worldPos[1]++) {
             for (worldPos[0] = bounds.left; worldPos[0] <= bounds.right; worldPos[0]++) {
@@ -1021,12 +1016,7 @@ class RenderWebGL extends EventEmitter {
             const drawable = this._allDrawables[id];
             // default pick list ignores visible and ghosted sprites.
             if (drawable.getVisible() && drawable.getUniforms().u_ghost !== 0) {
-                drawable.updateMatrix();
-                if (drawable.skin) {
-                    drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
-                } else {
-                    log.warn(`Could not find skin for drawable with id: ${id}`);
-                }
+                drawable.updateCPURenderAttributes();
                 return true;
             }
             return false;
@@ -1258,8 +1248,8 @@ class RenderWebGL extends EventEmitter {
         /** @todo remove this once URL-based skin setting is removed. */
         if (!drawable.skin || !drawable.skin.getTexture([100, 100])) return null;
 
-        drawable.updateMatrix();
-        drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
+
+        drawable.updateCPURenderAttributes();
         const bounds = drawable.getFastBounds();
 
         // Limit queries to the stage size.
@@ -1296,8 +1286,7 @@ class RenderWebGL extends EventEmitter {
                 const drawable = this._allDrawables[id];
                 if (drawable.skin && drawable._visible) {
                     // Update the CPU position data
-                    drawable.updateMatrix();
-                    drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
+                    drawable.updateCPURenderAttributes();
                     const candidateBounds = drawable.getFastBounds();
                     if (bounds.intersects(candidateBounds)) {
                         result.push({
@@ -1775,8 +1764,7 @@ class RenderWebGL extends EventEmitter {
     _getConvexHullPointsForDrawable (drawableID) {
         const drawable = this._allDrawables[drawableID];
 
-        drawable.updateMatrix();
-        drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
+        drawable.updateCPURenderAttributes();
 
         const [width, height] = drawable.skin.size;
         // No points in the hull if invisible or size is 0.

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -105,7 +105,7 @@ class SVGSkin extends Skin {
         return mip;
     }
 
-    updateSilhouette (scale = 1) {
+    updateSilhouette (scale = [100, 100]) {
         // Ensure a silhouette exists.
         this.getTexture(scale);
     }

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -222,6 +222,9 @@ class Skin extends EventEmitter {
     /**
      * Does this point touch an opaque or translucent point on this skin?
      * Nearest Neighbor version
+     * The caller is responsible for ensuring this skin's silhouette is up-to-date.
+     * @see updateSilhouette
+     * @see Drawable.updateCPURenderAttributes
      * @param {twgl.v3} vec A texture coordinate.
      * @return {boolean} Did it touch?
      */
@@ -232,6 +235,9 @@ class Skin extends EventEmitter {
     /**
      * Does this point touch an opaque or translucent point on this skin?
      * Linear Interpolation version
+     * The caller is responsible for ensuring this skin's silhouette is up-to-date.
+     * @see updateSilhouette
+     * @see Drawable.updateCPURenderAttributes
      * @param {twgl.v3} vec A texture coordinate.
      * @return {boolean} Did it touch?
      */

--- a/test/integration/cpu-render.html
+++ b/test/integration/cpu-render.html
@@ -42,8 +42,7 @@
                 if (!(drawable._visible && drawable.skin)) {
                     return;
                 }
-                drawable.updateMatrix();
-                drawable.skin.updateSilhouette();
+                drawable.updateCPURenderAttributes();
                 return { id, drawable };
             }).reverse().filter(Boolean);
             const color = new Uint8ClampedArray(3);


### PR DESCRIPTION
### Resolves

Resolves (part of) #545 
Resolves #546
Resolves https://github.com/LLK/scratch-gui/issues/5647

### Proposed Changes

This PR makes the following changes:
- Add `updateCPURenderAttributes` method to `Drawable`
- Move CPU render attribute update from `RenderWebGL._touchingBounds` to `RenderWebGL.isTouchingColor` and `RenderWebGL.isTouchingDrawables`
- Add documentation notes to `Drawable.isTouching`, `Skin.isTouchingNearest`, and `Skin.isTouchingLinear` explaining that those functions' callers are responsible for updating the silhouette + matrix
- Update CPU render attributes in `RenderWebGL._getConvexHullPointsForDrawable`

### Reason for Changes

- Add `updateCPURenderAttributes` method to `Drawable`
  - There were many places in `RenderWebGL` that called both `Drawable.updateMatrix` and `Drawable.skin.updateSilhouette`, and none that called just one or the other. Some checked whether the drawable's skin existed, others did not. I've consolidated calls to `Drawable.updateMatrix` and `Drawable.skin.updateSilhouette` into a single utility method, for conciseness and consistency.
  - This new consolidated method allows for future optimizations like [this one not included in this PR](https://github.com/adroitwhiz/scratch-render/commit/1f6fa1231713006789b02a7e6610961b871eb424), which in my testing improves "touching sprite" performance by 40-70%.
  - `updateCPURenderAttributes` does *not* multiply the drawable's scale by the screen-space scaling ratio, since CPU rendering always occurs at the "native" stage size.

- ~~Move CPU render attribute update from `RenderWebGL._touchingBounds` to `RenderWebGL.isTouchingColor` and `RenderWebGL.isTouchingDrawables`~~
  - ~~`_touchingBounds` doesn't actually require the passed drawable's matrix or silhouette to be up-to-date. However, `isTouchingColor` and `isTouchingDrawables` relied on it updating those. For clarity (and to prevent things from breaking if a future coder decided to "optimize" `_touchingBounds`), these calls have been moved (in the form of calls to the new `updateCPURenderAttributes` function) to the places that *actually* require the drawable's matrix and silhouette to be updated.~~ Moved to another PR

- Add documentation notes to `Drawable.isTouching`, `Skin.isTouchingNearest`, and `Skin.isTouchingLinear` explaining that those functions' callers are responsible for updating the silhouette + matrix
  - This should make it clearer to future coders that they cannot use a drawable's silhouette without updating it.

- ~~Update CPU render attributes in `RenderWebGL._getConvexHullPointsForDrawable`~~
  - ~~This appears to be what was causing the issue in #398. `_getConvexHullPointsForDrawable` calls methods which require the drawable's matrix + silhouette to be up-to-date, but previously did not update them.~~ Done in a previous PR

I have tested this manually and confirmed that it does *not* regress #543.