### PR TITLE
Rewrite the pen line shader to be more numerically stable

### DIFF
--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -36,6 +36,7 @@ uniform float u_ghost;
 #ifdef DRAW_MODE_line
 uniform vec4 u_lineColor;
 uniform float u_lineThickness;
+uniform float u_lineLength;
 uniform vec4 u_penPoints;
 #endif // DRAW_MODE_line
 
@@ -218,12 +219,10 @@ void main()
 	#else // DRAW_MODE_line
 	// Maaaaagic antialiased-line-with-round-caps shader.
 
-	float lineLength = length(u_penPoints.zw - u_penPoints.xy);
-
 	// "along-the-lineness". This increases parallel to the line.
 	// It goes from negative before the start point, to 0.5 through the start to the end, then ramps up again
 	// past the end point.
-	float d = ((v_texCoord.x - clamp(v_texCoord.x, 0.0, lineLength)) * 0.5) + 0.5;
+	float d = ((v_texCoord.x - clamp(v_texCoord.x, 0.0, u_lineLength)) * 0.5) + 0.5;
 
 	// Distance from (0.5, 0.5) to (d, the perpendicular coordinate). When we're in the middle of the line,
 	// d will be 0.5, so the distance will be 0 at points close to the line and will grow at points further from it.

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -3,6 +3,7 @@ precision mediump float;
 #ifdef DRAW_MODE_line
 uniform vec2 u_stageSize;
 uniform float u_lineThickness;
+uniform float u_lineLength;
 uniform vec4 u_penPoints;
 
 // Add this to divisors to prevent division by 0, which results in NaNs propagating through calculations.
@@ -31,15 +32,13 @@ void main() {
 	vec2 position = a_position;
 	float expandedRadius = (u_lineThickness * 0.5) + 1.4142135623730951;
 
-	float lineLength = length(u_penPoints.zw - u_penPoints.xy);
-
 	// The X coordinate increases along the length of the line. It's 0 at the center of the origin point
 	// and is in pixel-space (so at n pixels along the line, its value is n).
-	v_texCoord.x = mix(0.0, lineLength + (expandedRadius * 2.0), a_position.x) - expandedRadius;
+	v_texCoord.x = mix(0.0, u_lineLength + (expandedRadius * 2.0), a_position.x) - expandedRadius;
 	// The Y coordinate is perpendicular to the line. It's also in pixel-space.
 	v_texCoord.y = ((a_position.y - 0.5) * expandedRadius) + 0.5;
 
-	position.x *= lineLength + (2.0 * expandedRadius);
+	position.x *= u_lineLength + (2.0 * expandedRadius);
 	position.y *= 2.0 * expandedRadius;
 
 	// Center around first pen point
@@ -53,7 +52,7 @@ void main() {
 	pointDiff.x = (abs(pointDiff.x) < epsilon && abs(pointDiff.y) < epsilon) ? epsilon : pointDiff.x;
 	// The `normalized` vector holds rotational values equivalent to sine/cosine
 	// We're applying the standard rotation matrix formula to the position to rotate the quad to the line angle
-	vec2 normalized = pointDiff / max(lineLength, epsilon);
+	vec2 normalized = pointDiff / max(u_lineLength, epsilon);
 	position = mat2(normalized.x, normalized.y, -normalized.y, normalized.x) * position;
 	// Translate quad
 	position += u_penPoints.xy;

--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -33,6 +33,12 @@ void main() {
 
 	float lineLength = length(u_penPoints.zw - u_penPoints.xy);
 
+	// The X coordinate increases along the length of the line. It's 0 at the center of the origin point
+	// and is in pixel-space (so at n pixels along the line, its value is n).
+	v_texCoord.x = mix(0.0, lineLength + (expandedRadius * 2.0), a_position.x) - expandedRadius;
+	// The Y coordinate is perpendicular to the line. It's also in pixel-space.
+	v_texCoord.y = ((a_position.y - 0.5) * expandedRadius) + 0.5;
+
 	position.x *= lineLength + (2.0 * expandedRadius);
 	position.y *= 2.0 * expandedRadius;
 
@@ -43,7 +49,8 @@ void main() {
 	vec2 pointDiff = u_penPoints.zw - u_penPoints.xy;
 	// Ensure line has a nonzero length so it's rendered properly
 	// As long as either component is nonzero, the line length will be nonzero
-	pointDiff.x = abs(pointDiff.x) < epsilon ? epsilon : pointDiff.x;
+	// If the line is zero-length, give it a bit of horizontal length
+	pointDiff.x = (abs(pointDiff.x) < epsilon && abs(pointDiff.y) < epsilon) ? epsilon : pointDiff.x;
 	// The `normalized` vector holds rotational values equivalent to sine/cosine
 	// We're applying the standard rotation matrix formula to the position to rotate the quad to the line angle
 	vec2 normalized = pointDiff / max(lineLength, epsilon);
@@ -53,9 +60,7 @@ void main() {
 
 	// Apply view transform
 	position *= 2.0 / u_stageSize;
-
 	gl_Position = vec4(position, 0, 1);
-	v_texCoord = position * 0.5 * u_stageSize;
 	#else
 	gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
 	v_texCoord = a_texCoord;


### PR DESCRIPTION
### Resolves

Resolves #599
Resolves #595

### Proposed Changes

This PR rewrites the pen line shader to be much more numerically stable:
 - No more calculations that increase quadratically with the line length
 - No divisions in the fragment shader
 - Calculations that have a linear gradient, and can hence be linearly interpolated, are done in the vertex shader

I have tested this on an iPhone that exhibited #589 *and* an Android device that exhibited #595 and #599, and found it to fix those issues.

### Reason for Changes

I despise floating point numbers and floating point math. Whoever decided that floating-point precision was allowed to vary across different devices in the GL spec deserves slightly damp socks for the rest of their life.

### Test Coverage

Manual at this point
