### PR TITLE
Remove extractDrawable

### DIFF
--- a/src/playground/playground.js
+++ b/src/playground/playground.js
@@ -186,7 +186,7 @@ canvas.addEventListener('click', event => {
     const pickID = renderer.pick(mousePos.x, mousePos.y);
     console.log(`You clicked on ${(pickID < 0 ? 'nothing' : `ID# ${pickID}`)}`);
     if (pickID >= 0) {
-        console.dir(renderer.extractDrawable(pickID, mousePos.x, mousePos.y));
+        console.dir(renderer.extractDrawableScreenSpace(pickID, mousePos.x, mousePos.y));
     }
 });
 


### PR DESCRIPTION
### Resolves

Resolves #816

### Proposed Changes

This PR removes the `RenderWebGL.extractDrawable` method.

### Reason for Changes

`RenderWebGL.extractDrawable` is deprecated, has been replaced by `extractDrawableScreenSpace`, and is no longer used. It can now be removed.

### Test Coverage

N/A