### PR TITLE
Don't apply ghost effect to "color is touching color" drawable

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -679,9 +679,10 @@ class Drawable {
      * @param {twgl.v3} vec The scratch space [x,y] vector
      * @param {Drawable} drawable The drawable to sample the texture from
      * @param {Uint8ClampedArray} dst The "color4b" representation of the texture at point.
+     * @param {number} [effectMask] A bitmask for which effects to use. Optional.
      * @returns {Uint8ClampedArray} The dst object filled with the color4b
      */
-    static sampleColor4b (vec, drawable, dst) {
+    static sampleColor4b (vec, drawable, dst, effectMask) {
         const localPosition = getLocalPosition(drawable, vec);
         if (localPosition[0] < 0 || localPosition[1] < 0 ||
             localPosition[0] > 1 || localPosition[1] > 1) {
@@ -698,7 +699,7 @@ class Drawable {
         // : drawable.skin._silhouette.colorAtLinear(localPosition, dst);
 
         if (drawable.enabledEffects === 0) return textColor;
-        return EffectTransform.transformColor(drawable, textColor);
+        return EffectTransform.transformColor(drawable, textColor, effectMask);
     }
 }
 

--- a/src/EffectTransform.js
+++ b/src/EffectTransform.js
@@ -118,16 +118,17 @@ class EffectTransform {
      * Ghost and Color and Brightness effects.
      * @param {Drawable} drawable The drawable to get uniforms from.
      * @param {Uint8ClampedArray} inOutColor The color to transform.
+     * @param {number} [effectMask] A bitmask for which effects to use. Optional.
      * @returns {Uint8ClampedArray} dst filled with the transformed color
      */
-    static transformColor (drawable, inOutColor) {
-
+    static transformColor (drawable, inOutColor, effectMask) {
         // If the color is fully transparent, don't bother attempting any transformations.
         if (inOutColor[3] === 0) {
             return inOutColor;
         }
 
-        const effects = drawable.enabledEffects;
+        let effects = drawable.enabledEffects;
+        if (typeof effectMask === 'number') effects &= effectMask;
         const uniforms = drawable.getUniforms();
 
         const enableColor = (effects & ShaderManager.EFFECT_INFO.color.mask) !== 0;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -763,6 +763,9 @@ class RenderWebGL extends EventEmitter {
         const color = __touchingColor;
         const hasMask = Boolean(mask3b);
 
+        // "touching color" ignores ghost effect
+        const effectMask = ~ShaderManager.EFFECT_INFO.ghost.mask;
+
         // Scratch Space - +y is top
         for (let y = bounds.bottom; y <= bounds.top; y++) {
             if (bounds.width * (y - bounds.bottom) * (candidates.length + 1) >= maxPixelsForCPU) {
@@ -773,7 +776,7 @@ class RenderWebGL extends EventEmitter {
                 point[0] = x;
                 // if we use a mask, check our sample color...
                 if (hasMask ?
-                    maskMatches(Drawable.sampleColor4b(point, drawable, color), mask3b) :
+                    maskMatches(Drawable.sampleColor4b(point, drawable, color, effectMask), mask3b) :
                     drawable.isTouching(point)) {
                     RenderWebGL.sampleColor3b(point, candidates, color);
                     if (debugCanvasContext) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -763,7 +763,7 @@ class RenderWebGL extends EventEmitter {
         const color = __touchingColor;
         const hasMask = Boolean(mask3b);
 
-        // "touching color" ignores ghost effect
+        // Masked drawable ignores ghost effect
         const effectMask = ~ShaderManager.EFFECT_INFO.ghost.mask;
 
         // Scratch Space - +y is top


### PR DESCRIPTION
### Resolves

Resolves #575

### Proposed Changes

This PR re-adds the `effectMask` parameter to `sampleColor4b` and `transformColor`, and uses it to mask out the ghost effect for the target drawable of `isTouchingColor`.

### Reason for Changes

#515 made it so that the ghost effect multiplies all color channels by the ghost effect, not just the alpha value. Because of this, if the ghost effect is applied to a drawable, its colors will change, making the color mask invalid.

This was already fixed on the GPU path (which is why the tests pass), but I overlooked it for the CPU path.

### Test Coverage

Waiting on #537 for CPU/GPU parity tests