### PR TITLE
fix: fixed hull.js version to 0.2.10 because of breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "grapheme-breaker": "^0.3.2",
-        "hull.js": "^0.2.10",
+        "hull.js": "0.2.10",
         "ify-loader": "^1.0.4",
         "linebreak": "^0.3.0",
         "minilog": "^3.1.0",
@@ -10958,11 +10958,10 @@
       }
     },
     "node_modules/hull.js": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/hull.js/-/hull.js-0.2.11.tgz",
-      "integrity": "sha512-WEmMRCFqoZA0d7bD9KY9RK0rTBKRfNqDExi8OvFz5A57hpywyc0Wd5N4egF9cU+E69p1KjE/fTIYU4CjOgXdZQ==",
-      "deprecated": "This package is not maintained anymore on npmjs.com, please use GitHub URL to fetch the latest version. See the package homepage for instructions.",
-      "license": "BSD"
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/hull.js/-/hull.js-0.2.10.tgz",
+      "integrity": "sha512-UO3W30HxhWgeSpNKCdXt00xkwjRTGmhQaoZNP8ll509Nl+DP9juXE3wRGizihuop08FSB4xtAWIbWSe+RxEoog==",
+      "deprecated": "This package is not maintained anymore on npmjs.com, please use GitHub URL to fetch the latest version. See the package homepage for instructions."
     },
     "node_modules/human-signals": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "grapheme-breaker": "^0.3.2",
-    "hull.js": "^0.2.10",
+    "hull.js": "0.2.10",
     "ify-loader": "^1.0.4",
     "linebreak": "^0.3.0",
     "minilog": "^3.1.0",


### PR DESCRIPTION
### Reason for Changes

Due to the updated version, integration tests in `scratch-gui` were failing
