### PR TITLE
fix(deps): Use terser-webpack-plugin instead of uglifyjs-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,8 @@
         "scratch-render-fonts": "1.0.0-prerelease.20231017225105",
         "scratch-vm": "0.2.0-prerelease.20201125065300",
         "tap": "11.1.5",
+        "terser-webpack-plugin": "1.4.5",
         "travis-after-all": "1.4.5",
-        "uglifyjs-webpack-plugin": "1.3.0",
         "webpack": "4.47.0",
         "webpack-cli": "3.3.12",
         "webpack-dev-server": "3.11.2"
@@ -15434,51 +15434,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "node_modules/uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
-      "dev": true,
-      "dependencies": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uglify-es/node_modules/commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-      "dev": true
-    },
-    "node_modules/uglifyjs-webpack-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-      "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-      "dev": true,
-      "dependencies": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      },
-      "engines": {
-        "node": ">= 4.8 < 5.0.0 || >= 5.10"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -29081,40 +29036,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
-    },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "dev": true,
-      "requires": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-      "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-      "dev": true,
-      "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      }
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "scratch-render-fonts": "1.0.0-prerelease.20231017225105",
     "scratch-vm": "0.2.0-prerelease.20201125065300",
     "tap": "11.1.5",
+    "terser-webpack-plugin": "1.4.5",
     "travis-after-all": "1.4.5",
-    "uglifyjs-webpack-plugin": "1.3.0",
     "webpack": "4.47.0",
     "webpack-cli": "3.3.12",
     "webpack-dev-server": "3.11.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -26,7 +26,7 @@ const base = {
     },
     optimization: {
         minimizer: [
-            new UglifyJsPlugin({
+            new TerserPlugin({
                 include: /\.min\.js$/
             })
         ]


### PR DESCRIPTION
### Proposed Changes

This PR does three things:

* Mark `terser-webpack-plugin@1.4.5` (an existing dependency, via webpack) as a saved dev dependency.
* Remove dev dependency `uglifyjs-webpack-plugin`.
* Replace `UglifyJsPlugin` with `TerserPlugin` in Webpack config.

### Reason for Changes

[`uglifyjs-webpack-plugin` is deprecated.](https://github.com/webpack-contrib/uglifyjs-webpack-plugin#readme) The docs indicate to use [`terser-webpack-plugin`](https://webpack.js.org/plugins/terser-webpack-plugin/) instead.

The version `terser-webpack-plugin@1.4.5` is selected as it's the version which was previously installed (as a dependency of `webpack@4.46.0`, matching `^1.4.3`). This means we don't actually add or update any dependencies: note how `package-lock.json` changes only include removing dependencies.

Marking `terser-webpack-plugin` as saved at all [is required](https://webpack.js.org/plugins/terser-webpack-plugin/):

> Webpack v5 comes with the latest `terser-webpack-plugin` out of the box. If you are using Webpack v5 or above and wish to customize the options, you will still need to install `terser-webpack-plugin`. Using Webpack v4, you have to install `terser-webpack-plugin` v4.

**Removing uglifyjs-webpack-plugin is necessary to update to Webpack v5.** uglifyjs-webpack-plugin has not been updated since 2019 and strictly requires Webpack v4. Terser is the replacement Webpack recommends, and is supported on both v4 and v5.

Webpack v4 itself is deprecated as well, and due to a compatibility change, prevents readily running on Node above 16. Node 16 left maintenance LTS support in October 2023, so the development environment is now depending on a wholly unsupported version of Node, partially due to Webpack (and consequently `uglifyjs-webpack-plugin`).

### Test Coverage

All existing tests pass, the build succeeds, and `npm start` is also functioning as normal.
