### PR TITLE
ci: fix for GHA workflow script not pulling correct version var

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
             - name: Build
               run: |
                   npm run build
-                  npm --no-git-tag-version version $VERSION
+                  npm --no-git-tag-version version $RELEASE_VERSION
 
             - name: Deploy to NPM (do a dry-run if not on master, develop, or hotfix/*)
               env:


### PR DESCRIPTION
### Resolves

Resolves an issue where "npm version" wasn't pulling the correct variable.