### PR TITLE
Move SVG renderer logic back into SVGSkin

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -197,6 +197,7 @@ class SVGSkin extends Skin {
         const svgText = serializeSvgToString(svgTag, true /* shouldInjectFonts */);
         this._svgImageLoaded = false;
 
+        // If there is another load already in progress, replace the old onload to effectively cancel the old load
         this._svgImage.onload = () => {
             const {x, y, width, height} = svgTag.viewBox.baseVal;
             this._size[0] = width;

--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -29,7 +29,10 @@ class SVGSkin extends Skin {
         this._renderer = renderer;
 
         /** @type {HTMLImageElement} */
-        this._svgImage = null;
+        this._svgImage = document.createElement('img');
+
+        /** @type {boolean} */
+        this._svgImageLoaded = false;
 
         /** @type {Array<number>} */
         this._size = [0, 0];
@@ -165,7 +168,7 @@ class SVGSkin extends Skin {
         // Can't use bitwise stuff here because we need to handle negative exponents
         const mipScale = Math.pow(2, mipLevel - INDEX_OFFSET);
 
-        if (this._svgImage.complete && !this._scaledMIPs[mipLevel]) {
+        if (this._svgImageLoaded && !this._scaledMIPs[mipLevel]) {
             this._scaledMIPs[mipLevel] = this.createMIP(mipScale);
         }
 
@@ -191,10 +194,10 @@ class SVGSkin extends Skin {
      */
     setSVG (svgData, rotationCenter) {
         const svgTag = loadSvgString(svgData);
-        this._svgImage = document.createElement('img');
         const svgText = serializeSvgToString(svgTag, true /* shouldInjectFonts */);
+        this._svgImageLoaded = false;
 
-        this._svgImage.addEventListener('load', () => {
+        this._svgImage.onload = () => {
             const {x, y, width, height} = svgTag.viewBox.baseVal;
             this._size[0] = width;
             this._size[1] = height;
@@ -218,8 +221,10 @@ class SVGSkin extends Skin {
             this._rotationCenter[0] = rotationCenter[0] - x;
             this._rotationCenter[1] = rotationCenter[1] - y;
 
+            this._svgImageLoaded = true;
+
             this.emit(Skin.Events.WasAltered);
-        });
+        };
 
         this._svgImage.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgText)}`;
     }

--- a/test/helper/page-util.js
+++ b/test/helper/page-util.js
@@ -14,7 +14,7 @@ window.waitForSVGSkinLoad = renderer => new Promise(resolve => {
         for (const skin of renderer._allSkins) {
             if (skin.constructor.name !== 'SVGSkin') continue;
             numSVGSkins++;
-            if (skin._svgRenderer.loaded) numLoadedSVGSkins++;
+            if (skin._svgImage.complete) numLoadedSVGSkins++;
         }
 
         if (numSVGSkins === numLoadedSVGSkins) {
@@ -47,7 +47,7 @@ window.initVM = render => {
 
     vm.attachStorage(storage);
     vm.attachRenderer(render);
-    vm.attachV2SVGAdapter(new ScratchSVGRenderer.SVGRenderer());
+    vm.attachV2SVGAdapter(ScratchSVGRenderer.V2SVGAdapter);
     vm.attachV2BitmapAdapter(new ScratchSVGRenderer.BitmapAdapter());
 
     return vm;


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-svg-renderer/pull/213

### Resolves

A step towards #550

### Proposed Changes

This PR moves the logic for actually rendering SVGs back into `SVGSkin` from `SvgRenderer`, and removes the dependency on the `SvgRenderer` class.

### Reason for Changes

This will allow for future modifications to the way SVGs are drawn, which are necessary to fix #550.

### Test Coverage

Tested manually