### PR TITLE
Set v_texCoord in mystery mode

### DIFF
--- a/src/shaders/sprite.vert
+++ b/src/shaders/sprite.vert
@@ -70,6 +70,7 @@ void main() {
 	gl_Position = vec4(a_position * 2.0, 0, 1);
 	#elif defined(DRAW_MODE_mystery)
 	gl_Position = vec4(a_position * vec2(-2.0, 2.0), 0.0, 1.0);
+	v_texCoord = a_texCoord;
 	#else
 	gl_Position = u_projectionMatrix * u_modelMatrix * vec4(a_position, 0, 1);
 	v_texCoord = a_texCoord;


### PR DESCRIPTION
### Resolves

Resolves #836

### Proposed Changes

This PR sets `v_texCoord` in when drawing in "mystery mode".

### Reason for Changes

For mystery mode, we draw all sprites onto a framebuffer then draw that framebuffer (with a shadow) onto the stage. We were previously not passing in the texture coordinates when we did so, meaning that the entire framebuffer would be filled with the color of the top left pixel.

### Test Coverage

Tested manually
