### PR TITLE
Set rotation center to [0, 0] in setEmptyImageData

### DIFF
--- a/src/Skin.js
+++ b/src/Skin.js
@@ -212,6 +212,9 @@ class Skin extends EventEmitter {
             this._emptyImageTexture = twgl.createTexture(gl, textureOptions);
         }
 
+        this._rotationCenter[0] = 0;
+        this._rotationCenter[1] = 0;
+
         this._silhouette.update(this._emptyImageData);
         this.emit(Skin.Events.WasAltered);
     }


### PR DESCRIPTION
### Resolves

Resolves #562 

### Proposed Changes

This PR adds logic in `Skin.setEmptyImageData` to set the `Skin`'s rotation center to `[0, 0]`.

### Reason for Changes

Both [`BitmapSkin`](https://github.com/LLK/scratch-render/blob/a28753fb5a901073f7b61c2ada7505d183cb2b83/src/BitmapSkin.js#L79) and [`SVGSkin`](https://github.com/LLK/scratch-render/blob/develop/src/SVGSkin.js#L164) have logic to call `setEmptyImageData` and return early if they are passed an image whose width or height are 0.

However, because of this early return, their rotation centers are never properly set, and so continue to use their previously set values. The first time you load a project, these will be initialized to `[0, 0]`, but when you, for instance, delete the contents of a previously non-empty costume, they will be set to the previous costume's rotation center. This causes the costume to be fenced in too far.

I'm directly setting the skin's `_rotationCenter` instead of calling `setRotationCenter` both to avoid emitting `Skin.Events.WasAltered` twice, and because [I plan to remove `setRotationCenter` eventually](https://github.com/LLK/scratch-vm/pull/2314).
