### PR TITLE
Remove updateDrawableProperties

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -271,33 +271,6 @@ class Drawable {
     }
 
     /**
-     * Update the position, direction, scale, or effect properties of this Drawable.
-     * @deprecated Use specific update* methods instead.
-     * @param {object.<string,*>} properties The new property values to set.
-     */
-    updateProperties (properties) {
-        if ('position' in properties) {
-            this.updatePosition(properties.position);
-        }
-        if ('direction' in properties) {
-            this.updateDirection(properties.direction);
-        }
-        if ('scale' in properties) {
-            this.updateScale(properties.scale);
-        }
-        if ('visible' in properties) {
-            this.updateVisible(properties.visible);
-        }
-        const numEffects = ShaderManager.EFFECTS.length;
-        for (let index = 0; index < numEffects; ++index) {
-            const effectName = ShaderManager.EFFECTS[index];
-            if (effectName in properties) {
-                this.updateEffect(effectName, properties[effectName]);
-            }
-        }
-    }
-
-    /**
      * Calculate the transform to use when rendering this Drawable.
      * @private
      */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -1591,27 +1591,6 @@ class RenderWebGL extends EventEmitter {
     }
 
     /**
-     * Update the position, direction, scale, or effect properties of this Drawable.
-     * @deprecated Use specific updateDrawable* methods instead.
-     * @param {int} drawableID The ID of the Drawable to update.
-     * @param {object.<string,*>} properties The new property values to set.
-     */
-    updateDrawableProperties (drawableID, properties) {
-        const drawable = this._allDrawables[drawableID];
-        if (!drawable) {
-            /**
-             * @todo(https://github.com/LLK/scratch-vm/issues/2288) fix whatever's wrong in the VM which causes this, then add a warning or throw here.
-             * Right now this happens so much on some projects that a warning or exception here can hang the browser.
-             */
-            return;
-        }
-        if ('skinId' in properties) {
-            this.updateDrawableSkinId(drawableID, properties.skinId);
-        }
-        drawable.updateProperties(properties);
-    }
-
-    /**
      * Update the position object's x & y members to keep the drawable fenced in view.
      * @param {int} drawableID - The ID of the Drawable to update.
      * @param {Array.<number, number>} position to be fenced - An array of type [x, y]

--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -2,16 +2,12 @@ const ScratchRender = require('../RenderWebGL');
 const getMousePosition = require('./getMousePosition');
 
 const canvas = document.getElementById('scratch-stage');
-let fudge = 90;
 const renderer = new ScratchRender(canvas);
 renderer.setLayerGroupOrdering(['group1']);
 
 const drawableID = renderer.createDrawable('group1');
-renderer.updateDrawableProperties(drawableID, {
-    position: [0, 0],
-    scale: [100, 100],
-    direction: 90
-});
+renderer.updateDrawablePosition(drawableID, [0, 0]);
+renderer.updateDrawableDirectionScale(drawableID, 90, [100, 100]);
 
 const WantedSkinType = {
     bitmap: 'bitmap',
@@ -27,9 +23,7 @@ const image = new Image();
 image.addEventListener('load', () => {
     const bitmapSkinId = renderer.createBitmapSkin(image);
     if (wantedSkin === WantedSkinType.bitmap) {
-        renderer.updateDrawableProperties(drawableID2, {
-            skinId: bitmapSkinId
-        });
+        renderer.updateDrawableSkinId(drawableID2, bitmapSkinId);
     }
 });
 image.crossOrigin = 'anonymous';
@@ -40,9 +34,7 @@ const xhr = new XMLHttpRequest();
 xhr.addEventListener('load', function () {
     const skinId = renderer.createSVGSkin(xhr.responseText);
     if (wantedSkin === WantedSkinType.vector) {
-        renderer.updateDrawableProperties(drawableID2, {
-            skinId: skinId
-        });
+        renderer.updateDrawableSkinId(drawableID2, skinId);
     }
 });
 xhr.open('GET', 'https://cdn.assets.scratch.mit.edu/internalapi/asset/b7853f557e4426412e64bb3da6531a99.svg/get/');
@@ -51,9 +43,7 @@ xhr.send();
 if (wantedSkin === WantedSkinType.pen) {
     const penSkinID = renderer.createPenSkin();
 
-    renderer.updateDrawableProperties(drawableID2, {
-        skinId: penSkinID
-    });
+    renderer.updateDrawableSkinId(drawableID2, penSkinID);
 
     canvas.addEventListener('click', event => {
         let rect = canvas.getBoundingClientRect();
@@ -111,56 +101,36 @@ fudgeMaxInput.dispatchEvent(new CustomEvent('init'));
 fudgeInput.dispatchEvent(new CustomEvent('init'));
 
 const handleFudgeChanged = function (event) {
-    fudge = event.target.valueAsNumber;
-    const props = {};
+    const fudge = event.target.valueAsNumber;
     switch (fudgeProperty) {
     case 'posx':
-        props.position = [fudge, posY];
         posX = fudge;
+        renderer.updateDrawablePosition(drawableID2, [posX, posY]);
         break;
     case 'posy':
-        props.position = [posX, fudge];
         posY = fudge;
+        renderer.updateDrawablePosition(drawableID2, [posX, posY]);
         break;
     case 'direction':
-        props.direction = fudge;
+        renderer.updateDrawableDirection(drawableID2, fudge);
         break;
     case 'scalex':
-        props.scale = [fudge, scaleY];
-        scaleX = fudge;
-        break;
     case 'scaley':
-        props.scale = [scaleX, fudge];
-        scaleY = fudge;
-        break;
     case 'scaleboth':
-        props.scale = [fudge, fudge];
-        scaleX = fudge;
-        scaleY = fudge;
+        if (fudgeProperty === 'scalex' || fudgeProperty === 'scaleboth') scaleX = fudge;
+        if (fudgeProperty === 'scaley' || fudgeProperty === 'scaleboth') scaleY = fudge;
+        renderer.updateDrawableScale(drawableID2, [scaleX, scaleY]);
         break;
     case 'color':
-        props.color = fudge;
-        break;
     case 'whirl':
-        props.whirl = fudge;
-        break;
     case 'fisheye':
-        props.fisheye = fudge;
-        break;
     case 'pixelate':
-        props.pixelate = fudge;
-        break;
     case 'mosaic':
-        props.mosaic = fudge;
-        break;
     case 'brightness':
-        props.brightness = fudge;
-        break;
     case 'ghost':
-        props.ghost = fudge;
+        renderer.updateDrawableEffect(drawableID2, fudgeProperty, fudge);
         break;
     }
-    renderer.updateDrawableProperties(drawableID2, props);
 };
 
 fudgeInput.addEventListener('input', handleFudgeChanged);

--- a/src/playground/queryPlayground.js
+++ b/src/playground/queryPlayground.js
@@ -47,9 +47,7 @@ const handleCursorPositionChanged = () => {
     labelCursorPosition.innerHTML = positionHTML;
     if (drawables.cursor >= 0) {
         renderer.draw();
-        renderer.updateDrawableProperties(drawables.cursor, {
-            position: [cursorX, cursorY]
-        });
+        renderer.updateDrawablePosition(drawables.cursor, [cursorX, cursorY]);
 
         renderer.setUseGpuMode(ScratchRender.UseGpuModes.ForceGPU);
         renderer.setDebugCanvas(gpuQueryCanvas);
@@ -160,7 +158,7 @@ const makeTestPatternDrawable = function (group) {
     const image = makeTestPatternImage();
     const skinId = renderer.createBitmapSkin(image, 1);
     const drawableId = renderer.createDrawable(group);
-    renderer.updateDrawableProperties(drawableId, {skinId});
+    renderer.updateDrawableSkinId(drawableId, skinId);
     return drawableId;
 };
 
@@ -168,7 +166,7 @@ const makeCursorDrawable = function (group) {
     const image = makeCursorImage();
     const skinId = renderer.createBitmapSkin(image, 1, [0, 0]);
     const drawableId = renderer.createDrawable(group);
-    renderer.updateDrawableProperties(drawableId, {skinId});
+    renderer.updateDrawableSkinId(drawableId, skinId);
     return drawableId;
 };
 
@@ -186,10 +184,10 @@ const initRendering = () => {
     const corner10 = makeCursorDrawable(layerGroup.cursor);
     const corner11 = makeCursorDrawable(layerGroup.cursor);
 
-    renderer.updateDrawableProperties(corner00, {position: [-240, -179]});
-    renderer.updateDrawableProperties(corner01, {position: [-240, 180]});
-    renderer.updateDrawableProperties(corner10, {position: [239, -179]});
-    renderer.updateDrawableProperties(corner11, {position: [239, 180]});
+    renderer.updateDrawablePosition(corner00, [-240, -179]);
+    renderer.updateDrawablePosition(corner01, [-240, 180]);
+    renderer.updateDrawablePosition(corner10, [239, -179]);
+    renderer.updateDrawablePosition(corner11, [239, 180]);
 };
 
 initRendering();

--- a/test/unit/DrawableTests.js
+++ b/test/unit/DrawableTests.js
@@ -35,7 +35,7 @@ test('translate by position', t => {
     expected.initFromBounds(0, 200, -50, 0);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.updateProperties({position: [1, 2]});
+    drawable.updatePosition([1, 2]);
     expected.initFromBounds(1, 201, -48, 2);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
@@ -65,20 +65,22 @@ test('translate and rotate', t => {
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
 
-    drawable.updateProperties({position: [1, 2], direction: 0});
+    drawable.updatePosition([1, 2]);
+    drawable.updateDirection(0);
     expected.initFromBounds(1, 51, 2, 202);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.updateProperties({direction: 180});
+    drawable.updateDirection(180);
     expected.initFromBounds(-49, 1, -198, 2);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
     drawable.skin.rotationCenter = [100, 25];
-    drawable.updateProperties({direction: 270, position: [0, 0]});
+    drawable.updatePosition([0, 0]);
+    drawable.updateDirection(270);
     expected.initFromBounds(-100, 100, -25, 25);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.updateProperties({direction: 90});
+    drawable.updateDirection(90);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
     t.end();
@@ -94,7 +96,7 @@ test('rotate by non-right-angles', t => {
     expected.initFromBounds(-5, 5, -5, 5);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.updateProperties({direction: 45});
+    drawable.updateDirection(45);
     expected.initFromBounds(-7.071, 7.071, -7.071, 7.071);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
@@ -107,7 +109,7 @@ test('scale', t => {
     drawable.skin = new MockSkin();
     drawable.skin.size = [200, 50];
 
-    drawable.updateProperties({scale: [100, 50]});
+    drawable.updateScale([100, 50]);
     expected.initFromBounds(0, 200, -25, 0);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
@@ -116,7 +118,7 @@ test('scale', t => {
     t.same(snapToNearest(drawable.getAABB()), expected);
 
     drawable.skin.rotationCenter = [150, 50];
-    drawable.updateProperties({scale: [50, 50]});
+    drawable.updateScale([50, 50]);
     expected.initFromBounds(-75, 25, 0, 25);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
@@ -133,7 +135,7 @@ test('rotate and scale', t => {
     expected.initFromBounds(-50, 50, -950, 50);
     t.same(snapToNearest(drawable.getAABB()), expected);
 
-    drawable.updateProperties({scale: [40, 60]});
+    drawable.updateScale([40, 60]);
     drawable.skin.rotationCenter = [50, 50];
     expected.initFromBounds(-20, 20, -570, 30);
     t.same(snapToNearest(drawable.getAABB()), expected);


### PR DESCRIPTION
### Resolves

Resolves #721

### Proposed Changes

This PR removes the `updateDrawableProperties` function from the public `RenderWebGL` API surface, and the `Drawable.updateProperties` function. It also adjusts some testing code to no longer use those deprecated APIs.

### Reason for Changes

As detailed in #721, `updateDrawableProperties` has been deprecated in favor of individual functions for updating each property separately. As it is no longer called from anywhere in the codebase, it can be removed.

### Test Coverage

All existing tests (should) pass. I searched through all public LLK repos for `updateDrawableProperties` and `updateProperties`, and the only results are the test code used here, which this PR also fixes.