### PR TITLE
Update drawables' matrix + silhouette in _getConvexHullPointsForDrawable

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1762,6 +1762,10 @@ class RenderWebGL extends EventEmitter {
      */
     _getConvexHullPointsForDrawable (drawableID) {
         const drawable = this._allDrawables[drawableID];
+
+        drawable.updateMatrix();
+        drawable.skin.updateSilhouette(this._getDrawableScreenSpaceScale(drawable));
+
         const [width, height] = drawable.skin.size;
         // No points in the hull if invisible or size is 0.
         if (!drawable.getVisible() || width === 0 || height === 0) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/5647
Resolves #546

### Proposed Changes

This PR adds calls to `updateMatrix` and `updateSilhouette` inside `RenderWebGL._getConvexHullPointsForDrawable`.

### Reason for Changes

Text bubbles are positioned according to the convex hull of their sprite's current costume/skin. Generating convex hulls requires the sprite's drawable to have an up-to-date inverse matrix and its skin to have an up-to-date silhouette.

If those attributes are not up-to-date, the convex hull will not be properly generated, and speech bubbles will be incorrectly positioned. See also https://github.com/LLK/scratch-gui/issues/4344 for a previous instance of this happening.

These changes are also included in #555, but that PR is much larger in scope so it may be easier to review this one.