### PR TITLE
Fix SVG costume dimensions appearing as 0x0 in GUI

### DIFF
--- a/test/integration/skin-size-tests.js
+++ b/test/integration/skin-size-tests.js
@@ -1,0 +1,61 @@
+/* global render, ImageData */
+const {chromium} = require('playwright-chromium');
+const test = require('tap').test;
+const path = require('path');
+
+const indexHTML = path.resolve(__dirname, 'index.html');
+
+// immediately invoked async function to let us wait for each test to finish before starting the next.
+(async () => {
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    await page.goto(`file://${indexHTML}`);
+
+    await test('SVG skin size set properly', async t => {
+        t.plan(1);
+        const skinSize = await page.evaluate(() => {
+            const skinID = render.createSVGSkin(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 100"></svg>`);
+            return render.getSkinSize(skinID);
+        });
+        t.same(skinSize, [50, 100]);
+    });
+
+    await test('Bitmap skin size set correctly', async t => {
+        t.plan(1);
+        const skinSize = await page.evaluate(() => {
+            // Bitmap costumes are double resolution, so double the ImageData size
+            const skinID = render.createBitmapSkin(new ImageData(100, 200), 2);
+            return render.getSkinSize(skinID);
+        });
+        t.same(skinSize, [50, 100]);
+    });
+
+    await test('Pen skin size set correctly', async t => {
+        t.plan(1);
+        const skinSize = await page.evaluate(() => {
+            const skinID = render.createPenSkin();
+            return render.getSkinSize(skinID);
+        });
+        const nativeSize = await page.evaluate(() => render.getNativeSize());
+        t.same(skinSize, nativeSize);
+    });
+
+    await test('Text bubble skin size set correctly', async t => {
+        t.plan(1);
+        const skinSize = await page.evaluate(() => {
+            const skinID = render.createTextSkin('say', 'Hello', false);
+            return render.getSkinSize(skinID);
+        });
+        // The subtleties in font rendering may cause the size of the text bubble to vary, so just make sure it's not 0
+        t.notSame(skinSize, [0, 0]);
+    });
+
+    // close the browser window we used
+    await browser.close();
+})().catch(err => {
+    // Handle promise rejections by exiting with a nonzero code to ensure that tests don't erroneously pass
+    // eslint-disable-next-line no-console
+    console.error(err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
### Resolves

Resolves #945

### Proposed Changes

This PR moves the setting of `SVGSkin`s' `size` outside the callback which fires after the SVG image is loaded.

This isn't an ideal solution, as the skin is technically in an invalid state while the image is still loading--it has the `size` of the new image, but the texture of the old one, and we're relying on not emitting the `WasAltered` event until the new image has loaded, as if the event were to fire before the new image was loaded, the skin's old texture would appear stretched to the new image's dimensions.

Ideally, `setSVG` and `createSVGSkin` would return `Promise`s, and the VM would wait for them before setting the costume's size based on the skin's size, but that would be a breaking change since `createSVGSkin` currently returns the skin ID.

### Reason for Changes

[The VM reads back the skin's size immediately after calling `createSVGSkin`](https://github.com/LLK/scratch-vm/blob/977dfeec383884b33dca5fa53c701e480495668e/src/import/load-costume.js#L26-L27), but the "SVG loaded" callback fires asynchronously, after the VM has already read the skin's size.

### Test Coverage

Since this has happened [before](https://github.com/LLK/scratch-render/pull/497), I've added integration tests that ensure that all skins' dimensions are set synchronously.
