### PR TITLE
Move useNearest from Drawable to Skin

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -34,13 +34,6 @@ class BitmapSkin extends Skin {
     }
 
     /**
-     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
-     */
-    get isRaster () {
-        return true;
-    }
-
-    /**
      * @return {Array<number>} the "native" size, in texels, of this skin.
      */
     get size () {

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -490,40 +490,6 @@ class Drawable {
     }
 
     /**
-     * Should the drawable use NEAREST NEIGHBOR or LINEAR INTERPOLATION mode
-     * @param {?Array<Number>} scale Optionally, the screen-space scale of the drawable.
-     * @return {boolean} True if the drawable should use nearest-neighbor interpolation.
-     */
-    useNearest (scale = this.scale) {
-        // Raster skins (bitmaps) should always prefer nearest neighbor
-        if (this.skin.isRaster) {
-            return true;
-        }
-
-        // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
-        if ((this.enabledEffects & (
-            ShaderManager.EFFECT_INFO.fisheye.mask |
-            ShaderManager.EFFECT_INFO.whirl.mask |
-            ShaderManager.EFFECT_INFO.pixelate.mask |
-            ShaderManager.EFFECT_INFO.mosaic.mask
-        )) !== 0) {
-            return false;
-        }
-
-        // We can't use nearest neighbor unless we are a multiple of 90 rotation
-        if (this._direction % 90 !== 0) {
-            return false;
-        }
-
-        // If the scale of the skin is very close to 100 (0.99999 variance is okay I guess)
-        if (Math.abs(scale[0]) > 99 && Math.abs(scale[0]) < 101 &&
-            Math.abs(scale[1]) > 99 && Math.abs(scale[1]) < 101) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * Get the precise bounds for a Drawable.
      * This function applies the transform matrix to the known convex hull,
      * and then finds the minimum box along the axes.
@@ -660,7 +626,7 @@ class Drawable {
         if (this.skin) {
             this.skin.updateSilhouette(this._scale);
 
-            if (this.useNearest()) {
+            if (this.skin.useNearest(this._scale)) {
                 this.isTouching = this._isTouchingNearest;
             } else {
                 this.isTouching = this._isTouchingLinear;
@@ -734,10 +700,10 @@ class Drawable {
             dst[3] = 0;
             return dst;
         }
-        
+
         const textColor =
         // commenting out to only use nearest for now
-        // drawable.useNearest() ?
+        // drawable.skin.useNearest(drawable._scale) ?
              drawable.skin._silhouette.colorAtNearest(localPosition, dst);
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
 

--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -626,7 +626,7 @@ class Drawable {
         if (this.skin) {
             this.skin.updateSilhouette(this._scale);
 
-            if (this.skin.useNearest(this._scale)) {
+            if (this.skin.useNearest(this._scale, this)) {
                 this.isTouching = this._isTouchingNearest;
             } else {
                 this.isTouching = this._isTouchingLinear;
@@ -703,7 +703,7 @@ class Drawable {
 
         const textColor =
         // commenting out to only use nearest for now
-        // drawable.skin.useNearest(drawable._scale) ?
+        // drawable.skin.useNearest(drawable._scale, drawable) ?
              drawable.skin._silhouette.colorAtNearest(localPosition, dst);
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
 

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -152,17 +152,16 @@ class PenSkin extends Skin {
     }
 
     /**
-     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
-     */
-    get isRaster () {
-        return true;
-    }
-
-    /**
      * @return {Array<number>} the "native" size, in texels, of this skin. [width, height]
      */
     get size () {
         return [this._canvas.width, this._canvas.height];
+    }
+
+    useNearest (scale) {
+        // Use nearest-neighbor interpolation when scaling up the pen skin-- this matches Scratch 2.0.
+        // When scaling it down, use linear interpolation to avoid giving pen lines a "dashed" appearance.
+        return Math.max(scale[0], scale[1]) >= 100;
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1899,7 +1899,7 @@ class RenderWebGL extends EventEmitter {
 
             if (uniforms.u_skin) {
                 twgl.setTextureParameters(
-                    gl, uniforms.u_skin, {minMag: drawable.useNearest(drawableScale) ? gl.NEAREST : gl.LINEAR}
+                    gl, uniforms.u_skin, {minMag: drawable.skin.useNearest(drawableScale) ? gl.NEAREST : gl.LINEAR}
                 );
             }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1899,7 +1899,9 @@ class RenderWebGL extends EventEmitter {
 
             if (uniforms.u_skin) {
                 twgl.setTextureParameters(
-                    gl, uniforms.u_skin, {minMag: drawable.skin.useNearest(drawableScale) ? gl.NEAREST : gl.LINEAR}
+                    gl, uniforms.u_skin, {
+                        minMag: drawable.skin.useNearest(drawableScale, drawable) ? gl.NEAREST : gl.LINEAR
+                    }
                 );
             }
 

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -59,8 +59,6 @@ class SVGSkin extends Skin {
         return this._svgRenderer.size;
     }
 
-    // Because SVG skins' bounding boxes are currently not pixel-aligned, the idea here is to hide blurriness
-    // by using nearest-neighbor scaling if one screen-space pixel is "close enough" to one texture pixel.
     useNearest (scale) {
         // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
         if ((this.enabledEffects & (
@@ -77,8 +75,12 @@ class SVGSkin extends Skin {
             return false;
         }
 
+        // Because SVG skins' bounding boxes are currently not pixel-aligned, the idea here is to hide blurriness
+        // by using nearest-neighbor scaling if one screen-space pixel is "close enough" to one texture pixel.
         // If the scale of the skin is very close to 100 (0.99999 variance is okay I guess)
-        // TODO: Make this check more precise. Mipmaps complicate this somewhat.
+        // TODO: Make this check more precise. We should use nearest if there's less than one pixel's difference
+        // between the screen-space and texture-space sizes of the skin. Mipmaps make this harder because there are
+        // multiple textures (and hence multiple texture spaces) and we need to know which one to choose.
         if (Math.abs(scale[0]) > 99 && Math.abs(scale[0]) < 101 &&
             Math.abs(scale[1]) > 99 && Math.abs(scale[1]) < 101) {
             return true;

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -2,6 +2,7 @@ const twgl = require('twgl.js');
 
 const Skin = require('./Skin');
 const SvgRenderer = require('scratch-svg-renderer').SVGRenderer;
+const ShaderManager = require('./ShaderManager');
 
 const MAX_TEXTURE_DIMENSION = 2048;
 
@@ -56,6 +57,33 @@ class SVGSkin extends Skin {
      */
     get size () {
         return this._svgRenderer.size;
+    }
+
+    // Because SVG skins' bounding boxes are currently not pixel-aligned, the idea here is to hide blurriness
+    // by using nearest-neighbor scaling if one screen-space pixel is "close enough" to one texture pixel.
+    useNearest (scale) {
+        // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
+        if ((this.enabledEffects & (
+            ShaderManager.EFFECT_INFO.fisheye.mask |
+            ShaderManager.EFFECT_INFO.whirl.mask |
+            ShaderManager.EFFECT_INFO.pixelate.mask |
+            ShaderManager.EFFECT_INFO.mosaic.mask
+        )) !== 0) {
+            return false;
+        }
+
+        // We can't use nearest neighbor unless we are a multiple of 90 rotation
+        if (this._direction % 90 !== 0) {
+            return false;
+        }
+
+        // If the scale of the skin is very close to 100 (0.99999 variance is okay I guess)
+        // TODO: Make this check more precise. Mipmaps complicate this somewhat.
+        if (Math.abs(scale[0]) > 99 && Math.abs(scale[0]) < 101 &&
+            Math.abs(scale[1]) > 99 && Math.abs(scale[1]) < 101) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -59,9 +59,9 @@ class SVGSkin extends Skin {
         return this._svgRenderer.size;
     }
 
-    useNearest (scale) {
+    useNearest (scale, drawable) {
         // If the effect bits for mosaic, pixelate, whirl, or fisheye are set, use linear
-        if ((this.enabledEffects & (
+        if ((drawable.enabledEffects & (
             ShaderManager.EFFECT_INFO.fisheye.mask |
             ShaderManager.EFFECT_INFO.whirl.mask |
             ShaderManager.EFFECT_INFO.pixelate.mask |
@@ -71,7 +71,7 @@ class SVGSkin extends Skin {
         }
 
         // We can't use nearest neighbor unless we are a multiple of 90 rotation
-        if (this._direction % 90 !== 0) {
+        if (drawable._direction % 90 !== 0) {
             return false;
         }
 

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -60,13 +60,6 @@ class Skin extends EventEmitter {
     }
 
     /**
-     * @returns {boolean} true for a raster-style skin (like a BitmapSkin), false for vector-style (like SVGSkin).
-     */
-    get isRaster () {
-        return false;
-    }
-
-    /**
      * @return {int} the unique ID for this Skin.
      */
     get id () {
@@ -86,6 +79,18 @@ class Skin extends EventEmitter {
      */
     get size () {
         return [0, 0];
+    }
+
+    /**
+     * Should this skin's texture be filtered with nearest-neighbor or linear interpolation at the given scale?
+     * @param {?Array<Number>} scale The screen-space X and Y scaling factors at which this skin's texture will be
+     * displayed, as percentages (100 means 1 "native size" unit is 1 screen pixel; 200 means 2 screen pixels, etc).
+     * @return {boolean} True if this skin's texture, as returned by {@link getTexture}, should be filtered with
+     * nearest-neighbor interpolation.
+     */
+    // eslint-disable-next-line no-unused-vars
+    useNearest (scale) {
+        return true;
     }
 
     /**

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -85,11 +85,12 @@ class Skin extends EventEmitter {
      * Should this skin's texture be filtered with nearest-neighbor or linear interpolation at the given scale?
      * @param {?Array<Number>} scale The screen-space X and Y scaling factors at which this skin's texture will be
      * displayed, as percentages (100 means 1 "native size" unit is 1 screen pixel; 200 means 2 screen pixels, etc).
+     * @param {Drawable} drawable The drawable that this skin's texture will be applied to.
      * @return {boolean} True if this skin's texture, as returned by {@link getTexture}, should be filtered with
      * nearest-neighbor interpolation.
      */
     // eslint-disable-next-line no-unused-vars
-    useNearest (scale) {
+    useNearest (scale, drawable) {
         return true;
     }
 


### PR DESCRIPTION
## This PR depends on #555

### Resolves

Resolves #565 

### Proposed Changes

This PR moves the `useNearest` method from the `Drawable` class to the `Skin` class. The default behavior is to always use nearest-neighbor interpolation, but `Skin` subclasses can override the method to provide their own behavior, and two currently do:
- `SVGSkin.useNearest` has absorbed the complex logic previously present in `Drawable.useNearest` (checking if certain effects are set, the sprite is rotated, and the scale is close to 100%).
- `PenSkin.useNearest` will use nearest-neighbor interpolation when being scaled up, and linear interpolation when being scaled down. This prevents pen lines from appearing "dashed" when a `PenSkin` is displayed at <100% scale.

### Reason for Changes

I believe this is the clearest way to implement the desired interpolation behavior for `PenSkin`s.

Since textures belong to a `Skin`, it makes sense that deciding the proper way to interpolate a texture should be the responsibility of that `Skin`.