### PR TITLE
Take render target dimensions into account when drawing

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1320,9 +1320,15 @@ class RenderWebGL extends EventEmitter {
 
             gl.clearColor(0, 0, 0, 0);
             gl.clear(gl.COLOR_BUFFER_BIT);
-            // Don't apply the ghost effect. TODO: is this an intentional design decision?
             this._drawThese([drawableID], ShaderManager.DRAW_MODE.straightAlpha, projection,
-                {effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask});
+                {
+                    // Don't apply the ghost effect. TODO: is this an intentional design decision?
+                    effectMask: ~ShaderManager.EFFECT_INFO.ghost.mask,
+                    // We're doing this in screen-space, so the framebuffer dimensions should be those of the canvas in
+                    // screen-space. This is used to ensure SVG skins are rendered at the proper resolution.
+                    framebufferWidth: canvas.width,
+                    framebufferHeight: canvas.height
+                });
 
             const data = new Uint8Array(Math.floor(clampedWidth * clampedHeight * 4));
             gl.readPixels(0, 0, clampedWidth, clampedHeight, gl.RGBA, gl.UNSIGNED_BYTE, data);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1822,18 +1822,6 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
-     * Get the screen-space scale of a drawable, as percentages of the drawable's "normal" size.
-     * @param {Drawable} drawable The drawable whose screen-space scale we're fetching.
-     * @returns {Array<number>} The screen-space X and Y dimensions of the drawable's scale, as percentages.
-     */
-    _getDrawableScreenSpaceScale (drawable) {
-        return [
-            drawable.scale[0] * this._gl.canvas.width / this._nativeSize[0],
-            drawable.scale[1] * this._gl.canvas.height / this._nativeSize[1]
-        ];
-    }
-
-    /**
      * Draw a set of Drawables, by drawable ID
      * @param {Array<int>} drawables The Drawable IDs to draw, possibly this._drawList.
      * @param {ShaderManager.DRAW_MODE} drawMode Draw normally, silhouette, etc.
@@ -1865,7 +1853,10 @@ class RenderWebGL extends EventEmitter {
             if (!drawable.getVisible() && !opts.ignoreVisibility) continue;
 
             // Combine drawable scale with the native vs. backing pixel ratio
-            const drawableScale = this._getDrawableScreenSpaceScale(drawable);
+            const drawableScale = [
+                drawable.scale[0] * this._gl.canvas.width / this._nativeSize[0],
+                drawable.scale[1] * this._gl.canvas.height / this._nativeSize[1]
+            ];
 
             // If the skin or texture isn't ready yet, skip it.
             if (!drawable.skin || !drawable.skin.getTexture(drawableScale)) continue;


### PR DESCRIPTION
## Depends on #555

### Resolves

Resolves #545
Resolves #558

### Proposed Changes

This PR changes `_drawThese` to accept optional `framebufferWidth` and `framebufferHeight` parameters, and default to the "native size" (480x360) if they're not given.

These dimensions are used to calculate drawables' "framebuffer-space" scales.

### Reason for Changes

See #545. 
