### PR TITLE
Tweak pen shader to avoid float precision issues

### DIFF
--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -214,7 +214,7 @@ void main()
 	// Un-premultiply alpha.
 	gl_FragColor.rgb /= gl_FragColor.a + epsilon;
 	#endif
-  
+
 	#else // DRAW_MODE_line
 	// Maaaaagic antialiased-line-with-round-caps shader.
 	// Adapted from Inigo Quilez' 2D distance function cheat sheet
@@ -223,9 +223,14 @@ void main()
 	// The xy component of u_penPoints is the first point; the zw is the second point.
 	// This is done to minimize the number of gl.uniform calls, which can add up.
 	vec2 pa = v_texCoord - u_penPoints.xy, ba = u_penPoints.zw - u_penPoints.xy;
+
+	// Avoid division by zero
+	float baDot = dot(ba, ba);
+	baDot = (abs(baDot) < epsilon) ? epsilon : baDot;
+
 	// Magnitude of vector projection of this fragment onto the line (both relative to the line's start point).
 	// This results in a "linear gradient" which goes from 0.0 at the start point to 1.0 at the end point.
-	float projMagnitude = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+	float projMagnitude = clamp(dot(pa, ba) / baDot, 0.0, 1.0);
 
 	float lineDistance = length(pa - (ba * projMagnitude));
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -234,7 +234,8 @@ void main()
 
 	// Avoid division by zero
 	float baDot = dot(ba, ba);
-	baDot = (abs(baDot) < epsilon) ? epsilon : baDot;
+	// the dot product of a vector and itself is always positive
+	baDot = max(baDot, epsilon);
 
 	// Magnitude of vector projection of this fragment onto the line (both relative to the line's start point).
 	// This results in a "linear gradient" which goes from 0.0 at the start point to 1.0 at the end point.

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -42,7 +42,10 @@ void main() {
 	// Rotate quad to line angle
 	vec2 pointDiff = u_penPoints.zw - u_penPoints.xy;
 	// Ensure line has a nonzero length so it's rendered properly
+	// As long as either component is nonzero, the line length will be nonzero
 	pointDiff.x = abs(pointDiff.x) < epsilon ? epsilon : pointDiff.x;
+	// The `normalized` vector holds rotational values equivalent to sine/cosine
+	// We're applying the standard rotation matrix formula to the position to rotate the quad to the line angle
 	vec2 normalized = pointDiff / max(lineLength, epsilon);
 	position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
 	// Translate quad

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -40,7 +40,10 @@ void main() {
 	position -= expandedRadius;
 
 	// Rotate quad to line angle
-	vec2 normalized = (u_penPoints.zw - u_penPoints.xy + epsilon) / (lineLength + epsilon);
+	vec2 pointDiff = u_penPoints.zw - u_penPoints.xy;
+	// Ensure line has a nonzero length so it's rendered properly
+	pointDiff.x = abs(pointDiff.x) < epsilon ? epsilon : pointDiff.x;
+	vec2 normalized = pointDiff / max(lineLength, epsilon);
 	position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
 	// Translate quad
 	position += u_penPoints.xy;


### PR DESCRIPTION
### Resolves

Resolves #589
Resolves #595

### Proposed Changes

This PR tweaks the "epsilon" logic used in the shaders to avoid numerical instability and division by zero on low-precision hardware.

### Reason for Changes

~~If you revert #586, the commit message will be dangerously long~~

iOS Safari treats "medium precision" as much lower precision than other browsers, causing some of the pen line formulas to bug out and pen dots to not be drawn. This PR tweaks those formulas to avoid such numerical issues.

As a nice side effect, pen dots' quads will now be rectangular rather than diamond-shaped, which may provide a very slight speed boost.

There's another issue on some??? GPUs where certain calculations in the line shader could overflow the floating-point range if the lines are long enough. I confirmed this on a OnePlus 6T with an Adreno 630 GPU, and someone else reported this on an ARM Chromebook on the Bugs and Glitches forum; not sure where else it may occur.

### Test Coverage

Right now there's no way to test shaders across different hardware. It might be a good idea to look into whether that can be done.

I've manually tested this on an iPhone that was buggy before, and it fixes the issue.
