### PR TITLE
Move pen point difference calculation from shader code to JS

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -323,7 +323,7 @@ class PenSkin extends Skin {
             u_lineColor: __premultipliedColor,
             u_lineThickness: penAttributes.diameter || DefaultPenAttributes.diameter,
             u_lineLength: lineLength,
-            u_penPoints: [x0, -y0, x1, -y1],
+            u_penPoints: [x0, -y0, lineDiffX, -lineDiffY],
             u_stageSize: this.size
         };
 

--- a/src/shaders/sprite.frag
+++ b/src/shaders/sprite.frag
@@ -37,7 +37,6 @@ uniform float u_ghost;
 uniform vec4 u_lineColor;
 uniform float u_lineThickness;
 uniform float u_lineLength;
-uniform vec4 u_penPoints;
 #endif // DRAW_MODE_line
 
 #ifdef DRAW_MODE_background


### PR DESCRIPTION
### Resolves

Resolves #642

### Proposed Changes

This changes the pen line code so that the difference between pen points is calculated in JS instead of in the shader code.

I also stopped passing `u_penPoints` into the fragment shader (it hasn't needed that since last time I fixed this; I just forgot to remove it then), and clarified some of the comments.

### Reason for Changes

If the pen points' coordinates are both somewhat large, calculating the difference between them will be inaccurate if done using the lower floating-point precision on GPUs. This messes up vertex shader calculations further down the line.

I'm pleasantly surprised by how simple the fix was here--it shouldn't decrease performance at all.

### Test Coverage

Tested manually on an iPad Mini 5 (A2133) that was previously exhibiting the issue.
