### PR TITLE
Update jsdoc to allow requizzle to work on node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^4.6.1",
     "eslint-config-scratch": "^5.0.0",
     "gh-pages": "^1.0.0",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.0",
     "json": "^9.0.4",
     "playwright-chromium": "^1.0.1",
     "scratch-vm": "0.2.0-prerelease.20200622143012",


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-render/issues/680

### Proposed Changes
Update jsdoc

### Reason for Changes
Fixes requizzle on node 12, which was preventing tests from working for me locally

### Test Coverage
Ran tests locally
