### PR TITLE
Fix JSDoc for resetMIPs and setSVG

### DIFF
--- a/src/SVGSkin.js
+++ b/src/SVGSkin.js
@@ -156,9 +156,6 @@ class SVGSkin extends Skin {
 
     /**
      * Do a hard reset of the existing MIPs by deleting them.
-     * @param {Array<number>} [rotationCenter] - Optional rotation center for the SVG. If not supplied, it will be
-     * calculated from the bounding box
-     * @fires Skin.event:WasAltered
      */
     resetMIPs () {
         this._scaledMIPs.forEach(oldMIP => this._renderer.gl.deleteTexture(oldMIP));
@@ -169,7 +166,9 @@ class SVGSkin extends Skin {
     /**
      * Set the contents of this skin to a snapshot of the provided SVG data.
      * @param {string} svgData - new SVG to use.
-     * @param {Array<number>} [rotationCenter] - Optional rotation center for the SVG.
+     * @param {Array<number>} [rotationCenter] - Optional rotation center for the SVG. If not supplied, it will be
+     * calculated from the bounding box
+     * @fires Skin.event:WasAltered
      */
     setSVG (svgData, rotationCenter) {
         this._svgRenderer.loadSVG(svgData, false, () => {


### PR DESCRIPTION
### Resolves

Resolves #814

### Proposed Changes

This PR moves some JSDoc off of `SVGSkin.resetMIPs` back to `SVGSkin.setSVG` where it belongs.

### Reason for Changes

Documentation should be correct

### Test Coverage

N/A--this only touches comments
