### PR TITLE
Add extractDrawableScreenSpace method

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1242,7 +1242,8 @@ class RenderWebGL extends EventEmitter {
 
             gl.clearColor(0, 0, 0, 0);
             gl.clear(gl.COLOR_BUFFER_BIT);
-            this._drawThese([drawableID], ShaderManager.DRAW_MODE.straightAlpha, projection);
+            this._drawThese([drawableID], ShaderManager.DRAW_MODE.straightAlpha, projection,
+                {effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask});
 
             const data = new Uint8Array(Math.floor(clampedWidth * clampedHeight * 4));
             gl.readPixels(0, 0, clampedWidth, clampedHeight, gl.RGBA, gl.UNSIGNED_BYTE, data);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -44,6 +44,12 @@ const MAX_TOUCH_SIZE = [3, 3];
 const MASK_TOUCHING_COLOR_TOLERANCE = 2;
 
 /**
+ * Maximum number of pixels in either dimension of "extracted drawable" data
+ * @type {int}
+ */
+const MAX_EXTRACTED_DRAWABLE_DIMENSION = 2048;
+
+/**
  * Determines if the mask color is "close enough" (only test the 6 top bits for
  * each color).  These bit masks are what scratch 2 used to use, so we do the same.
  * @param {Uint8Array} a A color3b or color4b value.
@@ -1061,7 +1067,7 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
-     * @typedef DrawableExtraction
+     * @typedef DrawableExtractionOld
      * @property {Uint8Array} data Raw pixel data for the drawable
      * @property {int} width Drawable bounding box width
      * @property {int} height Drawable bounding box height
@@ -1076,7 +1082,8 @@ class RenderWebGL extends EventEmitter {
      * @param {int} drawableID The ID of the drawable to get pixel data for
      * @param {int} x The client x coordinate of the picking location.
      * @param {int} y The client y coordinate of the picking location.
-     * @return {?DrawableExtraction} Data about the picked drawable
+     * @return {?DrawableExtractionOld} Data about the picked drawable
+     * @deprecated Use {@link extractDrawableScreenSpace} instead.
      */
     extractDrawable (drawableID, x, y) {
         this._doExitDrawRegion();
@@ -1161,6 +1168,103 @@ class RenderWebGL extends EventEmitter {
             x: pickX,
             y: pickY
         };
+    }
+
+    /**
+     * @typedef DrawableExtraction
+     * @property {ImageData} data Raw pixel data for the drawable
+     * @property {number} x The x coordinate of the drawable's bounding box's top-left corner, in 'CSS pixels'
+     * @property {number} y The y coordinate of the drawable's bounding box's top-left corner, in 'CSS pixels'
+     * @property {number} width The drawable's bounding box width, in 'CSS pixels'
+     * @property {number} height The drawable's bounding box height, in 'CSS pixels'
+     */
+
+    /**
+     * Return a drawable's pixel data and bounds in screen space.
+     * @param {int} drawableID The ID of the drawable to get pixel data for
+     * @return {DrawableExtraction} Data about the picked drawable
+     */
+    extractDrawableScreenSpace (drawableID) {
+        const drawable = this._allDrawables[drawableID];
+        if (!drawable) throw new Error(`Could not extract drawable with ID ${drawableID}; it does not exist`);
+
+        this._doExitDrawRegion();
+
+        const nativeCenterX = this._nativeSize[0] * 0.5;
+        const nativeCenterY = this._nativeSize[1] * 0.5;
+
+        const scratchBounds = drawable.getFastBounds();
+
+        const canvas = this.canvas;
+        const scaleFactor = canvas.width / this._nativeSize[0];
+
+        const canvasSpaceBounds = new Rectangle();
+        canvasSpaceBounds.initFromBounds(
+            (scratchBounds.left + nativeCenterX) * scaleFactor,
+            (scratchBounds.right + nativeCenterX) * scaleFactor,
+            // in "canvas space", +y is down, but Rectangle methods assume bottom < top, so swap them
+            (nativeCenterY - scratchBounds.top) * scaleFactor,
+            (nativeCenterY - scratchBounds.bottom) * scaleFactor
+        );
+        canvasSpaceBounds.snapToInt();
+
+        // undo the transformation to transform the bounds, snapped to "canvas-pixel space", back to "Scratch space"
+        scratchBounds.initFromBounds(
+            (canvasSpaceBounds.left / scaleFactor) - nativeCenterX,
+            (canvasSpaceBounds.right / scaleFactor) - nativeCenterX,
+            nativeCenterY - (canvasSpaceBounds.top / scaleFactor),
+            nativeCenterY - (canvasSpaceBounds.bottom / scaleFactor)
+        );
+
+        const gl = this._gl;
+
+        // Set a reasonable max limit width and height for the bufferInfo bounds
+        const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+        const clampedWidth = Math.min(MAX_EXTRACTED_DRAWABLE_DIMENSION, canvasSpaceBounds.width, maxTextureSize);
+        const clampedHeight = Math.min(MAX_EXTRACTED_DRAWABLE_DIMENSION, canvasSpaceBounds.height, maxTextureSize);
+
+        // Make a new bufferInfo since this._queryBufferInfo is limited to 480x360
+        const bufferInfo = twgl.createFramebufferInfo(gl, [{format: gl.RGBA}], clampedWidth, clampedHeight);
+
+        try {
+            twgl.bindFramebufferInfo(gl, bufferInfo);
+
+            // Limit size of viewport to the bounds around the target Drawable,
+            // and create the projection matrix for the draw.
+            gl.viewport(0, 0, clampedWidth, clampedHeight);
+            const projection = twgl.m4.ortho(
+                scratchBounds.left,
+                scratchBounds.right,
+                scratchBounds.top,
+                scratchBounds.bottom,
+                -1, 1
+            );
+
+            gl.clearColor(0, 0, 0, 0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+            this._drawThese([drawableID], ShaderManager.DRAW_MODE.straightAlpha, projection);
+
+            const data = new Uint8Array(Math.floor(clampedWidth * clampedHeight * 4));
+            gl.readPixels(0, 0, clampedWidth, clampedHeight, gl.RGBA, gl.UNSIGNED_BYTE, data);
+            // readPixels can only read into a Uint8Array, but ImageData has to take a Uint8ClampedArray.
+            // We can share the same underlying buffer between them to avoid having to copy any data.
+            const imageData = new ImageData(new Uint8ClampedArray(data.buffer), clampedWidth, clampedHeight);
+
+            // On high-DPI devices, the canvas' width (in canvas pixels) will be larger than its width in CSS pixels.
+            // We want to return the CSS-space bounds,
+            // so take into account the ratio between the canvas' pixel dimensions and its layout dimensions.
+            const ratio = canvas.getBoundingClientRect().width / canvas.width;
+
+            return {
+                imageData,
+                x: canvasSpaceBounds.left * ratio,
+                y: canvasSpaceBounds.bottom * ratio,
+                width: canvasSpaceBounds.width * ratio,
+                height: canvasSpaceBounds.height * ratio
+            };
+        } finally {
+            gl.deleteFramebuffer(bufferInfo.framebuffer);
+        }
     }
 
     /**


### PR DESCRIPTION
~~This PR depends on #556~~ (merged now)

### Resolves

A step towards resolving https://github.com/LLK/scratch-render/issues/294, https://github.com/LLK/scratch-gui/issues/2388, https://github.com/LLK/scratch-gui/issues/1782, https://github.com/LLK/scratch-gui/issues/1894

### Proposed Changes

This PR deprecates `RenderWebGL.extractDrawable` in favor of a new method, `RenderWebGL.extractDrawableScreenSpace`. This new method differs in several ways:
- Most obviously, it functions in screen-space: it draws the drawable pixels at the same resolution as the regular canvas.
- It returns `ImageData` instead of a `Uint8Array`-- since this method is only used in the GUI once, that call site creates an `ImageData` from the result anyway, and we need to return the data's width and height somehow, it makes sense to just return an `ImageData` which has its width and height built in.
- It does not take `x` and `y` parameters--the math it did with those can be moved entirely to the GUI.
- It explicitly throws an error when the corresponding drawable for the passed `drawableID` does not exist. Previously it returned `null` and this was not handled by the GUI. An explicit error should result in a much more friendly and searchable error message if this function ever fails in the future.
- It does not add depth or stencil attachments to the framebuffer it creates.
- It deletes the framebuffer it creates, preventing memory leaks.
- ~~It applies the ghost effect to the extracted drawable, like 2.0 did when dragging sprites (this is why this PR depends on #556 -- ghosted sprites will appear too dark if the alpha is not properly un-premultiplied).~~ saving this for another day
- The one I'm the least sure about: ~~it doesn't attempt to handle WebGL operations failing/erroring out in various ways that may or may not be handled throughout the rest of the codebase. I'd be hesitant to attempt to add error-handling code for errors I cannot reproduce or trigger in some ways, but I'd like your opinions and reasoning behind why the previous `extractDrawable` handled errors the way it did.~~ I've added a `finally` clause that ensures that the created framebuffer is always deleted. I haven't added a fallback to `queryBufferInfo` just in case the created framebuffer is incomplete-- under what circumstances does that occur?

### Reason for Changes

These changes are a step towards resolving several sprite-dragging bugs.