### PR TITLE
try WebGL 2.0 if WebGL 1.0 fails

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -111,7 +111,12 @@ class RenderWebGL extends EventEmitter {
      * @private
      */
     static _getContext (canvas) {
-        return twgl.getWebGLContext(canvas, {alpha: false, stencil: true, antialias: false});
+        const contextAttribs = {alpha: false, stencil: true, antialias: false};
+        // getWebGLContext = try WebGL 1.0 only
+        // getContext = try WebGL 2.0 and if that doesn't work, try WebGL 1.0
+        // getWebGLContext || getContext = try WebGL 1.0 and if that doesn't work, try WebGL 2.0
+        return twgl.getWebGLContext(canvas, contextAttribs) ||
+            twgl.getContext(canvas, contextAttribs);
     }
 
     /**


### PR DESCRIPTION
### Resolves

Resolves LLK/scratch-android#401

### Proposed Changes

Before: try to use WebGL 1.0
After: try to use WebGL 1.0 and, if that fails, try to use WebGL 2.0

### Reason for Changes

In some configurations, WebGL 1.0 can be on a block-list while WebGL 2.0 is allowed. This is the case in the Android WebView with the Intel UHD 620, for example. In that situation, prior to this change, Scratch will not work at all. Allowing WebGL 2.0 means that Scratch can run on those configurations.

By trying WebGL 1.0 first and falling back to WebGL 2.0, this change should not have any positive or negative effect on any users for whom Scratch currently works.

### Test Coverage

Tested locally through the scratch-render playground and in a local build of the Android app running on the Chromebook experiencing LLK/scratch-android#401
