### PR TITLE
Remove setRotationCenter API

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -98,7 +98,8 @@ class BitmapSkin extends Skin {
         this._textureSize = BitmapSkin._getBitmapSize(bitmapData);
 
         if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
-        this.setRotationCenter.apply(this, rotationCenter);
+        this._rotationCenter[0] = rotationCenter[0];
+        this._rotationCenter[1] = rotationCenter[1];
 
         this.emit(Skin.Events.WasAltered);
     }

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1338,32 +1338,6 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
-     * Update a drawable's skin rotation center.
-     * @param {number} drawableID The drawable's id.
-     * @param {Array.<number>} rotationCenter The rotation center for the skin.
-     */
-    updateDrawableRotationCenter (drawableID, rotationCenter) {
-        const drawable = this._allDrawables[drawableID];
-        // TODO: https://github.com/LLK/scratch-vm/issues/2288
-        if (!drawable) return;
-        drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
-    }
-
-    /**
-     * Update a drawable's skin and rotation center together.
-     * @param {number} drawableID The drawable's id.
-     * @param {number} skinId The skin to update to.
-     * @param {Array.<number>} rotationCenter The rotation center for the skin.
-     */
-    updateDrawableSkinIdRotationCenter (drawableID, skinId, rotationCenter) {
-        const drawable = this._allDrawables[drawableID];
-        // TODO: https://github.com/LLK/scratch-vm/issues/2288
-        if (!drawable) return;
-        drawable.skin = this._allSkins[skinId];
-        drawable.skin.setRotationCenter(rotationCenter[0], rotationCenter[1]);
-    }
-
-    /**
      * Update a drawable's position.
      * @param {number} drawableID The drawable's id.
      * @param {Array.<number>} position The new position.
@@ -1455,9 +1429,6 @@ class RenderWebGL extends EventEmitter {
         }
         if ('skinId' in properties) {
             this.updateDrawableSkinId(drawableID, properties.skinId);
-        }
-        if ('rotationCenter' in properties) {
-            this.updateDrawableRotationCenter(drawableID, properties.rotationCenter);
         }
         drawable.updateProperties(properties);
     }

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -59,16 +59,6 @@ class SVGSkin extends Skin {
     }
 
     /**
-     * Set the origin, in object space, about which this Skin should rotate.
-     * @param {number} x - The x coordinate of the new rotation center.
-     * @param {number} y - The y coordinate of the new rotation center.
-     */
-    setRotationCenter (x, y) {
-        const viewOffset = this._svgRenderer.viewOffset;
-        super.setRotationCenter(x - viewOffset[0], y - viewOffset[1]);
-    }
-
-    /**
      * Create a MIP for a given scale.
      * @param {number} scale - The relative size of the MIP
      * @return {SVGMIP} An object that handles creating and updating SVG textures.
@@ -174,7 +164,10 @@ class SVGSkin extends Skin {
             this.resetMIPs();
 
             if (typeof rotationCenter === 'undefined') rotationCenter = this.calculateRotationCenter();
-            this.setRotationCenter.apply(this, rotationCenter);
+            const viewOffset = this._svgRenderer.viewOffset;
+            this._rotationCenter[0] = rotationCenter[0] - viewOffset[0];
+            this._rotationCenter[1] = rotationCenter[1] - viewOffset[1];
+
             this.emit(Skin.Events.WasAltered);
         });
     }

--- a/src/Skin.js
+++ b/src/Skin.js
@@ -5,19 +5,6 @@ const twgl = require('twgl.js');
 const RenderConstants = require('./RenderConstants');
 const Silhouette = require('./Silhouette');
 
-/**
- * Truncate a number into what could be stored in a 32 bit floating point value.
- * @param {number} num Number to truncate.
- * @return {number} Truncated value.
- */
-const toFloat32 = (function () {
-    const memory = new Float32Array(1);
-    return function (num) {
-        memory[0] = num;
-        return memory[0];
-    };
-}());
-
 class Skin extends EventEmitter {
     /**
      * Create a Skin, which stores and/or generates textures for use in rendering.
@@ -99,26 +86,6 @@ class Skin extends EventEmitter {
      */
     get size () {
         return [0, 0];
-    }
-
-    /**
-     * Set the origin, in object space, about which this Skin should rotate.
-     * @param {number} x - The x coordinate of the new rotation center.
-     * @param {number} y - The y coordinate of the new rotation center.
-     * @fires Skin.event:WasAltered
-     */
-    setRotationCenter (x, y) {
-        const emptySkin = this.size[0] === 0 && this.size[1] === 0;
-        // Compare a 32 bit x and y value against the stored 32 bit center
-        // values.
-        const changed = (
-            toFloat32(x) !== this._rotationCenter[0] ||
-            toFloat32(y) !== this._rotationCenter[1]);
-        if (!emptySkin && changed) {
-            this._rotationCenter[0] = x;
-            this._rotationCenter[1] = y;
-            this.emit(Skin.Events.WasAltered);
-        }
     }
 
     /**

--- a/test/fixtures/MockSkin.js
+++ b/test/fixtures/MockSkin.js
@@ -8,6 +8,16 @@ class MockSkin extends Skin {
     get size () {
         return this.dimensions || [0, 0];
     }
+
+    set rotationCenter (center) {
+        this._rotationCenter[0] = center[0];
+        this._rotationCenter[1] = center[1];
+        this.emit(Skin.Events.WasAltered);
+    }
+
+    get rotationCenter () {
+        return this._rotationCenter;
+    }
 }
 
 module.exports = MockSkin;

--- a/test/unit/DrawableTests.js
+++ b/test/unit/DrawableTests.js
@@ -48,11 +48,11 @@ test('translate by costume center', t => {
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
 
-    drawable.skin.setRotationCenter(1, 0);
+    drawable.skin.rotationCenter = [1, 0];
     expected.initFromBounds(-1, 199, -50, 0);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.skin.setRotationCenter(0, -2);
+    drawable.skin.rotationCenter = [0, -2];
     expected.initFromBounds(0, 200, -52, -2);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
@@ -73,7 +73,7 @@ test('translate and rotate', t => {
     expected.initFromBounds(-49, 1, -198, 2);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.skin.setRotationCenter(100, 25);
+    drawable.skin.rotationCenter = [100, 25];
     drawable.updateProperties({direction: 270, position: [0, 0]});
     expected.initFromBounds(-100, 100, -25, 25);
     t.same(snapToNearest(drawable.getAABB()), expected);
@@ -89,7 +89,7 @@ test('rotate by non-right-angles', t => {
     const drawable = new Drawable();
     drawable.skin = new MockSkin();
     drawable.skin.size = [10, 10];
-    drawable.skin.setRotationCenter(5, 5);
+    drawable.skin.rotationCenter = [5, 5];
 
     expected.initFromBounds(-5, 5, -5, 5);
     t.same(snapToNearest(drawable.getAABB()), expected);
@@ -111,11 +111,11 @@ test('scale', t => {
     expected.initFromBounds(0, 200, -25, 0);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.skin.setRotationCenter(0, 25);
+    drawable.skin.rotationCenter = [0, 25];
     expected.initFromBounds(0, 200, -12.5, 12.5);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.skin.setRotationCenter(150, 50);
+    drawable.skin.rotationCenter = [150, 50];
     drawable.updateProperties({scale: [50, 50]});
     expected.initFromBounds(-75, 25, 0, 25);
     t.same(snapToNearest(drawable.getAABB()), expected);
@@ -129,12 +129,12 @@ test('rotate and scale', t => {
     drawable.skin = new MockSkin();
     drawable.skin.size = [100, 1000];
 
-    drawable.skin.setRotationCenter(50, 50);
+    drawable.skin.rotationCenter = [50, 50];
     expected.initFromBounds(-50, 50, -950, 50);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
     drawable.updateProperties({scale: [40, 60]});
-    drawable.skin.setRotationCenter(50, 50);
+    drawable.skin.rotationCenter = [50, 50];
     expected.initFromBounds(-20, 20, -570, 30);
     t.same(snapToNearest(drawable.getAABB()), expected);
 


### PR DESCRIPTION
### Resolves

A step on the long-ish path towards fixing #550
Also a step towards fixing #570

### Proposed Changes

This PR removes the API for setting a drawable's rotation center and the `Skin.setRotationCenter` function.

It does *not* remove the API for setting a skin's rotation center when setting its contents.

To fix unit tests which previously called `Skin.setRotationCenter`, it also adds a `rotationCenter` setter (plus corresponding getter) to `MockSkin`, which the unit tests now use.

I'm not expecting this to be merged right away--in case https://github.com/LLK/scratch-vm/pull/2314 causes any regressions in the near future, it'll probably be beneficial to be able to revert that without having to re-add the rotation center API here as well.

### Reason for Changes

In order to fix (no, GitHub, it doesn't close) #550, vector costumes' SVG viewboxes must depend on their rotation centers. Every time the viewbox of an SVG is set, its `<img>` must be updated as well, which is a fundamentally asynchronous operation.

As such, a synchronous API for setting a skin's rotation center after the skin is loaded is incompatible with the changes necessary for #550.

With https://github.com/LLK/scratch-vm/pull/2314 merged, that synchronous API is no longer used and can be removed.
