### PR TITLE
fix(BitmapSkin): Prevent WebGL errors for 0-dimension bitmaps

### DIFF
--- a/src/BitmapSkin.js
+++ b/src/BitmapSkin.js
@@ -58,7 +58,8 @@ class BitmapSkin extends Skin {
      * @fires Skin.event:WasAltered
      */
     setBitmap (bitmapData, costumeResolution, rotationCenter) {
-        if (!bitmapData.width || !bitmapData.height) {
+        const [width, height] = BitmapSkin._getBitmapSize(bitmapData);
+        if (!width || !height) {
             super.setEmptyImageData();
             return;
         }


### PR DESCRIPTION
## Summary

Fixes a WebGL error that occurred when creating a new bitmap costume via the 'paint' button. The error was caused by attempting to create a texture from a source with zero width or height.

The fix is to use the `_getBitmapSize` static method to correctly check the dimensions of the incoming bitmap data at the beginning of `setBitmap`. This ensures that 0-width or 0-height bitmaps are handled gracefully before they can cause a WebGL error.

## Changes

- **src/BitmapSkin.js**: In `setBitmap`, the initial check for bitmap dimensions was not robust for all bitmap data types. This change replaces the simple property check with a call to `_getBitmapSize`, which correctly determines the bitmap's dimensions (e.g., using `naturalWidth` for images). This prevents 0x0 bitmaps from being passed to WebGL, fixing the reported errors.

## Related Issue

Closes #417

