### PR TITLE
Fix setRotationCenter empty skin detection

### DIFF
--- a/src/Skin.js
+++ b/src/Skin.js
@@ -108,7 +108,7 @@ class Skin extends EventEmitter {
      * @fires Skin.event:WasAltered
      */
     setRotationCenter (x, y) {
-        const emptySkin = this.size[0] === 0 && this.size[1] === 0;
+        const emptySkin = this.size[0] === 0 || this.size[1] === 0;
         // Compare a 32 bit x and y value against the stored 32 bit center
         // values.
         const changed = (


### PR DESCRIPTION
### Resolves

Resolves #571

### Proposed Changes

This PR changes `setRotationCenter`'s empty skin check to return true if either of the skin's dimensions are 0, whereas previously it only returned true if both were.

### Reason for Changes

`SVGSkin.setSVG` and `BitmapSkin.setBitmap` treat a skin as "empty" if *either* of its dimensions are 0. `setRotationCenter` did not, and because the VM calls `setRotationCenter` upon every costume switch, a costume with zero width *or* zero height (but not both) would have its rotation center improperly set.