### PR TITLE
Call draw() after resizing canvas

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -223,6 +223,8 @@ class RenderWebGL extends EventEmitter {
         const pixelRatio = window.devicePixelRatio || 1;
         this._gl.canvas.width = pixelsWide * pixelRatio;
         this._gl.canvas.height = pixelsTall * pixelRatio;
+        // Resizing the canvas can cause it to be cleared, so redraw it.
+        this.draw();
     }
 
     /**

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -220,11 +220,20 @@ class RenderWebGL extends EventEmitter {
      * @param {int} pixelsTall The desired height in device-independent pixels.
      */
     resize (pixelsWide, pixelsTall) {
+        const {canvas} = this._gl;
         const pixelRatio = window.devicePixelRatio || 1;
-        this._gl.canvas.width = pixelsWide * pixelRatio;
-        this._gl.canvas.height = pixelsTall * pixelRatio;
-        // Resizing the canvas can cause it to be cleared, so redraw it.
-        this.draw();
+        const newWidth = pixelsWide * pixelRatio;
+        const newHeight = pixelsTall * pixelRatio;
+
+        // Certain operations, such as moving the color picker, call `resize` once per frame, even though the canvas
+        // size doesn't change. To avoid unnecessary canvas updates, check that we *really* need to resize the canvas.
+        if (canvas.width !== newWidth || canvas.height !== newHeight) {
+            canvas.width = newWidth;
+            canvas.height = newHeight;
+            // Resizing the canvas causes it to be cleared, so redraw it.
+            this.draw();
+        }
+
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratch-gui/issues/5678

### Proposed Changes

This PR calls `RenderWebGL.draw` in `RenderWebGL.resize` after resizing the canvas.

### Reason for Changes

When the color picker is active, [`stage.jsx`'s `componentDidUpdate` is called once per frame, which itself calls `RenderWebGL.resize`](https://github.com/LLK/scratch-gui/blob/develop/src/containers/stage.jsx#L97). This clears the canvas once per frame, causing rapid flickering. To avoid this, always redraw the canvas after resizing it.

An alternative would be to [set `preserveDrawingBuffer: true` in the context creation attributes](https://github.com/LLK/scratch-render/blob/develop/src/RenderWebGL.js#L108) but this seems to better solve the root issue (a one-frame delay between a canvas resize and a redraw).