### PR TITLE
Un-premultiply extracted drawables

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1124,7 +1124,8 @@ class RenderWebGL extends EventEmitter {
         gl.clear(gl.COLOR_BUFFER_BIT);
         try {
             gl.disable(gl.BLEND);
-            this._drawThese([drawableID], ShaderManager.DRAW_MODE.default, projection,
+            // ImageData objects store alpha un-premultiplied, so draw with the `straightAlpha` draw mode.
+            this._drawThese([drawableID], ShaderManager.DRAW_MODE.straightAlpha, projection,
                 {effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask});
         } finally {
             gl.enable(gl.BLEND);

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -154,12 +154,12 @@ ShaderManager.EFFECTS = Object.keys(ShaderManager.EFFECT_INFO);
  */
 ShaderManager.DRAW_MODE = {
     /**
-     * Draw normally.
+     * Draw normally. Its output will use premultiplied alpha.
      */
     default: 'default',
 
     /**
-     * Un-premultiply alpha. Useful for reading pixels from GL into an ImageData object.
+     * Draw with non-premultiplied alpha. Useful for reading pixels from GL into an ImageData object.
      */
     straightAlpha: 'straightAlpha',
 

--- a/src/ShaderManager.js
+++ b/src/ShaderManager.js
@@ -159,6 +159,11 @@ ShaderManager.DRAW_MODE = {
     default: 'default',
 
     /**
+     * Un-premultiply alpha. Useful for reading pixels from GL into an ImageData object.
+     */
+    straightAlpha: 'straightAlpha',
+
+    /**
      * Draw a silhouette using a solid color.
      */
     silhouette: 'silhouette',

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -210,6 +210,11 @@ void main()
 	#endif // DRAW_MODE_colorMask
 	#endif // DRAW_MODE_silhouette
 
+	#ifdef DRAW_MODE_straightAlpha
+	// Un-premultiply alpha.
+	gl_FragColor.rgb /= gl_FragColor.a + epsilon;
+	#endif
+
 	#else // DRAW_MODE_lineSample
 	gl_FragColor = u_lineColor * clamp(
 		// Scale the capScale a little to have an aliased region.


### PR DESCRIPTION
### Resolves

Resolves #551

### Proposed Changes

This PR adds a new `straightAlpha` draw mode which un-premultiplies rendered sprites by dividing their RGB channels by their alpha channel in the shader, and uses that draw mode in `RenderWebGL.extractDrawable`.

### Reason for Changes

`RenderWebGL.extractDrawable` returns data which is expected to be un-premultiplied, as `scratch-gui` places it into an `ImageData` object and draws it to a canvas. If the data is premultiplied, partially-transparent pixels will appear darker than they should.